### PR TITLE
fixed: tell one renderer action's reply from another's

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -12,8 +12,8 @@
 #include "ThumbLoader.h"
 #include "UPnP.h"
 #include "UPnPInternal.h"
+#include "UPnPPlayerController.h"
 #include "cores/DataCacheCore.h"
-#include "dialogs/GUIDialogBusy.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogHelper.h"
@@ -21,14 +21,10 @@
 #include "music/MusicThumbLoader.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/Event.h"
 #include "utils/StringUtils.h"
-#include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoThumbLoader.h"
-
-#include <mutex>
 
 #include <Platinum/Source/Devices/MediaRenderer/PltMediaController.h>
 #include <Platinum/Source/Devices/MediaServer/PltDidl.h>
@@ -45,131 +41,6 @@ NPT_SET_LOCAL_LOGGER("xbmc.upnp.player")
 namespace UPNP
 {
 
-class CUPnPPlayerController : public PLT_MediaControllerDelegate
-{
-public:
-  CUPnPPlayerController(PLT_MediaController* control,
-                        PLT_DeviceDataReference& device,
-                        IPlayerCallback& callback)
-    : m_control(control),
-      m_transport(NULL),
-      m_device(device),
-      m_callback(callback),
-      m_posinfo({}),
-      m_logger(CServiceBroker::GetLogging().GetLogger("CUPnPPlayerController"))
-  {
-    m_device->FindServiceByType("urn:schemas-upnp-org:service:AVTransport:1", m_transport);
-  }
-
-  void OnSetAVTransportURIResult(NPT_Result res,
-                                 PLT_DeviceDataReference& device,
-                                 void* userdata) override
-  {
-    if (NPT_FAILED(res))
-      m_logger->error("OnSetAVTransportURIResult failed");
-    m_resstatus = res;
-    m_resevent.Set();
-  }
-
-  void OnPlayResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  {
-    if (NPT_FAILED(res))
-      m_logger->error("OnPlayResult failed");
-    m_resstatus = res;
-    m_resevent.Set();
-  }
-
-  void OnStopResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  {
-    if (NPT_FAILED(res))
-      m_logger->error("OnStopResult failed");
-    m_resstatus = res;
-    m_resevent.Set();
-  }
-
-  NPT_String GetTransportState() const
-  {
-    std::unique_lock lock(m_section);
-    return m_trainfo.cur_transport_state;
-  }
-
-  NPT_String GetTransportStatus() const
-  {
-    std::unique_lock lock(m_section);
-    return m_trainfo.cur_transport_status;
-  }
-
-  void OnGetTransportInfoResult(NPT_Result res,
-                                PLT_DeviceDataReference& device,
-                                PLT_TransportInfo* info,
-                                void* userdata) override
-  {
-    std::unique_lock lock(m_section);
-
-    if (NPT_FAILED(res))
-    {
-      m_logger->error("OnGetTransportInfoResult failed");
-      m_trainfo.cur_speed = "0";
-      m_trainfo.cur_transport_state = "STOPPED";
-      m_trainfo.cur_transport_status = "ERROR_OCCURED";
-    }
-    else
-      m_trainfo = *info;
-    m_traevnt.Set();
-  }
-
-  void UpdatePositionInfo()
-  {
-    if (m_postime == 0 || m_postime > CTimeUtils::GetFrameTime())
-      return;
-
-    m_control->GetTransportInfo(m_device, m_instance, this);
-    m_control->GetPositionInfo(m_device, m_instance, this);
-    m_postime = 0;
-  }
-
-  void OnGetPositionInfoResult(NPT_Result res,
-                               PLT_DeviceDataReference& device,
-                               PLT_PositionInfo* info,
-                               void* userdata) override
-  {
-    std::unique_lock lock(m_section);
-
-    if (NPT_FAILED(res) || info == NULL)
-    {
-      m_logger->error("OnGetPositionInfoResult failed");
-      m_posinfo = PLT_PositionInfo();
-    }
-    else
-      m_posinfo = *info;
-    m_postime = CTimeUtils::GetFrameTime() + 500;
-    m_posevnt.Set();
-  }
-
-  ~CUPnPPlayerController() override = default;
-
-  PLT_MediaController* m_control;
-  PLT_Service* m_transport;
-  PLT_DeviceDataReference m_device;
-  NPT_UInt32 m_instance = 0;
-  IPlayerCallback& m_callback;
-
-  NPT_Result m_resstatus;
-  CEvent m_resevent;
-
-  unsigned int m_postime = 0;
-
-  CEvent m_posevnt;
-  PLT_PositionInfo m_posinfo;
-
-  CEvent m_traevnt;
-  PLT_TransportInfo m_trainfo;
-
-private:
-  mutable CCriticalSection m_section;
-  Logger m_logger;
-};
-
 CUPnPPlayer::CUPnPPlayer(IPlayerCallback& callback, const char* uuid)
   : IPlayer(callback),
     CThread("UPnPPlayer"),
@@ -180,7 +51,7 @@ CUPnPPlayer::CUPnPPlayer(IPlayerCallback& callback, const char* uuid)
   PLT_DeviceDataReference device;
   if (NPT_SUCCEEDED(m_control->FindRenderer(uuid, device)))
   {
-    m_delegate = std::make_unique<CUPnPPlayerController>(m_control, device, callback);
+    m_delegate = std::make_unique<CUPnPPlayerController>(m_control, device);
     CUPnP::RegisterUserdata(m_delegate.get());
   }
   else
@@ -193,17 +64,6 @@ CUPnPPlayer::~CUPnPPlayer()
   CUPnP::UnregisterUserdata(m_delegate.get());
 }
 
-static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime<>& timeout)
-{
-  if (event.Wait(0ms))
-    return NPT_SUCCESS;
-
-  if (!CGUIDialogBusy::WaitOnEvent(event))
-    return NPT_FAILURE;
-
-  return NPT_SUCCESS;
-}
-
 int CUPnPPlayer::PlayFile(const CFileItem& file,
                           const CPlayerOptions& options,
                           XbmcThreads::EndTime<>& timeout)
@@ -214,6 +74,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   NPT_String path(file.GetPath().c_str());
   NPT_String tmp, resource;
   EMediaControllerQuirks quirks = EMEDIACONTROLLERQUIRKS_NONE;
+  CUPnPPlayerController::CAction* action = nullptr;
 
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
 
@@ -296,30 +157,25 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   // get the transport info to evaluate the TransportState to be able to
   // determine whether we first need to call Stop()
   timeout.Set(timeout.GetInitialTimeoutValue());
-  NPT_CHECK_LABEL_SEVERE(
-      m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-      failed_gettransportinfo);
-  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed_gettransportinfo);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->SendGetTransportInfo(action), failed_gettransportinfo);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_gettransportinfo);
 
-  if (m_delegate->m_trainfo.cur_transport_state != "NO_MEDIA_PRESENT" &&
-      m_delegate->m_trainfo.cur_transport_state != "STOPPED")
+  if (const NPT_String openingState = m_delegate->GetTransportState();
+      openingState != "NO_MEDIA_PRESENT" && openingState != "STOPPED")
   {
     timeout.Set(timeout.GetInitialTimeoutValue());
-    NPT_CHECK_LABEL_SEVERE(
-        m_control->Stop(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-        failed_stop);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_stop);
-    NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_stop);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->SendStop(action), failed_stop);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_stop);
+    NPT_CHECK_LABEL_SEVERE(action->GetStatus(), failed_stop);
 
     // Stop is acknowledged before the renderer has stopped. Wait for STOPPED so the states read
     // from here on belong to the file being opened.
     XbmcThreads::EndTime<> stopping(3s);
     while (!stopping.IsTimePast())
     {
-      if (NPT_FAILED(m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance,
-                                                 m_delegate.get())))
+      if (NPT_FAILED(m_delegate->SendGetTransportInfo(action)))
         break;
-      if (!m_delegate->m_traevnt.Wait(500ms))
+      if (!m_delegate->WaitForReplyFor(*action, 500ms))
         continue;
 
       const NPT_String stoppedState = m_delegate->GetTransportState();
@@ -329,29 +185,24 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   }
 
   timeout.Set(timeout.GetInitialTimeoutValue());
