### PR TITLE
[Estuary] Fix media source dialog default focus

### DIFF
--- a/addons/skin.estuary/xml/DialogMediaSource.xml
+++ b/addons/skin.estuary/xml/DialogMediaSource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol>10</defaultcontrol>
+	<defaultcontrol always="true">10</defaultcontrol>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">


### PR DESCRIPTION
## Description
Changes the Estuary media source dialog to always focus its default control when the dialog is opened.

Specifically, `DialogMediaSource.xml` now uses `<defaultcontrol always="true">10</defaultcontrol>`. This ensures the source path list receives focus each time the dialog is freshly opened.

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/29184

When the “Add video source” dialog was opened a second time, Kodi could attempt to restore focus to the last-used control instead of the dialog’s default control. If that previous control was disabled, the first navigation action could be swallowed: the user would hear the navigation sound, but focus would not visibly move.

The dialog should behave consistently every time it is opened, with focus starting on the path/source list.

## How has this been tested?
Tested by reviewing the Estuary XML change and confirming the dialog default control is now marked with `always="true"`.

Expected behavior to verify manually:
- Open the “Add video source” dialog.
- Confirm focus starts on the source path list.
- Navigate to another control and close/complete the dialog.
- Reopen the dialog.
- Confirm focus again starts on the source path list and the first navigation action works normally.

## What is the effect on users?
Users adding multiple media sources will get consistent focus behavior each time the “Add video source” dialog is opened. This prevents the first navigation input from appearing to be ignored on subsequent openings of the dialog.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed