### PR TITLE
RetroPlayer: Fix rewind state buffer sizing

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -2,6 +2,7 @@ xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
 xbmc/cores/RetroPlayer/rendering/test test/retroplayer_rendering
+xbmc/cores/RetroPlayer/streams/memory/test test/retroplayer_memory
 xbmc/cores/VideoPlayer/Buffers/test test/videoplayer_buffers
 xbmc/cores/VideoPlayer/test       test/videoplayer
 xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers

--- a/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
@@ -11,9 +11,6 @@
 using namespace KODI;
 using namespace RETRO;
 
-// Pad forward to nearest boundary of bytes
-#define PAD_TO_CEIL(x, bytes) ((((x) + (bytes) - 1) / (bytes)) * (bytes))
-
 CLinearMemoryStream::CLinearMemoryStream()
 {
   Reset();
@@ -24,7 +21,7 @@ void CLinearMemoryStream::Init(size_t frameSize, uint64_t maxFrameCount)
   Reset();
 
   m_frameSize = frameSize;
-  m_paddedFrameSize = PAD_TO_CEIL(m_frameSize, sizeof(uint32_t));
+  m_paddedFrameSize = (m_frameSize + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   m_maxFrames = maxFrameCount;
 }
 
@@ -64,12 +61,12 @@ uint8_t* CLinearMemoryStream::BeginFrame()
   if (!m_bHasCurrentFrame)
   {
     if (!m_currentFrame)
-      m_currentFrame.reset(new uint32_t[m_paddedFrameSize]);
+      m_currentFrame = std::make_unique<uint32_t[]>(m_paddedFrameSize);
     return reinterpret_cast<uint8_t*>(m_currentFrame.get());
   }
 
   if (!m_nextFrame)
-    m_nextFrame.reset(new uint32_t[m_paddedFrameSize]);
+    m_nextFrame = std::make_unique<uint32_t[]>(m_paddedFrameSize);
   return reinterpret_cast<uint8_t*>(m_nextFrame.get());
 }
 

--- a/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.h
+++ b/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.h
@@ -47,7 +47,7 @@ protected:
   // Helper function
   uint64_t BufferSize() const;
 