-  NPT_CHECK_LABEL_SEVERE(m_control->SetAVTransportURI(m_delegate->m_device, m_delegate->m_instance,
-                                                      obj->m_Resources[res_index].m_Uri,
-                                                      (const char*)tmp, m_delegate.get()),
+  NPT_CHECK_LABEL_SEVERE(m_delegate->SendSetAVTransportURI(
+                             action, obj->m_Resources[res_index].m_Uri, (const char*)tmp),
                          failed_setavtransporturi);
-  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_setavtransporturi);
-  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_setavtransporturi);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_setavtransporturi);
+  NPT_CHECK_LABEL_SEVERE(action->GetStatus(), failed_setavtransporturi);
 
   timeout.Set(timeout.GetInitialTimeoutValue());
-  NPT_CHECK_LABEL_SEVERE(
-      m_control->Play(m_delegate->m_device, m_delegate->m_instance, "1", m_delegate.get()),
-      failed_play);
-  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_play);
-  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_play);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->SendPlay(action), failed_play);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_play);
+  NPT_CHECK_LABEL_SEVERE(action->GetStatus(), failed_play);
 
   /* wait for PLAYING state */
   timeout.Set(timeout.GetInitialTimeoutValue());
   do
   {
     // Wait for the reply before reading the state, or the first pass sees the old file's state.
-    NPT_CHECK_LABEL_SEVERE(
-        m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-        failed_waitplaying);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed_waitplaying);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->SendGetTransportInfo(action), failed_waitplaying);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_waitplaying);
 
     const NPT_String transportStatus = m_delegate->GetTransportStatus();
     const NPT_String transportState = m_delegate->GetTransportState();
@@ -409,17 +260,16 @@ failed:
 bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
 {
   XbmcThreads::EndTime<> timeout(10s);
+  CUPnPPlayerController::CAction* action = nullptr;
 
   m_started = false;
 
   /* if no path we want to attach to a already playing player */
   if (file.GetPath().empty())
   {
-    NPT_CHECK_LABEL_SEVERE(
-        m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-        failed);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->SendGetTransportInfo(action), failed);
 
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed);
 
     /* make sure the attached player is actually playing */
     const NPT_String transportState = m_delegate->GetTransportState();
@@ -467,6 +317,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
   NPT_Reference<PLT_MediaObject> obj;
   NPT_String path(file.GetPath().c_str());
   NPT_String tmp;
+  CUPnPPlayerController::CAction* action = nullptr;
 
   if (VIDEO::IsVideoDb(file))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
@@ -482,12 +333,11 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
   }
 
   NPT_CHECK_LABEL_WARNING(
-      m_control->SetNextAVTransportURI(m_delegate->m_device, m_delegate->m_instance,
-                                       file.GetPath().c_str(), (const char*)tmp, m_delegate.get()),
+      m_delegate->SendSetNextAVTransportURI(action, file.GetPath().c_str(), (const char*)tmp),
       failed);
-  if (!m_delegate->m_resevent.Wait(10000ms))
+  if (!m_delegate->WaitForReplyFor(*action, 10000ms))
     goto failed;
-  NPT_CHECK_LABEL_WARNING(m_delegate->m_resstatus, failed);
+  NPT_CHECK_LABEL_WARNING(action->GetStatus(), failed);
   return true;
 
 failed:
@@ -497,14 +347,15 @@ failed:
 
 bool CUPnPPlayer::CloseFile(bool reopen)
 {
+  CUPnPPlayerController::CAction* action = nullptr;
+
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
   if (m_stopremote)
   {
-    NPT_CHECK_LABEL(m_control->Stop(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-                    failed);
-    if (!m_delegate->m_resevent.Wait(10000ms))
+    NPT_CHECK_LABEL(m_delegate->SendStop(action), failed);
+    if (!m_delegate->WaitForReplyFor(*action, 10000ms))
       goto failed;
-    NPT_CHECK_LABEL(m_delegate->m_resstatus, failed);
+    NPT_CHECK_LABEL(action->GetStatus(), failed);
   }
 
   if (m_started)

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -160,7 +160,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   NPT_CHECK_LABEL_SEVERE(m_delegate->SendGetTransportInfo(action), failed_gettransportinfo);
   NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_gettransportinfo);
 
-  if (const NPT_String openingState = m_delegate->GetTransportState();
+  if (const NPT_String openingState = action->GetTransportState();
       openingState != "NO_MEDIA_PRESENT" && openingState != "STOPPED")
   {
     timeout.Set(timeout.GetInitialTimeoutValue());
@@ -178,7 +178,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
       if (!m_delegate->WaitForReplyFor(*action, 500ms))
         continue;
 
-      const NPT_String stoppedState = m_delegate->GetTransportState();
+      const NPT_String stoppedState = action->GetTransportState();
       if (stoppedState == "STOPPED" || stoppedState == "NO_MEDIA_PRESENT")
         break;
     }
@@ -204,8 +204,8 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
     NPT_CHECK_LABEL_SEVERE(m_delegate->SendGetTransportInfo(action), failed_waitplaying);
     NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed_waitplaying);
 
-    const NPT_String transportStatus = m_delegate->GetTransportStatus();
-    const NPT_String transportState = m_delegate->GetTransportState();
+    const NPT_String transportStatus = action->GetTransportStatus();
+    const NPT_String transportState = action->GetTransportState();
     if (transportState == "PLAYING" || transportState == "PAUSED_PLAYBACK")
     {
       break;
@@ -272,7 +272,7 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
     NPT_CHECK_LABEL_SEVERE(m_delegate->WaitForReply(*action, timeout), failed);
 
     /* make sure the attached player is actually playing */
-    const NPT_String transportState = m_delegate->GetTransportState();
+    const NPT_String transportState = action->GetTransportState();
     if (transportState != "PLAYING" && transportState != "PAUSED_PLAYBACK")
     {
       goto failed;

--- a/xbmc/network/upnp/UPnPPlayerController.h
+++ b/xbmc/network/upnp/UPnPPlayerController.h
@@ -1,0 +1,304 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ServiceBroker.h"
+#include "UPnP.h"
+#include "dialogs/GUIDialogBusy.h"
+#include "threads/CriticalSection.h"
+#include "threads/Event.h"
+#include "threads/SystemClock.h"
+#include "utils/TimeUtils.h"
+#include "utils/log.h"
+#include "utils/logtypes.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <Platinum/Source/Devices/MediaRenderer/PltMediaController.h>
+#include <Platinum/Source/Platinum/Platinum.h>
+
+namespace UPNP
+{
+
+inline NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime<>& timeout)
+{
+  if (event.Wait(std::chrono::milliseconds(0)))
+    return NPT_SUCCESS;
+
+  if (!CGUIDialogBusy::WaitOnEvent(event))
+    return NPT_FAILURE;
+
+  return NPT_SUCCESS;
+}
+
+class CUPnPPlayerController : public PLT_MediaControllerDelegate
+{
+public:
+  CUPnPPlayerController(PLT_MediaController* control, PLT_DeviceDataReference& device)
+    : m_control(control),
+      m_device(device),
+      m_posinfo({}),
+      m_logger(CServiceBroker::GetLogging().GetLogger("CUPnPPlayerController"))
+  {
+  }
+
+  NPT_String GetTransportState() const
+  {
+    std::unique_lock lock(m_section);
+    return m_trainfo.cur_transport_state;
+  }
+
+  NPT_String GetTransportStatus() const
+  {
+    std::unique_lock lock(m_section);
+    return m_trainfo.cur_transport_status;
+  }
+
+  void OnGetTransportInfoResult(NPT_Result res,
+                                PLT_DeviceDataReference& device,
+                                PLT_TransportInfo* info,
+                                void* userdata) override
+  {
+    std::unique_lock lock(m_section);
+
+    if (NPT_FAILED(res))
+    {
+      m_logger->error("OnGetTransportInfoResult failed");
+      m_trainfo.cur_speed = "0";
+      m_trainfo.cur_transport_state = "STOPPED";
+      m_trainfo.cur_transport_status = "ERROR_OCCURED";
+    }
+    else
+      m_trainfo = *info;
+  }
+
+  void UpdatePositionInfo()
+  {
+    if (m_postime == 0 || m_postime > CTimeUtils::GetFrameTime())
+      return;
+
+    m_control->GetTransportInfo(m_device, m_instance, this);
+    m_control->GetPositionInfo(m_device, m_instance, this);
+    m_postime = 0;
+  }
+
+  void OnGetPositionInfoResult(NPT_Result res,
+                               PLT_DeviceDataReference& device,
+                               PLT_PositionInfo* info,
+                               void* userdata) override
+  {
+    std::unique_lock lock(m_section);
+
+    if (NPT_FAILED(res) || info == NULL)
+    {
+      m_logger->error("OnGetPositionInfoResult failed");
+      m_posinfo = PLT_PositionInfo();
+    }
+    else
+      m_posinfo = *info;
+    m_postime = CTimeUtils::GetFrameTime() + 500;
+  }
+
+  ~CUPnPPlayerController() override
+  {
+    std::unique_lock lock(m_actionSection);
+    for (const auto& action : m_actions)
+      CUPnP::UnregisterUserdata(action.get());
+  }
+
+  // Platinum identifies a reply only by its userdata pointer, so each action is its own delegate.
+  // A wait pumps the render loop through the busy dialog, which can re-enter the player and start
+  // another action.
+  class CAction : public PLT_MediaControllerDelegate
+  {
+  public:
+    explicit CAction(CUPnPPlayerController& owner) : m_owner(owner) {}
+
+    CEvent& Event() { return m_event; }
+    NPT_Result GetStatus() const { return m_status; }
+    void Retire() { m_retired = true; }
+    bool IsSpent() const { return m_retired && m_replied; }
+
+    void OnSetAVTransportURIResult(NPT_Result res,
+                                   PLT_DeviceDataReference& device,
+                                   void* userdata) override
+    {
+      Complete(res, "OnSetAVTransportURIResult");
+    }
+
+    void OnPlayResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
+    {
+      Complete(res, "OnPlayResult");
+    }
+
+    void OnStopResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
+    {
+      Complete(res, "OnStopResult");
+    }
+
+    void OnGetTransportInfoResult(NPT_Result res,
+                                  PLT_DeviceDataReference& device,
+                                  PLT_TransportInfo* info,
+                                  void* userdata) override
+    {
+      m_owner.OnGetTransportInfoResult(res, device, info, userdata);
+      Complete(res, "OnGetTransportInfoResult");
+    }
+
+  private:
+    void Complete(NPT_Result res, const char* action)
+    {
+      if (NPT_FAILED(res))
+        m_owner.m_logger->error("{} failed", action);
+      m_status = res;
+      m_replied = true;
+      m_event.Set();
+    }
+
+    CUPnPPlayerController& m_owner;
+    CEvent m_event;
+    std::atomic<NPT_Result> m_status{NPT_FAILURE};
+    std::atomic<bool> m_replied{false};
+    std::atomic<bool> m_retired{false};
+  };
+
+  CAction* BeginAction()
+  {
+    std::unique_lock lock(m_actionSection);
+    ReapSpent();
+    m_actions.push_back(std::make_unique<CAction>(*this));
+    CAction* action = m_actions.back().get();
+    CUPnP::RegisterUserdata(action);
+    return action;
+  }
+
+  // Not freed here: the caller reads the reply off the action after the wait. A later BeginAction
+  // frees it once its reply has arrived.
+  void EndAction(CAction& action) { action.Retire(); }
+
+  // Platinum never replies to a request it did not accept, so waiting for one would hold the action
+  // for the life of the player.
+  void DiscardUnsent(CAction& action)
+  {
+    action.Retire();
+    Release(action);
+  }
+
+  template<typename F>
+  NPT_Result Send(CAction*& action, F&& send)
+  {
+    action = BeginAction();
+    const NPT_Result res = send(action);
+    if (NPT_FAILED(res))
+    {
+      DiscardUnsent(*action);
+      action = nullptr;
+    }
+    return res;
+  }
+
+  NPT_Result SendGetTransportInfo(CAction*& action)
+  {
+    return Send(action, [this](void* userdata)
+                { return m_control->GetTransportInfo(m_device, m_instance, userdata); });
+  }
+
+  NPT_Result SendStop(CAction*& action)
+  {
+    return Send(action,
+                [this](void* userdata) { return m_control->Stop(m_device, m_instance, userdata); });
+  }
+
+  NPT_Result SendPlay(CAction*& action)
+  {
+    return Send(action, [this](void* userdata)
+                { return m_control->Play(m_device, m_instance, "1", userdata); });
+  }
+
+  NPT_Result SendSetAVTransportURI(CAction*& action, const char* uri, const char* metadata)
+  {
+    return Send(
+        action, [&](void* userdata)
+        { return m_control->SetAVTransportURI(m_device, m_instance, uri, metadata, userdata); });
+  }
+
+  NPT_Result SendSetNextAVTransportURI(CAction*& action, const char* uri, const char* metadata)
+  {
+    return Send(action,
+                [&](void* userdata)
+                {
+                  return m_control->SetNextAVTransportURI(m_device, m_instance, uri, metadata,
+                                                          userdata);
+                });
+  }
+
+  size_t HeldActionCount() const
+  {
+    std::unique_lock lock(m_actionSection);
+    return m_actions.size();
+  }
+
+  NPT_Result WaitForReply(CAction& action, XbmcThreads::EndTime<>& timeout)
+  {
+    const NPT_Result result = WaitOnEvent(action.Event(), timeout);
+    EndAction(action);
+    return result;
+  }
+
+  bool WaitForReplyFor(CAction& action, std::chrono::milliseconds timeout)
+  {
+    const bool replied = action.Event().Wait(timeout);
+    EndAction(action);
+    return replied;
+  }
+
+  PLT_MediaController* m_control;
+  PLT_DeviceDataReference m_device;
+  NPT_UInt32 m_instance = 0;
+
+  unsigned int m_postime = 0;
+
+  PLT_PositionInfo m_posinfo;
+
+private:
+  void Release(CAction& action)
+  {
+    std::unique_lock lock(m_actionSection);
+    CUPnP::UnregisterUserdata(&action);
+    std::erase_if(m_actions, [&action](const auto& held) { return held.get() == &action; });
+  }
+
+  // Platinum fails an accepted request on its own HTTP timeout, so an action normally replies and
+  // is freed here. One accepted while the control point is stopping never replies, and is held
+  // until the player goes away. Called with m_actionSection held.
+  void ReapSpent()
+  {
+    const auto spent = [](const std::unique_ptr<CAction>& action)
+    {
+      if (!action->IsSpent())
+        return false;
+      CUPnP::UnregisterUserdata(action.get());
+      return true;
+    };
+    std::erase_if(m_actions, spent);
+  }
+
+  mutable CCriticalSection m_actionSection;
+  std::vector<std::unique_ptr<CAction>> m_actions;
+
+  mutable CCriticalSection m_section;
+  PLT_TransportInfo m_trainfo;
+  Logger m_logger;
+};
+
+} // namespace UPNP

--- a/xbmc/network/upnp/UPnPPlayerController.h
+++ b/xbmc/network/upnp/UPnPPlayerController.h
@@ -129,6 +129,18 @@ public:
     void Retire() { m_retired = true; }
     bool IsSpent() const { return m_retired && m_replied; }
 
+    NPT_String GetTransportState() const
+    {
+      std::unique_lock lock(m_section);
+      return m_trainfo.cur_transport_state;
+    }
+
+    NPT_String GetTransportStatus() const
+    {
+      std::unique_lock lock(m_section);
+      return m_trainfo.cur_transport_status;
+    }
+
     void OnSetAVTransportURIResult(NPT_Result res,
                                    PLT_DeviceDataReference& device,
                                    void* userdata) override
@@ -151,6 +163,19 @@ public:
                                   PLT_TransportInfo* info,
                                   void* userdata) override
     {
+      {
+        std::unique_lock lock(m_section);
+        if (NPT_FAILED(res) || info == NULL)
+        {
+          m_trainfo.cur_speed = "0";
+          m_trainfo.cur_transport_state = "STOPPED";
+          m_trainfo.cur_transport_status = "ERROR_OCCURED";
+        }
+        else
+          m_trainfo = *info;
+      }
+      // CUPnPPlayer::Process watches the controller's copy for the end of playback. Left to the
+      // poll, which can be 500ms behind, it still reads STOPPED as playback starts.
       m_owner.OnGetTransportInfoResult(res, device, info, userdata);
       Complete(res, "OnGetTransportInfoResult");
     }
@@ -166,6 +191,8 @@ public:
     }
 
     CUPnPPlayerController& m_owner;