-  size_t m_paddedFrameSize;
+  size_t m_paddedFrameSize; // Number of uint32_t words, including padding
   uint64_t m_maxFrames;
 
   /**

--- a/xbmc/cores/RetroPlayer/streams/memory/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/streams/memory/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestDeltaPairMemoryStream.cpp)
+
+core_add_test_library(retroplayer_memory_test)

--- a/xbmc/cores/RetroPlayer/streams/memory/test/TestDeltaPairMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/test/TestDeltaPairMemoryStream.cpp
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::RETRO;
+
+namespace
+{
+class TestMemoryStream : public CDeltaPairMemoryStream
+{
+public:
+  size_t WordCount() const { return m_paddedFrameSize; }
+  size_t LastDeltaCount() const { return m_rewindBuffer.back().buffer.size(); }
+};
+} // namespace
+
+class TestDeltaPairMemoryStream : public testing::Test
+{
+protected:
+  void ExpectZeroPadding(const uint8_t* frame) const
+  {
+    for (size_t i = m_stream.FrameSize(); i < m_stream.WordCount() * sizeof(uint32_t); ++i)
+      EXPECT_EQ(0, frame[i]) << "Byte " << i;
+  }
+
+  TestMemoryStream m_stream;
+};
+
+TEST_F(TestDeltaPairMemoryStream, SizesStorageInWords)
+{
+  for (const size_t stateSize : {4099, 4096})
+  {
+    SCOPED_TRACE(stateSize);
+    m_stream.Init(stateSize, 4);
+
+    EXPECT_EQ(stateSize, m_stream.FrameSize());
+    ASSERT_EQ(stateSize == 4099 ? 1025 : 1024, m_stream.WordCount());
+
+    uint8_t* frame = m_stream.BeginFrame();
+    ASSERT_NE(nullptr, frame);
+    std::fill_n(frame, stateSize, 0x5a);
+    ExpectZeroPadding(frame);
+    m_stream.SubmitFrame();
+
+    frame = m_stream.BeginFrame();
+    ASSERT_NE(nullptr, frame);
+    std::fill_n(frame, stateSize, 0xa5);
+    ExpectZeroPadding(frame);
+    m_stream.SubmitFrame();
+    ExpectZeroPadding(m_stream.CurrentFrame());
+  }
+}
+
+TEST_F(TestDeltaPairMemoryStream, RewindsAndPreservesPaddingThroughBufferReuse)
+{
+  for (const size_t stateSize : {4099, 4096})
+  {
+    SCOPED_TRACE(stateSize);
+    m_stream.Init(stateSize, 4);
+
+    std::vector<uint8_t> first(stateSize);
+    for (size_t i = 0; i < stateSize; ++i)
+      first[i] = static_cast<uint8_t>(i);
+    std::vector<uint8_t> second = first;
+    second.back() ^= 0xff;
+
+    for (const auto* state : {&first, &second, &second, &first})
+    {
+      uint8_t* frame = m_stream.BeginFrame();
+      ASSERT_NE(nullptr, frame);
+      std::copy(state->begin(), state->end(), frame);
+      ExpectZeroPadding(frame);
+      m_stream.SubmitFrame();
+      EXPECT_EQ(0, std::memcmp(state->data(), m_stream.CurrentFrame(), stateSize));
+      ExpectZeroPadding(m_stream.CurrentFrame());
+      if (m_stream.PastFramesAvailable() > 0)
+      {
+        EXPECT_EQ(m_stream.PastFramesAvailable() == 2 ? 0 : 1, m_stream.LastDeltaCount());
+      }
+    }
+
+    for (const auto* state : {&second, &second, &first})
+    {
+      ASSERT_EQ(1, m_stream.RewindFrames(1));
+      EXPECT_EQ(0, std::memcmp(state->data(), m_stream.CurrentFrame(), stateSize));
+      ExpectZeroPadding(m_stream.CurrentFrame());
+    }
+
+    uint8_t* frame = m_stream.BeginFrame();
+    ASSERT_NE(nullptr, frame);
+    std::copy(first.begin(), first.end(), frame);
+    ExpectZeroPadding(frame);
+    m_stream.SubmitFrame();
+    EXPECT_EQ(0, m_stream.LastDeltaCount());
+    ASSERT_EQ(1, m_stream.RewindFrames(1));
+    EXPECT_EQ(0, std::memcmp(first.data(), m_stream.CurrentFrame(), stateSize));
+    ExpectZeroPadding(m_stream.CurrentFrame());
+  }
+}


### PR DESCRIPTION
## Description

AI use:

Fix an error in RetroPlayer's rewind state buffer sizing.

Serialized state sizes are reported in bytes, but the padded byte count was used as a `uint32_t` element count. This caused full-state buffers to be approximately 4x larger than required, and the XOR delta loop scanned approximately 4x as many words, including excess uninitialized storage beyond the serialized state.

Convert the size to a padded `uint32_t` word count while preserving the exact byte size passed to the game client. The buffers are value-initialized so the final partial-word padding remains zero through reuse and rewind.

## Motivation and context

Realtime rewind serializes emulator state every frame, so unnecessary allocation and XOR work directly affects gameplay performance. The impact is especially large for cores with large savestates; a 16 MiB serialized state previously resulted in roughly 64 MiB full-state buffers and about 16.8 million XOR iterations instead of about 4.2 million.

Related slowdown reports:

* https://github.com/kodi-game/game.libretro.beetle-psx/issues/13 — slowdown later identified as most likely caused by realtime rewind.
* https://github.com/kodi-game/game.libretro.beetle-psx/issues/21 — reports a 16 MiB serialized state and unplayably slow gameplay; disabling realtime rewind restored fluent gameplay.

This does not attempt to eliminate every source of rewind overhead; it fixes the incorrect buffer sizing and excess XOR work in the existing implementation.

## How has this been tested?

Added focused tests covering:

* 4099-byte and word-aligned serialized states
* Correct `uint32_t` word capacity
* Zeroed partial-word padding
* Rewind reconstruction
* XOR delta counts
* Buffer reuse and resubmission after rewind

The tests verify that the exact byte-sized state is preserved while only the required padded words are allocated and processed.

## What is the effect on users?

Reduced memory use and CPU work when realtime rewind is enabled, especially for emulators with large serialized states.

For full-state buffers, memory allocation and XOR scanning are reduced by approximately 4x compared to the broken sizing calculation.

## Types of change

<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
* [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
* [ ] **None of the above** (please explain below)