+    mutable CCriticalSection m_section;
+    PLT_TransportInfo m_trainfo;
     CEvent m_event;
     std::atomic<NPT_Result> m_status{NPT_FAILURE};
     std::atomic<bool> m_replied{false};

--- a/xbmc/network/upnp/test/CMakeLists.txt
+++ b/xbmc/network/upnp/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestUPnPFileMediaServer.cpp
             TestUPnPInternal.cpp
+            TestUPnPPlayerController.cpp
 )
 
 core_add_test_library(network_upnp_test)

--- a/xbmc/network/upnp/test/TestUPnPPlayerController.cpp
+++ b/xbmc/network/upnp/test/TestUPnPPlayerController.cpp
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "network/upnp/UPnPPlayerController.h"
+
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+using namespace UPNP;
+using namespace std::chrono_literals;
+
+namespace
+{
+// No media controller is given, so each test delivers a reply by calling the action's handler
+// directly, as Platinum does with the userdata.
+class TestUPnPPlayerController : public ::testing::Test
+{
+protected:
+  TestUPnPPlayerController() : m_device(new PLT_DeviceData()), m_controller(nullptr, m_device) {}
+
+  PLT_DeviceDataReference m_device;
+  CUPnPPlayerController m_controller;
+};
+} // unnamed namespace
+
+TEST_F(TestUPnPPlayerController, AnActionIsReadableAfterItIsRetired)
+{
+  auto* action = m_controller.BeginAction();
+  ASSERT_NE(nullptr, action);
+
+  action->OnPlayResult(NPT_SUCCESS, m_device, action);
+  m_controller.EndAction(*action);
+
+  // Checked on the count, because reading a freed action would not fail.
+  EXPECT_EQ(1U, m_controller.HeldActionCount());
+  EXPECT_EQ(NPT_SUCCESS, action->GetStatus());
+}
+
+TEST_F(TestUPnPPlayerController, AReplyDoesNotReachAnotherAction)
+{
+  auto* first = m_controller.BeginAction();
+  m_controller.EndAction(*first);
+  auto* second = m_controller.BeginAction();
+  ASSERT_NE(first, second);
+
+  first->OnStopResult(NPT_FAILURE, m_device, first);
+
+  EXPECT_TRUE(first->Event().Wait(0ms));
+  EXPECT_FALSE(second->Event().Wait(0ms));
+}
+
+TEST_F(TestUPnPPlayerController, AnActionThatNeverRepliedIsNotASuccess)
+{
+  auto* action = m_controller.BeginAction();
+
+  EXPECT_NE(NPT_SUCCESS, action->GetStatus());
+}
+
+TEST_F(TestUPnPPlayerController, AFailedSendLeavesNoAction)
+{
+  CUPnPPlayerController::CAction* action = nullptr;
+  const NPT_Result result =
+      m_controller.Send(action, [](void* userdata) { return NPT_ERROR_INVALID_STATE; });
+
+  EXPECT_TRUE(NPT_FAILED(result));
+  EXPECT_EQ(nullptr, action);
+}
+
+TEST_F(TestUPnPPlayerController, RepliedActionsDoNotAccumulate)
+{
+  for (int i = 0; i < 20; ++i)
+  {
+    auto* action = m_controller.BeginAction();
+    action->OnPlayResult(NPT_SUCCESS, m_device, action);
+    m_controller.EndAction(*action);
+  }
+
+  // Only the action begun last is still held; the others were freed on reply.
+  EXPECT_EQ(1U, m_controller.HeldActionCount());
+}

--- a/xbmc/network/upnp/test/TestUPnPPlayerController.cpp
+++ b/xbmc/network/upnp/test/TestUPnPPlayerController.cpp
@@ -62,6 +62,24 @@ TEST_F(TestUPnPPlayerController, AnActionThatNeverRepliedIsNotASuccess)
   EXPECT_NE(NPT_SUCCESS, action->GetStatus());
 }
 
+TEST_F(TestUPnPPlayerController, TransportInfoBelongsToTheActionThatAskedForIt)
+{
+  auto* playing = m_controller.BeginAction();
+  m_controller.EndAction(*playing);
+  auto* stopped = m_controller.BeginAction();
+
+  PLT_TransportInfo playingInfo;
+  playingInfo.cur_transport_state = "PLAYING";
+  playing->OnGetTransportInfoResult(NPT_SUCCESS, m_device, &playingInfo, playing);
+
+  PLT_TransportInfo stoppedInfo;
+  stoppedInfo.cur_transport_state = "STOPPED";
+  stopped->OnGetTransportInfoResult(NPT_SUCCESS, m_device, &stoppedInfo, stopped);
+
+  EXPECT_STREQ("PLAYING", playing->GetTransportState().GetChars());
+  EXPECT_STREQ("STOPPED", stopped->GetTransportState().GetChars());
+}
+
 TEST_F(TestUPnPPlayerController, AFailedSendLeavesNoAction)
 {
   CUPnPPlayerController::CAction* action = nullptr;


### PR DESCRIPTION
**TL;DR:** Bug fix. Every action `CUPnPPlayer` sends a renderer carries the same userdata and signals the same event, so a reply that arrives late releases whatever wait is outstanding now and hands it the wrong status. Each action becomes its own delegate with its own event and status, and then its own transport information. Split out of #29155.

## Description
Two commits.

### `fixed: tell one renderer action's reply from another's`
`CUPnPPlayer` passes `m_delegate.get()` as the userdata for every action it sends, so every reply Platinum hands back carries the same address and sets the same event. A reply that arrives after the player has stopped waiting for it — because the action timed out, or was abandoned — releases whatever wait is outstanding now and hands it that reply's status. `CGUIDialogBusy::WaitOnEvent` pumps `ProcessRenderLoop`, so the application can also re-enter the player and start an action while an open is waiting on another.

Each action is now its own `PLT_MediaControllerDelegate`, carrying the event its caller waits on and the status its reply returned. The loop that waits for the transport to reach `STOPPED` takes an action per `GetTransportInfo` call rather than reusing one event.

**Retiring an action is not the same as freeing it.** `CUPnP` drops a reply whose userdata is not registered, under the same lock its dispatch holds, so unregistering stops a reply reaching the object it named. It does not stop the address being handed to a later action while a reply carrying it is still in flight: that reply would pass the registry check and be delivered to the new action. So an action is freed once its reply has arrived and its caller has finished with it, and at once if the request was never sent.

**Platinum does not answer everything it accepts.** `PLT_CtrlPoint::InvokeAction` discards the result of `StartTask`, and a task aborted before it sends never reaches `ProcessResponse`. An action caught by either is held until the player goes away, which is what happened to every action before this change.

An action's status starts as a failure, so an action that never replied cannot read as a success.

The controller's result handlers for `Play`, `Stop` and `SetAVTransportURI` are gone, since no awaited action names the controller any more. `CUPnPPlayerController` moves to its own header so it can be tested, and loses three members nothing read.

### `fixed: keep each renderer action's transport state for its own caller`
The player thread keeps polling `GetTransportInfo` through `UpdatePositionInfo()`, and every reply wrote the controller's single copy of the transport state. A poll reply could overwrite an awaited result between it arriving and the caller reading it.

Each action now keeps the transport information its own reply carried, and the awaited sites read it from the action. The reply still updates the controller's copy, which `CUPnPPlayer::Process()` watches for the end of playback: left to the poll, which can be half a second behind, it still reads `STOPPED` as playback starts.

## Motivation and context
Split out of #29155 at @reardonia's suggestion; that PR is the `CGUIDialogBusy` timeout and is unrelated to this. Earlier revisions were reviewed by @reardonia and by Codex, and the defects they found are addressed above.

The `SetNextAVTransportURI` reply fix that an earlier revision carried has moved to #29288, next to the gapless playback that calls it: nothing called `QueueNextFile()` on this player. #29288, #29289 and #29290 all touch `UPnPPlayer.cpp`, so whichever lands after this needs a manual rebase.

## How has this been tested?
`TestUPnPPlayerController` drives an action by calling its reply back on it directly, which is all Platinum does with the userdata it is handed, so no controller, device or network is involved. The first commit has five cases: an action stays readable after it is retired; a reply does not reach another action; an action that never replied does not read as a success; a failed send leaves no action; replied actions do not accumulate. The second adds that transport information belongs to the action that asked for it.

Asserting on a *read* after retirement does not catch a use-after-free, since it passes on freed memory, so that case asserts on the held-action count instead.

Each commit builds and passes the UPnP tests on its own. Full gtest suite passes. clang-format clean on the changed lines.

## What is the effect on users?
A renderer that answers slowly no longer causes the player to act on a reply belonging to an action it has already abandoned.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
