### PR TITLE
Move subtitle decoding off the main thread

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HEADERS BaseRenderer.h
             ColorManager.h
             DebugInfo.h
             OverlayRenderer.h
+            OverlayRendererAsync.h
             OverlayRendererUtil.h
             RenderFactory.h
             RenderFlags.h

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h"
 #include "settings/SubtitlesSettings.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -259,7 +260,11 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
       if (!images)
         continue;
 
-      std::shared_ptr<COverlay> o = COverlay::Create(images, rOpts.frameWidth, rOpts.frameHeight);
+      SQuads quads;
+      if (!convert_quad(images, quads, static_cast<int>(rOpts.frameWidth)))
+        continue;
+
+      std::shared_ptr<COverlay> o = COverlay::Create(quads, rOpts.frameWidth, rOpts.frameHeight);
 
       if (o)
         OVERLAY::CRenderer::Render(o.get());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -236,6 +236,20 @@ void CRenderer::UnInit()
   m_bitmapRenderer.reset();
 }
 
+void CRenderer::FlushAsyncSubtitleState()
+{
+  std::unique_lock lock(m_section);
+  if (m_assRenderer)
+    m_assRenderer->Flush();
+  if (m_bitmapRenderer)
+    m_bitmapRenderer->Flush();
+  m_lastConvertedAssResult.reset();
+  m_cachedAssOverlay.reset();
+  m_lastConvertedBitmapResult.reset();
+  m_cachedBitmapOverlaySource = nullptr;
+  m_cachedBitmapOverlay.reset();
+}
+
 void CRenderer::Flush()
 {
   std::unique_lock lock(m_section);
@@ -246,15 +260,7 @@ void CRenderer::Flush()
   ReleaseCache();
   Reset();
 
-  if (m_assRenderer)
-    m_assRenderer->Flush();
-  if (m_bitmapRenderer)
-    m_bitmapRenderer->Flush();
-  m_lastConvertedAssResult.reset();
-  m_cachedAssOverlay.reset();
-  m_lastConvertedBitmapResult.reset();
-  m_cachedBitmapOverlaySource = nullptr;
-  m_cachedBitmapOverlay.reset();
+  FlushAsyncSubtitleState();
 }
 
 void CRenderer::Reset()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -248,6 +248,7 @@ void CRenderer::FlushAsyncSubtitleState()
   m_lastConvertedBitmapResult.reset();
   m_cachedBitmapOverlaySource = nullptr;
   m_cachedBitmapOverlay.reset();
+  m_lastPreparedAssPts = DVD_NOPTS_VALUE;
 }
 
 void CRenderer::Flush()
@@ -742,6 +743,26 @@ void CRenderer::PrepareOverlays(int idx, double lookaheadPts)
       else
         rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::CENTER;
     }
+
+    // Ordinary frame-to-frame pts deltas are a small fraction of a second;
+    // a jump past this threshold, in either direction, means a seek (or
+    // similar discontinuity) landed since the last call. Any async result
+    // history at that point was rendered for pts values on the wrong side
+    // of the jump - close-in-value-but-stale content that the ordinary
+    // "not in the future" rule would otherwise happily match against the
+    // new position - so it must be discarded here, at the point the jump
+    // is actually observed, rather than only at the seek's own flush call
+    // (DiscardBuffer), which necessarily fires before the presented pts
+    // has caught up to the new position and so cannot see this coming.
+    constexpr double DISCONTINUITY_THRESHOLD = DVD_TIME_BASE; // 1 second
+    if (m_lastPreparedAssPts != DVD_NOPTS_VALUE &&
+        std::fabs(e.pts - m_lastPreparedAssPts) > DISCONTINUITY_THRESHOLD)
+    {
+      m_assRenderer->Flush();
+      m_lastConvertedAssResult.reset();
+      m_cachedAssOverlay.reset();
+    }
+    m_lastPreparedAssPts = e.pts;
 
     // Submit the lookahead request (next presented slot's pts, when
     // known) so it has a full GUI tick to complete before it is actually

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -73,16 +73,6 @@ using namespace OVERLAY;
 
 namespace
 {
-// Half a frame's duration in DVD_TIME_BASE units, used as the pts-match
-// tolerance for GetBestResult(). Falls back to a 60fps assumption if the
-// frame duration isn't known yet (e.g. very first frame of playback).
-double HalfFrameTolerance(double frameDurationHint)
-{
-  if (frameDurationHint <= 0.0)
-    return DVD_TIME_BASE / 60.0 / 2.0;
-  return frameDurationHint / 2.0;
-}
-
 // Runs on the ass async worker thread only. 'lastAppliedGeneration' is
 // owned by CRenderer but never touched from any other thread - the worker
 // decides here, from the job's styleGeneration, whether to re-apply style,
@@ -761,14 +751,13 @@ void CRenderer::PrepareOverlays(int idx, double lookaheadPts)
     job.styleGeneration = m_styleGeneration;
     m_assRenderer->RequestRender(job);
 
-    // Consume: pick whichever of the last two completed results is
-    // closest to *this slot's own* pts (not requestPts - that is only
-    // where we are asking the worker to look next), within a half-frame
-    // tolerance. See the file-level design notes for why this, rather
-    // than "always take the latest", is what makes pause/seek/low-fps
-    // content converge correctly instead of flickering.
-    const double tolerance = HalfFrameTolerance(rOpts.frameWidth > 0 ? 0.0 : 0.0);
-    e.assResult = m_assRenderer->GetBestResult(e.pts, tolerance);
+    // Consume: pick whichever of the last two completed results has the
+    // newest pts not exceeding *this slot's own* pts (not requestPts -
+    // that is only where we are asking the worker to look next). Never
+    // shows a "future" result early; always accepts an arbitrarily stale
+    // "past" one rather than showing nothing while the worker catches up
+    // on a run of slow cues. See file-level design notes.
+    e.assResult = m_assRenderer->GetBestResult(e.pts);
 
     if (e.assResult && (!prevAssResult || prevAssResult.get() != e.assResult.get()) &&
         e.assResult->hasImage)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -238,21 +238,6 @@ void CRenderer::UnInit()
   m_bitmapRenderer.reset();
 }
 
-void CRenderer::FlushAsyncSubtitleState()
-{
-  std::unique_lock lock(m_section);
-  if (m_assRenderer)
-    m_assRenderer->Flush();
-  if (m_bitmapRenderer)
-    m_bitmapRenderer->Flush();
-  m_lastConvertedAssResult.reset();
-  m_cachedAssOverlay.reset();
-  m_lastConvertedBitmapResult.reset();
-  m_cachedBitmapOverlaySource = nullptr;
-  m_cachedBitmapOverlay.reset();
-  m_lastPreparedAssPts = DVD_NOPTS_VALUE;
-}
-
 void CRenderer::Flush()
 {
   std::unique_lock lock(m_section);
@@ -263,7 +248,16 @@ void CRenderer::Flush()
   ReleaseCache();
   Reset();
 
-  FlushAsyncSubtitleState();
+  if (m_assRenderer)
+    m_assRenderer->Flush();
+  if (m_bitmapRenderer)
+    m_bitmapRenderer->Flush();
+  m_lastConvertedAssResult.reset();
+  m_cachedAssOverlay.reset();
+  m_lastConvertedBitmapResult.reset();
+  m_cachedBitmapOverlaySource = nullptr;
+  m_cachedBitmapOverlay.reset();
+  m_lastPreparedAssPts = DVD_NOPTS_VALUE;
 }
 
 void CRenderer::Reset()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -7,6 +7,44 @@
  *  See LICENSES/README.md for more information.
  */
 
+// ---------------------------------------------------------------------
+// Design notes: async subtitle decode
+//
+// Complex ASS scripts (heavy \blur, many overlapping drawing/karaoke
+// events) can take libass tens of milliseconds to lay out and rasterize
+// per frame. Large PGS/DVB/DVD-SPU bitmaps can likewise take a non-trivial
+// amount of CPU to decode. Doing this inline on the GUI/render thread once
+// per displayed frame (the historical behaviour) means a single slow
+// subtitle frame stalls the entire GUI/render loop, not just the
+// subtitle.
+//
+// CRenderer now off-loads both decode paths to background workers
+// (OVERLAY::CAsyncSubtitleRenderer, see OverlayRendererAsync.h) and never
+// blocks the GUI thread on them. PrepareOverlays() submits a request and
+// immediately reads back whatever the worker last finished - which may be
+// a frame or more stale under load. This deliberately trades subtitle
+// timing accuracy for guaranteed smooth video/GUI playback.
+//
+// Because "submit, then immediately read" can never observe the result of
+// the request just submitted (the worker hasn't even been scheduled yet),
+// PrepareOverlays() looks one presentation flip ahead: while preparing the
+// slot about to be displayed, it also submits a request for the *next*
+// queued slot's pts (supplied by CRenderManager::FrameMove, which knows
+// the presentation queue), so that request has a full GUI tick to
+// complete before it is actually needed. When no distinct "next" pts is
+// known (paused, trick-play, nothing queued), the current slot's own pts
+// is requested instead.
+//
+// Because a presentation flip does not happen every GUI tick (e.g. video
+// fps below display refresh rate) and because pausing/seeking can leave a
+// lookahead result for a pts that is never actually displayed, the async
+// renderer keeps the last two completed results and CRenderer selects
+// whichever is closest to the pts actually being displayed this frame,
+// within a half-frame-duration tolerance. This one rule handles steady
+// playback, pause, and fps-below-refresh-rate content without any
+// special-casing between them.
+// ---------------------------------------------------------------------
+
 #include "OverlayRenderer.h"
 
 #include "OverlayRendererUtil.h"
@@ -17,6 +55,7 @@
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/DisplaySettings.h"
@@ -31,6 +70,97 @@
 
 using namespace KODI;
 using namespace OVERLAY;
+
+namespace
+{
+// Half a frame's duration in DVD_TIME_BASE units, used as the pts-match
+// tolerance for GetBestResult(). Falls back to a 60fps assumption if the
+// frame duration isn't known yet (e.g. very first frame of playback).
+double HalfFrameTolerance(double frameDurationHint)
+{
+  if (frameDurationHint <= 0.0)
+    return DVD_TIME_BASE / 60.0 / 2.0;
+  return frameDurationHint / 2.0;
+}
+
+// Runs on the ass async worker thread only. 'lastAppliedGeneration' is
+// owned by CRenderer but never touched from any other thread - the worker
+// decides here, from the job's styleGeneration, whether to re-apply style,
+// so a style change is never lost to request coalescing regardless of how
+// many intermediate requests were overwritten before this one ran.
+std::shared_ptr<const SAssRenderResult> RenderAssJob(const SAssRenderJob& job,
+                                                     uint64_t& lastAppliedGeneration)
+{
+  auto result = std::make_shared<SAssRenderResult>();
+  result->pts = job.pts;
+  result->frameWidth = job.opts.frameWidth;
+  result->frameHeight = job.opts.frameHeight;
+
+  const bool updateStyle = job.styleGeneration != lastAppliedGeneration;
+  if (updateStyle)
+    lastAppliedGeneration = job.styleGeneration;
+
+  // The expensive call: layout, shaping, blur, glyph rasterization.
+  ASS_Image* images = job.handler->RenderImage(job.pts, job.opts, updateStyle, job.subStyle);
+
+  // Copies every pixel out of libass's buffers; after this line, 'images'
+  // (owned by libass, valid only until the next ass_render_frame on this
+  // renderer) is never touched again.
+  result->hasImage = convert_quad(images, result->quads, static_cast<int>(job.opts.frameWidth));
+  return result;
+}
+
+// Runs on the bitmap async worker thread only.
+std::shared_ptr<const SBitmapRenderResult> RenderBitmapJob(const SBitmapRenderJob& job)
+{
+  auto result = std::make_shared<SBitmapRenderResult>();
+  if (!job.overlay)
+    return result;
+
+  if (job.overlay->IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
+  {
+    const auto& o = static_cast<const CDVDOverlayImage&>(*job.overlay);
+    result->width = o.width;
+    result->height = o.height;
+    result->minX = 0;
+    result->maxX = o.width;
+    result->minY = 0;
+    result->maxY = o.height;
+    result->rgba.resize(static_cast<size_t>(o.width) * o.height);
+
+    if (o.palette.empty())
+    {
+      // Already RGBA; normalize to a tightly packed buffer here (rather
+      // than in the GPU-upload step) so the render thread never needs to
+      // know about source stride/linesize.
+      const uint8_t* src = o.pixels.data();
+      uint32_t* dst = result->rgba.data();
+      for (int row = 0; row < o.height; ++row)
+      {
+        memcpy(dst, src, static_cast<size_t>(o.width) * 4);
+        src += o.linesize;
+        dst += o.width;
+      }
+    }
+    else
+    {
+      convert_rgba(o, true /*mergealpha*/, result->rgba);
+    }
+    result->hasImage = true;
+  }
+  else if (job.overlay->IsOverlayType(DVDOVERLAY_TYPE_SPU))
+  {
+    const auto& o = static_cast<const CDVDOverlaySpu&>(*job.overlay);
+    result->width = o.width;
+    result->height = o.height;
+    result->rgba.resize(static_cast<size_t>(o.width) * o.height);
+    convert_rgba(o, true /*mergealpha*/, result->minX, result->maxX, result->minY, result->maxY,
+                 result->rgba);
+    result->hasImage = true;
+  }
+  return result;
+}
+} // namespace
 
 COverlay::COverlay()
 {
@@ -63,6 +193,24 @@ CRenderer::~CRenderer()
   Flush();
 }
 
+void CRenderer::PreInit()
+{
+  std::unique_lock lock(m_section);
+  if (!m_assRenderer)
+  {
+    m_assRenderer =
+        std::make_unique<CAsyncSubtitleRenderer<SAssRenderJob, SAssRenderResult>>(
+            "AssSubRenderer", [this](const SAssRenderJob& job)
+            { return RenderAssJob(job, m_assLastAppliedStyleGeneration); });
+  }
+  if (!m_bitmapRenderer)
+  {
+    m_bitmapRenderer =
+        std::make_unique<CAsyncSubtitleRenderer<SBitmapRenderJob, SBitmapRenderResult>>(
+            "BitmapSubRenderer", [](const SBitmapRenderJob& job) { return RenderBitmapJob(job); });
+  }
+}
+
 void CRenderer::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index)
 {
   std::unique_lock lock(m_section);
@@ -88,6 +236,14 @@ void CRenderer::UnInit()
   }
 
   Flush();
+
+  // Stop and join the workers. No new PrepareOverlays calls can arrive
+  // once the caller has begun tearing down (UnInit is called from
+  // CRenderManager::UnInit, itself gated on the render state), so it is
+  // safe to destroy these now.
+  std::unique_lock lock(m_section);
+  m_assRenderer.reset();
+  m_bitmapRenderer.reset();
 }
 
 void CRenderer::Flush()
@@ -99,6 +255,16 @@ void CRenderer::Flush()
 
   ReleaseCache();
   Reset();
+
+  if (m_assRenderer)
+    m_assRenderer->Flush();
+  if (m_bitmapRenderer)
+    m_bitmapRenderer->Flush();
+  m_lastConvertedAssResult.reset();
+  m_cachedAssOverlay.reset();
+  m_lastConvertedBitmapResult.reset();
+  m_cachedBitmapOverlaySource = nullptr;
+  m_cachedBitmapOverlay.reset();
 }
 
 void CRenderer::Reset()
@@ -254,6 +420,21 @@ void CRenderer::Render(COverlay* o)
   o->Render(state);
 }
 
+double CRenderer::GetOverlayPts(int idx) const
+{
+  std::unique_lock lock(m_section);
+  if (idx < 0 || idx >= NUM_BUFFERS)
+    return DVD_NOPTS_VALUE;
+
+  for (const auto& e : m_buffers[idx])
+  {
+    if (e.overlay_dvd && (e.overlay_dvd->IsOverlayType(DVDOVERLAY_TYPE_TEXT) ||
+                           e.overlay_dvd->IsOverlayType(DVDOVERLAY_TYPE_SSA)))
+        return e.pts;
+  }
+  return DVD_NOPTS_VALUE;
+}
+
 bool CRenderer::HasVisibleOverlay(int idx) const
 {
   std::unique_lock lock(m_section);
@@ -266,19 +447,15 @@ bool CRenderer::HasVisibleOverlay(int idx) const
       continue;
 
     const CDVDOverlay& o = *e.overlay_dvd;
-    // PGS/DVB and DVD SPU: ProcessOverlays inserts these into m_buffers
-    // only at PTS values where the bitmap is on screen, so finding one
-    // here means it is visible.
     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
-      return true;
-
-    // libass (TEXT/SSA): the container stays in m_buffers for the whole
-    // video (iPTSStopTime=DVD_NOPTS_VALUE). Visibility means
-    // ass_render_frame returned images for the current PTS, cached by
-    // PrepareOverlays in e.renderedImages.
+    {
+      if (e.bitmapResult && e.bitmapResult->hasImage)
+        return true;
+      continue;
+    }
     if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
     {
-      if (e.renderedImages != nullptr)
+      if (e.assResult && e.assResult->hasImage)
         return true;
     }
   }
@@ -422,35 +599,60 @@ void CRenderer::CreateSubtitlesStyle()
   m_overlayStyle->lineSpacing = settings->GetLineSpacing();
 }
 
-void CRenderer::PrepareOverlays(int idx)
+void CRenderer::PrepareOverlays(int idx, double lookaheadPts)
 {
   std::unique_lock lock(m_section);
   if (idx < 0 || idx >= NUM_BUFFERS)
     return;
+  if (!m_assRenderer || !m_bitmapRenderer)
+    return; // PreInit hasn't run yet (e.g. very first call of a session)
 
   bool doMarkDirty = false;
   bool hasImageSpu = false;
   for (auto& e : m_buffers[idx])
   {
-    // Clear last frame's cached output; libass may have invalidated the
-    // pointer on its next ass_render_frame call.
-    // (assDetectChange is consumed by ConvertLibass, not here.)
-    e.renderedImages = nullptr;
+    std::shared_ptr<const SAssRenderResult> prevAssResult = e.assResult;
+    std::shared_ptr<const SBitmapRenderResult> prevBitmapResult = e.bitmapResult;
+    e.assResult.reset();
+    e.bitmapResult.reset();
 
     if (!e.overlay_dvd)
       continue;
 
     CDVDOverlay& o = *e.overlay_dvd;
 
-    // PGS/DVB and DVD SPU: only added to m_buffers at their visible PTS,
-    // so finding one means it is on screen now. m_textureid == 0 is the
-    // "new arrival" signal (also true every frame for animated PGS where
-    // each frame is a fresh CDVDOverlay). Disappearance is caught after
-    // the loop by the hasImageSpu vs m_prevHadImageSpu check.
     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
     {
       hasImageSpu = true;
-      if (o.m_textureid == 0)
+
+      // Static content per event: decode once (submitted the first time
+      // we see this exact overlay object) and reuse thereafter, exactly
+      // like the pre-existing m_textureid gating did on the GUI thread -
+      // the only change is that the decode itself now happens off it.
+      SBitmapRenderJob job;
+      job.overlay = e.overlay_dvd;
+      m_bitmapRenderer->RequestRender(job);
+
+      auto result = m_bitmapRenderer->GetLatestResult();
+      if (result && &*e.overlay_dvd == nullptr)
+        result.reset(); // unreachable; keeps analyzers happy about null overlay_dvd
+      // Only accept the latest result if it was actually decoded from
+      // *this* overlay object - GetLatestResult has no identity filter of
+      // its own (unlike the ass path's pts-based matching).
+      if (result)
+      {
+        // The job we just submitted carries the identity check: if the
+        // worker's latest published result came from a job whose overlay
+        // pointer differs from this one, ignore it - it belongs to some
+        // other bitmap overlay (e.g. we just switched from one event to
+        // the next) and will be superseded once our own job completes.
+        // We approximate this cheaply by re-deriving the job the result
+        // must have come from is unknowable from SBitmapRenderResult
+        // alone by design (it is decode-only), so identity is instead
+        // tracked via the GUI-thread-side cache below at Convert() time.
+        e.bitmapResult = result;
+      }
+      if (!prevBitmapResult && e.bitmapResult && e.bitmapResult->hasImage)
         doMarkDirty = true;
       continue;
     }
@@ -462,20 +664,16 @@ void CRenderer::PrepareOverlays(int idx)
     if (!ovAss.GetLibassHandler())
       continue;
 
-    bool updateStyle = !m_overlayStyle || m_isSettingsChanged;
-    if (updateStyle)
+    if (!m_overlayStyle || m_isSettingsChanged)
     {
       m_isSettingsChanged = false;
       LoadSettings();
       CreateSubtitlesStyle();
+      ++m_styleGeneration;
     }
 
-    // rOpts setup moved from CRenderer::ConvertLibass; duplicated in CDebugRenderer::CRenderer::Render.
     SUBTITLES::STYLE::renderOpts rOpts;
 
-    // Three rects: source (subtitle canvas), video (playing size), frame
-    // (render target; may exceed video to include letterbox bars so libass
-    // can place subtitles in them).
     rOpts.sourceWidth = m_rs.Width();
     rOpts.sourceHeight = m_rs.Height();
     rOpts.videoWidth = m_rd.Width();
@@ -483,31 +681,22 @@ void CRenderer::PrepareOverlays(int idx)
     rOpts.frameWidth = m_rv.Width();
     rOpts.frameHeight = m_rv.Height();
 
-    // Render subtitle of half-sbs and half-ou video in full screen, not in half screen
     if (m_stereomode == "left_right" || m_stereomode == "right_left")
     {
-      // only half-sbs video, sbs video don't need to change source size
       if (rOpts.sourceWidth / rOpts.sourceHeight < 1.2f)
         rOpts.sourceWidth = m_rs.Width() * 2;
     }
     else if (m_stereomode == "top_bottom" || m_stereomode == "bottom_top")
     {
-      // only half-ou video, ou video don't need to change source size
       if (rOpts.sourceWidth / rOpts.sourceHeight > 2.5f)
         rOpts.sourceHeight = m_rs.Height() * 2;
     }
 
-    // Set position of subtitles based on video calibration settings
     RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-    // Keep track of subtitle position value change,
-    // can be changed by GUI Calibration or by window mode/resolution change or
-    // by user manual change (e.g. keyboard shortcut)
     if (m_subtitlePosResInfo != resInfo.iSubtitles)
     {
       if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
       {
-        // m_subtitlePosition has been changed
-        // and has been requested to save the value to resInfo
         resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
         CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
             CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
@@ -519,23 +708,12 @@ void CRenderer::PrepareOverlays(int idx)
 
     rOpts.m_par = resInfo.fPixelRatio;
 
-    // rOpts.position and margins (set to style) can invalidate the text
-    // positions to subtitles type that make use of margins to position text on
-    // the screen (e.g. ASS/WebVTT) then we allow to set them when position
-    // override setting is enabled only
     if (ovAss.IsForcedMargins())
     {
       rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::DISABLED;
     }
     else if (m_subtitleAlign == SUBTITLES::Align::MANUAL)
     {
-      // When vertical margins are used Libass apply a displacement in percentage
-      // of the height available to line position, this displacement causes
-      // problems with subtitle calibration bar on Video Calibration window,
-      // so when you moving the subtitle bar of the GUI the text will no longer
-      // match the bar, this calculation compensates for the displacement.
-      // Note also that the displacement compensation will cause a different
-      // default position of the text, different from the other alignment positions
       double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
 
       int assPlayResY = ovAss.GetLibassHandler()->GetPlayResY();
@@ -549,8 +727,6 @@ void CRenderer::PrepareOverlays(int idx)
     }
     else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_OUTSIDE)
     {
-      // To keep consistent the position of text as other alignment positions
-      // we avoid apply the displacement compensation
       double posPx =
           static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin - resInfo.Overscan.top);
       rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
@@ -561,8 +737,6 @@ void CRenderer::PrepareOverlays(int idx)
       rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::INSIDE_VIDEO;
     }
 
-    // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
-    // This setting influence style->alignment property
     if (ovAss.IsTextAlignEnabled())
     {
       if (m_subtitleHorizontalAlign == SUBTITLES::HorizontalAlign::LEFT)
@@ -573,25 +747,36 @@ void CRenderer::PrepareOverlays(int idx)
         rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::CENTER;
     }
 
-    e.renderedFrameWidth = rOpts.frameWidth;
-    e.renderedFrameHeight = rOpts.frameHeight;
+    // Submit the lookahead request (next presented slot's pts, when
+    // known) so it has a full GUI tick to complete before it is actually
+    // displayed. Fall back to this slot's own pts when no distinct next
+    // pts is available (paused, trick-play, nothing queued yet).
+    const double requestPts = (lookaheadPts != DVD_NOPTS_VALUE) ? lookaheadPts : e.pts;
 
-    // Pull the libass output for this PTS. Cached on the SElement until
-    // ConvertLibass consumes it later in this frame's GUI walk.
-    int currentChange = 0;
-    e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
-                                                             m_overlayStyle, &currentChange);
-    if (currentChange > 0)
-    {
-      // Persist on the overlay so a skipped GUI render does not drop the change.
-      ovAss.m_pendingChange = currentChange;
+    SAssRenderJob job;
+    job.handler = ovAss.GetLibassHandler();
+    job.pts = requestPts;
+    job.opts = rOpts;
+    job.subStyle = m_overlayStyle;
+    job.styleGeneration = m_styleGeneration;
+    m_assRenderer->RequestRender(job);
+
+    // Consume: pick whichever of the last two completed results is
+    // closest to *this slot's own* pts (not requestPts - that is only
+    // where we are asking the worker to look next), within a half-frame
+    // tolerance. See the file-level design notes for why this, rather
+    // than "always take the latest", is what makes pause/seek/low-fps
+    // content converge correctly instead of flickering.
+    const double tolerance = HalfFrameTolerance(rOpts.frameWidth > 0 ? 0.0 : 0.0);
+    e.assResult = m_assRenderer->GetBestResult(e.pts, tolerance);
+
+    if (e.assResult && (!prevAssResult || prevAssResult.get() != e.assResult.get()) &&
+        e.assResult->hasImage)
       doMarkDirty = true;
-    }
+    else if (prevAssResult && prevAssResult->hasImage && (!e.assResult || !e.assResult->hasImage))
+      doMarkDirty = true; // subtitle disappeared
   }
 
-  // PGS/DVB/SPU disappearance: arrival is caught by m_textureid==0 in
-  // the loop above. Without this, a PGS subtitle ending leaves its
-  // cached bitmap on the GUI plane until something else dirties.
   if (hasImageSpu != m_prevHadImageSpu)
     doMarkDirty = true;
   m_prevHadImageSpu = hasImageSpu;
@@ -602,30 +787,46 @@ void CRenderer::PrepareOverlays(int idx)
 
 std::shared_ptr<COverlay> CRenderer::ConvertLibass(SElement& e)
 {
-  // If no images not execute the renderer
-  if (!e.renderedImages)
+  if (!e.assResult || !e.assResult->hasImage)
     return nullptr;
 
-  CDVDOverlayLibass& o = static_cast<CDVDOverlayLibass&>(*e.overlay_dvd);
+  // Pointer-identity cache: the async result is immutable, so if this is
+  // the same object we built a COverlay from last time, reuse it - no
+  // need to re-upload identical pixels to the GPU. Replaces the previous
+  // o.m_textureid/o.m_pendingChange bookkeeping (only ever one libass
+  // container active at a time, so a single cache slot suffices).
+  if (m_cachedAssOverlay && m_lastConvertedAssResult.get() == e.assResult.get())
+    return m_cachedAssOverlay;
 
-  if (o.m_textureid)
-  {
-    if (o.m_pendingChange == 0)
-    {
-      std::map<unsigned int, std::shared_ptr<COverlay>>::iterator it =
-          m_textureCache.find(o.m_textureid);
-      if (it != m_textureCache.end())
-        return it->second;
-    }
-  }
+  m_cachedAssOverlay =
+      COverlay::Create(e.assResult->quads, e.assResult->frameWidth, e.assResult->frameHeight);
+  m_lastConvertedAssResult = e.assResult;
+  return m_cachedAssOverlay;
+}
 
-  std::shared_ptr<COverlay> overlay =
-      COverlay::Create(e.renderedImages, e.renderedFrameWidth, e.renderedFrameHeight);
+std::shared_ptr<COverlay> CRenderer::ConvertBitmap(SElement& e)
+{
+  if (!e.bitmapResult || !e.bitmapResult->hasImage || !e.overlay_dvd)
+    return nullptr;
 
-  m_textureCache[m_textureid] = overlay;
-  o.m_textureid = m_textureid;
-  m_textureid++;
-  o.m_pendingChange = 0; // consume
+  // Identity check the async mailbox itself cannot provide (it only knows
+  // about jobs/results, not "which overlay object"): if the cached
+  // COverlay was built from a different source overlay, or the decoded
+  // result object has changed, rebuild.
+  if (m_cachedBitmapOverlay && m_cachedBitmapOverlaySource == e.overlay_dvd.get() &&
+      m_lastConvertedBitmapResult.get() == e.bitmapResult.get())
+    return m_cachedBitmapOverlay;
+
+  CDVDOverlay& o = *e.overlay_dvd;
+  std::shared_ptr<COverlay> overlay;
+  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
+    overlay = COverlay::Create(static_cast<CDVDOverlayImage&>(o), *e.bitmapResult, m_rs);
+  else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+    overlay = COverlay::Create(static_cast<CDVDOverlaySpu&>(o), *e.bitmapResult);
+
+  m_cachedBitmapOverlay = overlay;
+  m_cachedBitmapOverlaySource = e.overlay_dvd.get();
+  m_lastConvertedBitmapResult = e.bitmapResult;
   return overlay;
 }
 
@@ -635,44 +836,12 @@ std::shared_ptr<COverlay> CRenderer::Convert(SElement& e)
     return nullptr;
 
   CDVDOverlay& o = *e.overlay_dvd;
-  std::shared_ptr<COverlay> r = NULL;
 
   if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
-  {
-    CDVDOverlayLibass& ovAss = static_cast<CDVDOverlayLibass&>(o);
-    if (!ovAss.GetLibassHandler())
-      return nullptr;
-
-    // Build the COverlay from libass output PrepareOverlays cached on e
-    // earlier this frame; avoids re-entering libass during render.
-    r = ConvertLibass(e);
-
-    if (!r)
-      return nullptr;
-  }
-  else if (o.m_textureid)
-  {
-    std::map<unsigned int, std::shared_ptr<COverlay>>::iterator it =
-        m_textureCache.find(o.m_textureid);
-    if (it != m_textureCache.end())
-      r = it->second;
-  }
-
-  if (r)
-  {
-    return r;
-  }
-
-  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
-    r = COverlay::Create(static_cast<CDVDOverlayImage&>(o), m_rs);
-  else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
-    r = COverlay::Create(static_cast<CDVDOverlaySpu&>(o));
-
-  m_textureCache[m_textureid] = r;
-  o.m_textureid = m_textureid;
-  m_textureid++;
-
-  return r;
+    return ConvertLibass(e);
+  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+    return ConvertBitmap(e);
+  return nullptr;
 }
 
 void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -107,6 +107,8 @@ std::shared_ptr<const SBitmapRenderResult> RenderBitmapJob(const SBitmapRenderJo
   if (!job.overlay)
     return result;
 
+  result->sourceOverlay = job.overlay.get();
+
   if (job.overlay->IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
   {
     const auto& o = static_cast<const CDVDOverlayImage&>(*job.overlay);
@@ -630,25 +632,17 @@ void CRenderer::PrepareOverlays(int idx, double lookaheadPts)
       job.overlay = e.overlay_dvd;
       m_bitmapRenderer->RequestRender(job);
 
+      // GetLatestResult() has no per-job identity of its own - it is just
+      // "the most recent thing the worker finished" - so verify it was
+      // actually decoded from *this* overlay before accepting it. Without
+      // this, a slow decode for a just-superseded overlay object could
+      // complete after a new one has taken its place in m_buffers and get
+      // shown under the new object's placement, however briefly.
       auto result = m_bitmapRenderer->GetLatestResult();
-      if (result && &*e.overlay_dvd == nullptr)
-        result.reset(); // unreachable; keeps analyzers happy about null overlay_dvd
-      // Only accept the latest result if it was actually decoded from
-      // *this* overlay object - GetLatestResult has no identity filter of
-      // its own (unlike the ass path's pts-based matching).
-      if (result)
-      {
-        // The job we just submitted carries the identity check: if the
-        // worker's latest published result came from a job whose overlay
-        // pointer differs from this one, ignore it - it belongs to some
-        // other bitmap overlay (e.g. we just switched from one event to
-        // the next) and will be superseded once our own job completes.
-        // We approximate this cheaply by re-deriving the job the result
-        // must have come from is unknowable from SBitmapRenderResult
-        // alone by design (it is decode-only), so identity is instead
-        // tracked via the GUI-thread-side cache below at Convert() time.
+
+      if (result && result->sourceOverlay == e.overlay_dvd.get())
         e.bitmapResult = result;
-      }
+
       if (!prevBitmapResult && e.bitmapResult && e.bitmapResult->hasImage)
         doMarkDirty = true;
       continue;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -61,6 +61,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
@@ -773,6 +774,14 @@ void CRenderer::PrepareOverlays(int idx, double lookaheadPts)
     // "past" one rather than showing nothing while the worker catches up
     // on a run of slow cues. See file-level design notes.
     e.assResult = m_assRenderer->GetBestResult(e.pts);
+
+    if (e.assResult.get() != prevAssResult.get())
+    {
+      CLog::Log(LOGDEBUG,
+                "ASYNC_SUB[ass]: display pts={:.3f} now showing result pts={:.3f} (hasImage={})",
+                e.pts / DVD_TIME_BASE, e.assResult ? e.assResult->pts / DVD_TIME_BASE : -1.0,
+                e.assResult && e.assResult->hasImage);
+    }
 
     if (e.assResult && (!prevAssResult || prevAssResult.get() != e.assResult.get()) &&
         e.assResult->hasImage)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -241,17 +241,6 @@ namespace OVERLAY {
 
     void Release(int idx);
 
-    /*!
-     * \brief Clear the async decode workers' pending request and result
-     *  history, without touching m_buffers, the texture cache, or
-     *  subtitle-position calibration state. Called on every seek
-     *  (CRenderManager::DiscardBuffer) so stale pre-seek subtitle content
-     *  can never be matched against a post-seek pts; the full Flush()
-     *  below also calls this, for the heavier stream-reconfiguration
-     *  case.
-     */
-    void FlushAsyncSubtitleState();
-
     /*
      * \brief pts already recorded (by AddOverlay, delay-adjusted) for the
      *  TEXT/SSA overlay in buffer slot 'idx', or DVD_NOPTS_VALUE if that

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -361,6 +361,12 @@ namespace OVERLAY {
     const CDVDOverlay* m_cachedBitmapOverlaySource{nullptr};
     std::shared_ptr<COverlay> m_cachedBitmapOverlay;
 
+    // GUI-thread-only: last e.pts seen for the libass container, used to
+    // detect seeks/discontinuities directly at the point pts is consumed
+    // (see PrepareOverlays) rather than relying on a flush call's timing,
+    // which can land before the presented pts actually jumps.
+    double m_lastPreparedAssPts{DVD_NOPTS_VALUE};
+
     // Current subtitle position
     int m_subtitlePosition{0};
     // Current subtitle position from resolution info,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -11,17 +11,20 @@
 
 #include "BaseRenderer.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h"
+#include "cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h"
 #include "cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h"
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "OverlayRendererAsync.h"
+#include "OverlayRendererUtil.h"
 #include "settings/SubtitlesSettings.h"
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>
-
-typedef struct ass_image ASS_Image;
 
 class CDVDOverlay;
 class CDVDOverlayLibass;
@@ -49,12 +52,100 @@ namespace OVERLAY {
    */
   void MarkDirty();
 
+  /*!
+   * \brief Immutable, self-contained output of one asynchronous libass
+   *  render pass: ass_render_frame() plus the CPU-side glyph-atlas packing
+   *  (convert_quad) that used to run inline on the GUI/render thread.
+   *  convert_quad() copies every pixel it needs out of libass's internal
+   *  ASS_Image list, so this struct owns everything it refers to and
+   *  remains valid indefinitely - in particular, past the point where the
+   *  next ass_render_frame() call on the same renderer would invalidate
+   *  the original ASS_Image list.
+   */
+  struct SAssRenderResult
+  {
+    double pts{0.0};
+    bool hasImage{false};
+    float frameWidth{0.0f};
+    float frameHeight{0.0f};
+    SQuads quads;
+  };
+
+  //! One request for the async libass worker. Equality (used for request
+  //! coalescing) intentionally ignores nothing: an unchanged pts, style
+  //! generation, and geometry means the previous render is still valid.
+  struct SAssRenderJob
+  {
+    std::shared_ptr<CDVDSubtitlesLibass> handler;
+    double pts{0.0};
+    KODI::SUBTITLES::STYLE::renderOpts opts{};
+    std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> subStyle;
+    // Bumped by CRenderer whenever the user's subtitle style settings
+    // change. The worker (not the submitter) decides whether a given
+    // render needs to re-apply style, by comparing generations, so a
+    // style change can never be lost to request coalescing.
+    uint64_t styleGeneration{0};
+
+    bool operator==(const SAssRenderJob& other) const
+    {
+      return handler == other.handler && pts == other.pts && subStyle == other.subStyle &&
+             styleGeneration == other.styleGeneration &&
+             opts.frameWidth == other.opts.frameWidth &&
+             opts.frameHeight == other.opts.frameHeight &&
+             opts.videoWidth == other.opts.videoWidth &&
+             opts.videoHeight == other.opts.videoHeight &&
+             opts.sourceWidth == other.opts.sourceWidth &&
+             opts.sourceHeight == other.opts.sourceHeight && opts.m_par == other.opts.m_par &&
+             opts.marginsMode == other.opts.marginsMode && opts.position == other.opts.position &&
+             opts.horizontalAlignment == other.opts.horizontalAlignment;
+    }
+  };
+
+  /*!
+   * \brief Decoded, CPU-owned output of one bitmap subtitle (PGS/DVB image
+   *  or DVD SPU) decode pass. Unlike libass, the source CDVDOverlay for
+   *  these types is stable/immutable once constructed - there is no
+   *  ephemeral-pointer hazard - so this struct exists purely to move the
+   *  (potentially large) convert_rgba() CPU cost off the GUI thread; the
+   *  render thread still reads placement fields directly off the source
+   *  CDVDOverlayImage/CDVDOverlaySpu object.
+   */
+  struct SBitmapRenderResult
+  {
+    // Not used for pts-matching (bitmap overlays are event-scoped, not
+    // re-evaluated per frame); present for interface uniformity only.
+    double pts{0.0};
+    bool hasImage{false};
+    std::vector<uint32_t> rgba; // tightly packed, width*height, row-major
+    int width{0};
+    int height{0};
+    // SPU only: convert_rgba()'s visible-content crop. Image overlays set
+    // these to the full [0,width) x [0,height) rect.
+    int minX{0};
+    int maxX{0};
+    int minY{0};
+    int maxY{0};
+  };
+
+  struct SBitmapRenderJob
+  {
+    std::shared_ptr<CDVDOverlay> overlay; // CDVDOverlayImage or CDVDOverlaySpu
+
+    bool operator==(const SBitmapRenderJob& other) const
+    {
+      return overlay.get() == other.overlay.get();
+    }
+  };
+
   class COverlay
   {
   public:
-    static std::shared_ptr<COverlay> Create(const CDVDOverlayImage& o, CRect& rSource);
-    static std::shared_ptr<COverlay> Create(const CDVDOverlaySpu& o);
-    static std::shared_ptr<COverlay> Create(ASS_Image* images, float width, float height);
+    static std::shared_ptr<COverlay> Create(const CDVDOverlayImage& o,
+                                            const SBitmapRenderResult& decoded,
+                                            CRect& rSource);
+    static std::shared_ptr<COverlay> Create(const CDVDOverlaySpu& o,
+                                            const SBitmapRenderResult& decoded);
+    static std::shared_ptr<COverlay> Create(const SQuads& quads, float width, float height);
 
     COverlay();
     virtual ~COverlay();
@@ -111,14 +202,29 @@ namespace OVERLAY {
     virtual void Render(int idx, float depth = 0.0f);
 
     /*!
-     * \brief Pre-walk hook: render libass output for the present slot.
-     *  Called once per frame on the GUI/main thread before the GUI walk-skip
-     *  decision. Caches the ASS_Image* and detect_change flag on each
-     *  SElement so ConvertLibass can consume them during the walk without
-     *  re-entering libass. Calls MarkDirty internally when libass reports
-     *  a visible or changed subtitle.
+     * \brief Create the background decode worker(s). Called once per
+     *  playback session from CRenderManager::PreInit(), which already
+     *  guarantees a consistent thread regardless of caller; torn down in
+     *  UnInit(). Cheap (thread creation only), deliberately not deferred
+     *  to first use so the one-time cost lands during session startup
+     *  rather than when the first subtitle needs to be shown.
      */
-    void PrepareOverlays(int idx);
+    void PreInit();
+
+    /*!
+     * \brief Pre-walk hook: submit this frame's (and, when available, the
+     *  next presented frame's) subtitle decode requests to the async
+     *  workers, and fetch whatever results are ready. Called once per
+     *  frame on the GUI/main thread; never blocks on libass or bitmap
+     *  decode. Calls MarkDirty internally when the visible/cached result
+     *  changes.
+     * \param idx the buffer slot about to be presented this frame.
+     * \param lookaheadPts pts of the next frame due to be presented after
+     *  this one (already subtitle-delay adjusted, matching e.pts), or
+     *  DVD_NOPTS_VALUE if none is known yet (paused, trick-play, or
+     *  nothing queued) - in which case idx's own pts is used instead.
+     */
+    void PrepareOverlays(int idx, double lookaheadPts);
 
     /*!
      * \brief Release resources
@@ -135,18 +241,22 @@ namespace OVERLAY {
     void Release(int idx);
 
     /*!
+     * \brief pts already recorded (by AddOverlay, delay-adjusted) for the
+     *  TEXT/SSA overlay in buffer slot 'idx', or DVD_NOPTS_VALUE if that
+     *  slot has no such overlay. Used by CRenderManager::FrameMove to
+     *  supply PrepareOverlays' lookahead pts from the next queued slot,
+     *  before that slot becomes the presented one.
+     */
+    double GetOverlayPts(int idx)const;
+
+    /*!
      * \brief True if any overlay in m_buffers[idx] is visible this frame.
-     *
-     *  PGS/DVB and DVD SPU: ProcessOverlays only inserts at the visible PTS,
-     *  so any entry in m_buffers means visible.
-     *
-     *  libass (TEXT/SSA): the container is added once with no stop PTS and
-     *  stays in m_buffers for the whole video. Visibility means
-     *  ass_render_frame returned images for the current PTS, cached on
-     *  e.renderedImages by PrepareOverlays.
+     *  For libass entries this reflects whichever async result
+     *  PrepareOverlays most recently selected for this SElement, which may
+     *  be a frame or two stale under load - see class-level notes.
      *
      *  Must be called after PrepareOverlays has run this frame; before that
-     *  e.renderedImages reflects the previous frame's state.
+     *  the selected result reflects the previous frame's state.
      */
     bool HasVisibleOverlay(int idx) const;
     void SetVideoRect(CRect &source, CRect &dest, CRect &view);
@@ -176,12 +286,12 @@ namespace OVERLAY {
       SElement() : overlay_dvd(NULL) { pts = 0.0; }
       double pts;
       std::shared_ptr<CDVDOverlay> overlay_dvd;
-      // libass output cached by PrepareOverlays; read by ConvertLibass during
-      // render. libass owns the pointer; valid only until the next
-      // ass_render_frame call.
-      ASS_Image* renderedImages{nullptr};
-      float renderedFrameWidth{0.0f};
-      float renderedFrameHeight{0.0f};
+      // Most recent async result PrepareOverlays selected for this
+      // SElement this frame (libass: closest-pts match within tolerance;
+      // bitmap: latest result matching this overlay's identity). May be
+      // null if no result is available/acceptable yet.
+      std::shared_ptr<const SAssRenderResult> assResult;
+      std::shared_ptr<const SBitmapRenderResult> bitmapResult;
     };
 
     void Render(COverlay* o);
@@ -189,6 +299,9 @@ namespace OVERLAY {
     // Build a COverlay (cached or freshly created) from the libass output
     // already produced by PrepareOverlays. Does not call ass_render_frame.
     std::shared_ptr<COverlay> ConvertLibass(SElement& e);
+    // Build a COverlay (cached or freshly created) from the bitmap decode
+    // already produced by PrepareOverlays. Does not call convert_rgba.
+    std::shared_ptr<COverlay> ConvertBitmap(SElement& e);
 
     void CreateSubtitlesStyle();
 
@@ -215,6 +328,28 @@ namespace OVERLAY {
     CRect m_rs; // Source size
     CRect m_rd; // Video size, may be influenced by video settings (e.g. zoom)
     std::string m_stereomode;
+
+    // Async decode workers. Created in PreInit(), destroyed in UnInit();
+    // null in between playback sessions and briefly at startup.
+    std::unique_ptr<CAsyncSubtitleRenderer<SAssRenderJob, SAssRenderResult>> m_assRenderer;
+    std::unique_ptr<CAsyncSubtitleRenderer<SBitmapRenderJob, SBitmapRenderResult>> m_bitmapRenderer;
+
+    // Worker-thread-only: read/written exclusively from inside the
+    // m_assRenderer render function, never touched from the GUI thread.
+    uint64_t m_assLastAppliedStyleGeneration{~0ULL};
+
+    // Bumped whenever the subtitle style is rebuilt; see SAssRenderJob.
+    uint64_t m_styleGeneration{0};
+
+    // GUI-thread-only pointer-identity caches: avoid re-uploading to the
+    // GPU when the async result driving a slot's overlay hasn't changed
+    // since the last frame.
+    std::shared_ptr<const SAssRenderResult> m_lastConvertedAssResult;
+    std::shared_ptr<COverlay> m_cachedAssOverlay;
+    std::shared_ptr<const SBitmapRenderResult> m_lastConvertedBitmapResult;
+    const CDVDOverlay* m_cachedBitmapOverlaySource{nullptr};
+    std::shared_ptr<COverlay> m_cachedBitmapOverlay;
+
     // Current subtitle position
     int m_subtitlePosition{0};
     // Current subtitle position from resolution info,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -115,6 +115,7 @@ namespace OVERLAY {
     // Not used for pts-matching (bitmap overlays are event-scoped, not
     // re-evaluated per frame); present for interface uniformity only.
     double pts{0.0};
+    const CDVDOverlay* sourceOverlay{nullptr}; ///< Identity of the decoded from CDVDOverlay
     bool hasImage{false};
     std::vector<uint32_t> rgba; // tightly packed, width*height, row-major
     int width{0};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -241,6 +241,17 @@ namespace OVERLAY {
     void Release(int idx);
 
     /*!
+     * \brief Clear the async decode workers' pending request and result
+     *  history, without touching m_buffers, the texture cache, or
+     *  subtitle-position calibration state. Called on every seek
+     *  (CRenderManager::DiscardBuffer) so stale pre-seek subtitle content
+     *  can never be matched against a post-seek pts; the full Flush()
+     *  below also calls this, for the heavier stream-reconfiguration
+     *  case.
+     */
+    void FlushAsyncSubtitleState();
+
+    /*
      * \brief pts already recorded (by AddOverlay, delay-adjusted) for the
      *  TEXT/SSA overlay in buffer slot 'idx', or DVD_NOPTS_VALUE if that
      *  slot has no such overlay. Used by CRenderManager::FrameMove to

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+#include "threads/Event.h"
+#include "threads/Thread.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace OVERLAY
+{
+
+/*!
+ * \brief Generic, type-agnostic single-worker async render pipeline, shared
+ *  by both the libass (TEXT/SSA) and bitmap (PGS/DVB/DVD-SPU) decode paths
+ *  in CRenderer. The decode logic itself (what a "job" means, how to turn
+ *  it into a "result") stays entirely separate per type - this class only
+ *  provides the threading discipline both paths need identically:
+ *
+ *  - RequestRender() is cheap and non-blocking, called from the GUI/render
+ *    thread. It keeps only the single newest not-yet-started job (a
+ *    one-slot mailbox): if the worker falls behind, older requests are
+ *    simply overwritten rather than queued, so the worker always works on
+ *    the most current job instead of working through a growing backlog.
+ *    A request identical to the last one submitted is dropped rather than
+ *    resubmitted, since re-running an unchanged job wastes worker time -
+ *    this matters because the caller may submit the same lookahead target
+ *    on several consecutive GUI ticks before a presentation flip actually
+ *    happens (e.g. video frame rate below display refresh rate).
+ *
+ *  - GetBestResult() is also non-blocking and never waits on the worker.
+ *    It keeps the last two completed results and returns whichever has a
+ *    target pts closest to the caller-supplied 'displayPts', provided the
+ *    difference is within 'tolerance'. This is what makes pause, seeks,
+ *    and low-fps-on-high-refresh content converge on the correct result
+ *    instead of transiently showing a "future" one that happened to finish
+ *    early (see design notes at the top of OverlayRenderer.cpp).
+ *
+ *  - GetLatestResult() returns just the most recently completed result,
+ *    with no pts matching. Used by the bitmap path, where a result is
+ *    valid for as long as the source CDVDOverlay it was decoded from is
+ *    on screen, rather than needing to match a specific per-frame pts.
+ *
+ *  - Flush() clears the mailbox and both result history slots and bumps
+ *    an internal epoch counter. libass has no cancellation point, so a
+ *    render already in flight when Flush() is called cannot be
+ *    interrupted; it is left to finish, but its result is silently
+ *    dropped instead of published, since it carries a now-stale epoch.
+ *    This keeps Flush() itself instant (never blocks on the worker) while
+ *    guaranteeing a post-flush read can never observe pre-flush content.
+ *
+ *  TJob must be equality-comparable (operator==), used for request
+ *  deduplication. TResult must expose a 'double pts' member, used by
+ *  GetBestResult(); GetLatestResult() has no such requirement.
+ */
+template<typename TJob, typename TResult>
+class CAsyncSubtitleRenderer : private CThread
+{
+public:
+  using RenderFunc = std::function<std::shared_ptr<const TResult>(const TJob&)>;
+
+  CAsyncSubtitleRenderer(const std::string& threadName, RenderFunc renderFunc)
+    : CThread(threadName.c_str()), m_renderFunc(std::move(renderFunc))
+  {
+    Create();
+  }
+
+  ~CAsyncSubtitleRenderer() override { StopThread(true); }
+
+  void RequestRender(TJob job)
+  {
+    std::unique_lock lock(m_requestLock);
+    if (m_lastSubmittedJob && *m_lastSubmittedJob == job)
+      return;
+    m_lastSubmittedJob = std::make_unique<TJob>(job);
+    m_pendingJob = std::make_unique<TJob>(std::move(job));
+    m_pendingEpoch = m_epoch.load();
+    lock.unlock();
+    m_requestEvent.Set();
+  }
+
+  std::shared_ptr<const TResult> GetBestResult(double displayPts, double tolerance) const
+  {
+    std::unique_lock lock(m_resultLock);
+    std::shared_ptr<const TResult> best;
+    double bestDiff = tolerance;
+    for (const auto& entry : m_results)
+    {
+      if (!entry)
+        continue;
+      double diff = std::fabs(entry->pts - displayPts);
+      if (diff <= bestDiff)
+      {
+        bestDiff = diff;
+        best = entry;
+      }
+    }
+    return best;
+  }
+
+  std::shared_ptr<const TResult> GetLatestResult() const
+  {
+    std::unique_lock lock(m_resultLock);
+    return m_results[m_newest];
+  }
+
+  void Flush()
+  {
+    std::unique_lock lock1(m_requestLock);
+    std::unique_lock lock2(m_resultLock);
+    m_pendingJob.reset();
+    m_lastSubmittedJob.reset();
+    m_epoch.fetch_add(1);
+    m_results[0].reset();
+    m_results[1].reset();
+    m_newest = 0;
+  }
+
+private:
+  void Process() override
+  {
+    using namespace std::chrono_literals;
+
+    while (!m_bStop)
+    {
+      std::unique_ptr<TJob> job;
+      uint64_t epoch;
+      {
+        std::unique_lock lock(m_requestLock);
+        if (!m_pendingJob)
+        {
+          lock.unlock();
+          AbortableWait(m_requestEvent, 500ms);
+          continue;
+        }
+        job = std::move(m_pendingJob);
+        epoch = m_pendingEpoch;
+      }
+
+      // The expensive part: may take anywhere from <1ms to 100+ms
+      // depending on the source. The GUI/render thread is never blocked
+      // by this call; it only ever reads whatever was last published.
+      std::shared_ptr<const TResult> result = m_renderFunc(*job);
+
+      if (epoch != m_epoch.load())
+        continue; // Flush() happened while rendering; discard silently.
+
+      std::unique_lock lock(m_resultLock);
+      m_newest = 1 - m_newest;
+      m_results[m_newest] = std::move(result);
+    }
+  }
+
+  RenderFunc m_renderFunc;
+
+  mutable CCriticalSection m_requestLock;
+  CEvent m_requestEvent;
+  std::unique_ptr<TJob> m_pendingJob;
+  std::unique_ptr<TJob> m_lastSubmittedJob;
+  uint64_t m_pendingEpoch{0};
+
+  mutable CCriticalSection m_resultLock;
+  std::shared_ptr<const TResult> m_results[2];
+  int m_newest{0};
+
+  std::atomic<uint64_t> m_epoch{0};
+};
+
+} // namespace OVERLAY

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
+#include "utils/log.h"
 
 #include <atomic>
 #include <chrono>
@@ -86,7 +87,9 @@ public:
   using RenderFunc = std::function<std::shared_ptr<const TResult>(const TJob&)>;
 
   CAsyncSubtitleRenderer(const std::string& threadName, RenderFunc renderFunc)
-    : CThread(threadName.c_str()), m_renderFunc(std::move(renderFunc))
+    : CThread(threadName.c_str()),
+      m_threadName(threadName),
+      m_renderFunc(std::move(renderFunc))
   {
     Create();
   }
@@ -98,6 +101,16 @@ public:
     std::unique_lock lock(m_requestLock);
     if (m_lastSubmittedJob && *m_lastSubmittedJob == job)
       return;
+
+    if (m_pendingJob)
+    {
+      // The worker hasn't even started the previous job yet - it is about
+      // to be overwritten and will never be rendered. This, not a slow
+      // render itself, is what "skips a cue entirely" looks like.
+      CLog::Log(LOGDEBUG, "ASYNC_SUB[{}]: dropping never-started job (#{} dropped total)",
+                m_threadName, ++m_droppedPendingJobs);
+    }
+
     m_lastSubmittedJob = std::make_unique<TJob>(job);
     m_pendingJob = std::make_unique<TJob>(std::move(job));
     m_pendingEpoch = m_epoch.load();
@@ -166,8 +179,13 @@ private:
       // The expensive part: may take anywhere from <1ms to 100+ms
       // depending on the source. The GUI/render thread is never blocked
       // by this call; it only ever reads whatever was last published.
+      const auto t0 = std::chrono::steady_clock::now();
       std::shared_ptr<const TResult> result = m_renderFunc(*job);
-
+      const double renderMs =
+          std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+      CLog::Log(LOGDEBUG, "ASYNC_SUB[{}]: render for pts={:.3f} took {:.1f}ms", m_threadName,
+                result->pts / DVD_TIME_BASE, renderMs);
+ 
       std::unique_lock lock(m_resultLock);
       // Deciding "is this still valid" and "publish it" must happen under
       // the same lock Flush() uses to bump the epoch, otherwise a Flush()
@@ -175,14 +193,24 @@ private:
       // publish a result the flush was supposed to have discarded.
       if (epoch == m_epoch.load())
       {
+        if (m_results[m_newest])
+          CLog::Log(LOGDEBUG, "ASYNC_SUB[{}]: superseding unread result pts={:.3f}", m_threadName,
+                    m_results[m_newest]->pts / DVD_TIME_BASE);
         m_newest = 1 - m_newest;
         m_results[m_newest] = std::move(result);
       }
-      // else: Flush() happened while rendering; discard silently.
+      else
+      {
+        // Flush() happened while rendering; discard silently.
+        CLog::Log(LOGDEBUG, "ASYNC_SUB[{}]: discarding stale-epoch result for pts={:.3f}",
+                  m_threadName, result->pts / DVD_TIME_BASE);
+      }
     }
   }
 
+  std::string m_threadName;
   RenderFunc m_renderFunc;
+  uint64_t m_droppedPendingJobs{0};
 
   mutable CCriticalSection m_requestLock;
   CEvent m_requestEvent;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -42,12 +43,18 @@ namespace OVERLAY
  *    happens (e.g. video frame rate below display refresh rate).
  *
  *  - GetBestResult() is also non-blocking and never waits on the worker.
- *    It keeps the last two completed results and returns whichever has a
- *    target pts closest to the caller-supplied 'displayPts', provided the
- *    difference is within 'tolerance'. This is what makes pause, seeks,
- *    and low-fps-on-high-refresh content converge on the correct result
- *    instead of transiently showing a "future" one that happened to finish
- *    early (see design notes at the top of OverlayRenderer.cpp).
+ *    It keeps the last two completed results and returns whichever has
+ *    the newest target pts that does not exceed the caller-supplied
+ *    'displayPts' - i.e. it will never return a result for a subtitle
+ *    that is not due to be shown yet (which would mean showing it
+ *    prematurely - the pause-transition case, see design notes at the
+ *    top of OverlayRenderer.cpp). Staleness in the other direction is
+ *    accepted without limit: an old-but-still-valid result is exactly
+ *    the degraded-but-smooth behaviour this class exists to provide
+ *    when the worker cannot keep up (e.g. a fast run of complex cues),
+ *    so it is always preferred over showing nothing while the worker
+ *    catches up. Returns nullptr only if every stored result is still
+ *    ahead of 'displayPts' (nothing suitable has ever been rendered yet).
  *
  *  - GetLatestResult() returns just the most recently completed result,
  *    with no pts matching. Used by the bitmap path, where a result is
@@ -92,19 +99,19 @@ public:
     m_requestEvent.Set();
   }
 
-  std::shared_ptr<const TResult> GetBestResult(double displayPts, double tolerance) const
+  std::shared_ptr<const TResult> GetBestResult(double displayPts) const
   {
     std::unique_lock lock(m_resultLock);
     std::shared_ptr<const TResult> best;
-    double bestDiff = tolerance;
+    double bestPts = -std::numeric_limits<double>::infinity();
     for (const auto& entry : m_results)
     {
-      if (!entry)
+      if (!entry || entry->pts > displayPts)
         continue;
       double diff = std::fabs(entry->pts - displayPts);
-      if (diff <= bestDiff)
+      if (entry->pts > bestPts)
       {
-        bestDiff = diff;
+        bestPts = entry->pts;
         best = entry;
       }
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2026 Team Kodi
+ *  Copyright (C) 2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
@@ -113,7 +114,7 @@ public:
     {
       if (!entry || entry->pts > displayPts)
         continue;
-      double diff = std::fabs(entry->pts - displayPts);
+
       if (entry->pts > bestPts)
       {
         bestPts = entry->pts;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererAsync.h
@@ -66,7 +66,12 @@ namespace OVERLAY
  *    render already in flight when Flush() is called cannot be
  *    interrupted; it is left to finish, but its result is silently
  *    dropped instead of published, since it carries a now-stale epoch.
- *    This keeps Flush() itself instant (never blocks on the worker) while
+ *    The epoch check happens inside the same critical section that
+ *    Flush() uses to bump the epoch and clear history, so a render that
+ *    finishes concurrently with a Flush() call cannot slip its result in
+ *    between the check and the publish - whichever of the two reaches
+ *    the lock first fully completes before the other proceeds. This
+ *    keeps Flush() itself instant (never blocks on the worker) while
  *    guaranteeing a post-flush read can never observe pre-flush content.
  *
  *  TJob must be equality-comparable (operator==), used for request
@@ -162,12 +167,17 @@ private:
       // by this call; it only ever reads whatever was last published.
       std::shared_ptr<const TResult> result = m_renderFunc(*job);
 
-      if (epoch != m_epoch.load())
-        continue; // Flush() happened while rendering; discard silently.
-
       std::unique_lock lock(m_resultLock);
-      m_newest = 1 - m_newest;
-      m_results[m_newest] = std::move(result);
+      // Deciding "is this still valid" and "publish it" must happen under
+      // the same lock Flush() uses to bump the epoch, otherwise a Flush()
+      // landing between an outside-the-lock check and this write could
+      // publish a result the flush was supposed to have discarded.
+      if (epoch == m_epoch.load())
+      {
+        m_newest = 1 - m_newest;
+        m_results[m_newest] = std::move(result);
+      }
+      // else: Flush() happened while rendering; discard silently.
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -61,12 +61,12 @@ static bool LoadTexture(int width, int height, int stride
   return true;
 }
 
-std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+std::shared_ptr<COverlay> COverlay::Create(const SQuads& quads, float width, float height)
 {
-  return std::make_shared<COverlayQuadsDX>(images, width, height);
+  return std::make_shared<COverlayQuadsDX>(quads, width, height);
 }
 
-COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
+COverlayQuadsDX::COverlayQuadsDX(const SQuads& quads, float width, float height)
 {
   m_width  = 1.0;
   m_height = 1.0;
@@ -75,10 +75,6 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
   m_x      = 0.0f;
   m_y      = 0.0f;
   m_count  = 0;
-
-  SQuads quads;
-  if (!convert_quad(images, quads, static_cast<int>(width)))
-    return;
 
   float u, v;
   if (!LoadTexture(quads.size_x, quads.size_y, quads.size_x, DXGI_FORMAT_R8_UNORM,
@@ -89,7 +85,7 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
 
   Vertex* vt = new Vertex[6 * quads.quad.size()];
   Vertex* vt_orig = vt;
-  SQuad* vs = quads.quad.data();
+  const SQuad* vs = quads.quad.data();
 
   float scale_u = u / quads.size_x;
   float scale_v = v / quads.size_y;
@@ -206,30 +202,26 @@ void COverlayQuadsDX::Render(SRenderState &state)
   pGUIShader->RestoreBuffers();
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o,
+                                           const SBitmapRenderResult& decoded,
+                                           CRect& rSource)
 {
-  return std::make_shared<COverlayImageDX>(o, rSource);
+  return std::make_shared<COverlayImageDX>(o, decoded, rSource);
 }
 
 COverlayImageDX::~COverlayImageDX()
 {
 }
 
-COverlayImageDX::COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource)
+COverlayImageDX::COverlayImageDX(const CDVDOverlayImage& o,
+                                 const SBitmapRenderResult& decoded,
+                                 CRect& rSource)
 {
-  if (o.palette.empty())
-  {
-    m_pma = false;
-    const uint32_t* rgba = reinterpret_cast<const uint32_t*>(o.pixels.data());
-    Load(rgba, o.width, o.height, o.linesize);
-  }
-  else
-  {
-    std::vector<uint32_t> rgba(o.width * o.height);
-    m_pma = !!USE_PREMULTIPLIED_ALPHA;
-    convert_rgba(o, m_pma, rgba);
-    Load(rgba.data(), o.width, o.height, o.width * 4);
-  }
+  // Decode already happened on the bitmap async worker (OverlayRenderer.cpp,
+  // RenderBitmapJob); 'decoded.rgba' is always tightly packed regardless of
+  // whether the source was paletted or raw, so stride is always width*4.
+  m_pma = o.palette.empty() ? false : !!USE_PREMULTIPLIED_ALPHA;
+  Load(decoded.rgba.data(), decoded.width, decoded.height, decoded.width * 4);
 
   if (o.source_width > 0 && o.source_height > 0)
   {
@@ -272,18 +264,17 @@ COverlayImageDX::COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource)
   }
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o,
+                                           const SBitmapRenderResult& decoded)
 {
-  return std::make_shared<COverlayImageDX>(o);
+  return std::make_shared<COverlayImageDX>(o, decoded);
 }
 
-COverlayImageDX::COverlayImageDX(const CDVDOverlaySpu& o)
+COverlayImageDX::COverlayImageDX(const CDVDOverlaySpu& o, const SBitmapRenderResult& decoded)
 {
-  int min_x, max_x, min_y, max_y;
-  std::vector<uint32_t> rgba(o.width * o.height);
-
-  convert_rgba(o, USE_PREMULTIPLIED_ALPHA, min_x, max_x, min_y, max_y, rgba);
-  Load(rgba.data() + min_x + min_y * o.width, max_x - min_x, max_y - min_y, o.width * 4);
+  const int min_x = decoded.minX, max_x = decoded.maxX, min_y = decoded.minY, max_y = decoded.maxY;
+  Load(decoded.rgba.data() + min_x + min_y * decoded.width, max_x - min_x, max_y - min_y,
+       +decoded.width * 4);
 
   m_align = ALIGN_VIDEO;
   m_pos = POSITION_ABSOLUTE;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -22,7 +22,7 @@ namespace OVERLAY {
     : public COverlay
   {
   public:
-    COverlayQuadsDX(ASS_Image* images, float width, float height);
+    COverlayQuadsDX(const SQuads& quads, float width, float height);
     virtual ~COverlayQuadsDX();
 
     void Render(SRenderState& state);
@@ -40,8 +40,10 @@ namespace OVERLAY {
      *  \param o The overlay image
      *  \param rSource The video source rect size
      */
-    explicit COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource);
-    explicit COverlayImageDX(const CDVDOverlaySpu& o);
+    explicit COverlayImageDX(const CDVDOverlayImage& o,
+                             const SBitmapRenderResult& decoded,
+                             CRect& rSource);
+    explicit COverlayImageDX(const CDVDOverlaySpu& o, const SBitmapRenderResult& decoded);
     virtual ~COverlayImageDX();
 
     void Load(const uint32_t* rgba, int width, int height, int stride);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -78,12 +78,16 @@ static void LoadTexture(GLenum target
   *v = (GLfloat)height / height2;
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o,
+                                           const SBitmapRenderResult& decoded,
+                                           CRect& rSource)
 {
-  return std::make_shared<COverlayTextureGL>(o, rSource);
+  return std::make_shared<COverlayTextureGL>(o, decoded, rSource);
 }
 
-COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource)
+COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o,
+                                     const SBitmapRenderResult& decoded,
+                                     CRect& rSource)
 {
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
@@ -93,19 +97,12 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  if (o.palette.empty())
-  {
-    m_pma = false;
-    const uint32_t* rgba = reinterpret_cast<const uint32_t*>(o.pixels.data());
-    LoadTexture(GL_TEXTURE_2D, o.width, o.height, o.linesize, &m_u, &m_v, false, rgba);
-  }
-  else
-  {
-    std::vector<uint32_t> rgba(o.width * o.height);
-    m_pma = !!USE_PREMULTIPLIED_ALPHA;
-    convert_rgba(o, m_pma, rgba);
-    LoadTexture(GL_TEXTURE_2D, o.width, o.height, o.width * 4, &m_u, &m_v, false, rgba.data());
-  }
+  // Decode already happened on the bitmap async worker (OverlayRenderer.cpp,
+  // RenderBitmapJob); 'decoded.rgba' is always tightly packed regardless of
+  // whether the source was paletted or raw, so stride is always width*4.
+  m_pma = o.palette.empty() ? false : !!USE_PREMULTIPLIED_ALPHA;
+  LoadTexture(GL_TEXTURE_2D, decoded.width, decoded.height, decoded.width * 4, &m_u, &m_v, false,
+              decoded.rgba.data());
 
   glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -150,17 +147,18 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource)
   }
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o,
+                                           const SBitmapRenderResult& decoded)
 {
-  return std::make_shared<COverlayTextureGL>(o);
+  return std::make_shared<COverlayTextureGL>(o, decoded);
 }
 
-COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o)
+COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o, const SBitmapRenderResult& decoded)
 {
-  int min_x, max_x, min_y, max_y;
-  std::vector<uint32_t> rgba(o.width * o.height);
-
-  convert_rgba(o, USE_PREMULTIPLIED_ALPHA, min_x, max_x, min_y, max_y, rgba);
+  const int min_x = decoded.minX;
+  const int max_x = decoded.maxX;
+  const int min_y = decoded.minY;
+  const int max_y = decoded.maxY;
 
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
@@ -170,8 +168,8 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  LoadTexture(GL_TEXTURE_2D, max_x - min_x, max_y - min_y, o.width * 4, &m_u, &m_v, false,
-              rgba.data() + min_x + min_y * o.width);
+  LoadTexture(GL_TEXTURE_2D, max_x - min_x, max_y - min_y, decoded.width * 4, &m_u, &m_v, false,
+              decoded.rgba.data() + min_x + min_y * decoded.width);
 
   glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -184,12 +182,12 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o)
   m_pma = !!USE_PREMULTIPLIED_ALPHA;
 }
 
-std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+std::shared_ptr<COverlay> COverlay::Create(const SQuads& quads, float width, float height)
 {
-  return std::make_shared<COverlayGlyphGL>(images, width, height);
+  return std::make_shared<COverlayGlyphGL>(quads, width, height);
 }
 
-COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, float width, float height)
+COverlayGlyphGL::COverlayGlyphGL(const SQuads& quads, float width, float height)
 {
   m_width  = 1.0;
   m_height = 1.0;
@@ -197,10 +195,6 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, float width, float height)
   m_pos    = POSITION_RELATIVE;
   m_x      = 0.0f;
   m_y      = 0.0f;
-
-  SQuads quads;
-  if (!convert_quad(images, quads, static_cast<int>(width)))
-    return;
 
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
@@ -218,7 +212,7 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, float width, float height)
   m_vertex.resize(quads.quad.size() * 4);
 
   VERTEX* vt = m_vertex.data();
-  SQuad* vs = quads.quad.data();
+  const SQuad* vs = quads.quad.data();
 
   for (size_t i = 0; i < quads.quad.size(); i++)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -27,8 +27,10 @@ namespace OVERLAY {
      *  \param o The overlay image
      *  \param rSource The video source rect size
      */
-    explicit COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource);
-    explicit COverlayTextureGL(const CDVDOverlaySpu& o);
+    explicit COverlayTextureGL(const CDVDOverlayImage& o,
+                               const SBitmapRenderResult& decoded,
+                               CRect& rSource);
+    explicit COverlayTextureGL(const CDVDOverlaySpu& o, const SBitmapRenderResult& decoded);	 
     ~COverlayTextureGL() override;
 
     void Render(SRenderState& state) override;
@@ -42,7 +44,7 @@ namespace OVERLAY {
   class COverlayGlyphGL : public COverlay
   {
   public:
-    COverlayGlyphGL(ASS_Image* images, float width, float height);
+    COverlayGlyphGL(const SQuads& quads, float width, float height);
 
     ~COverlayGlyphGL() override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -138,12 +138,16 @@ static void LoadTexture(GLenum target,
   *v = (GLfloat)height / height2;
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o,
+                                           const SBitmapRenderResult& decoded,
+                                           CRect& rSource)
 {
-  return std::make_shared<COverlayTextureGLES>(o, rSource);
+  return std::make_shared<COverlayTextureGLES>(o, decoded, rSource);
 }
 
-COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSource)
+COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o,
+                                         const SBitmapRenderResult& decoded,
+                                         CRect& rSource)
 {
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
@@ -153,19 +157,12 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSour
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  if (o.palette.empty())
-  {
-    m_pma = false;
-    const uint32_t* rgba = reinterpret_cast<const uint32_t*>(o.pixels.data());
-    LoadTexture(GL_TEXTURE_2D, o.width, o.height, o.linesize, &m_u, &m_v, false, rgba);
-  }
-  else
-  {
-    std::vector<uint32_t> rgba(o.width * o.height);
-    m_pma = !!USE_PREMULTIPLIED_ALPHA;
-    convert_rgba(o, m_pma, rgba);
-    LoadTexture(GL_TEXTURE_2D, o.width, o.height, o.width * 4, &m_u, &m_v, false, rgba.data());
-  }
+  // Decode already happened on the bitmap async worker (OverlayRenderer.cpp,
+  // RenderBitmapJob); 'decoded.rgba' is always tightly packed regardless of
+  // whether the source was paletted or raw, so stride is always width*4.
+  m_pma = o.palette.empty() ? false : !!USE_PREMULTIPLIED_ALPHA;
+  LoadTexture(GL_TEXTURE_2D, decoded.width, decoded.height, decoded.width * 4, &m_u, &m_v, false,
+              decoded.rgba.data());
 
   glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -210,18 +207,20 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSour
   }
 }
 
-std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o,
+                                           const SBitmapRenderResult& decoded)
 {
-  return std::make_shared<COverlayTextureGLES>(o);
+  return std::make_shared<COverlayTextureGLES>(o, decoded);
 }
 
-COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o)
+COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o,
+                                         const SBitmapRenderResult& decoded)
 {
-  int min_x, max_x, min_y, max_y;
-  std::vector<uint32_t> rgba(o.width * o.height);
-
-  convert_rgba(o, USE_PREMULTIPLIED_ALPHA, min_x, max_x, min_y, max_y, rgba);
-
+  const int min_x = decoded.minX;
+  const int max_x = decoded.maxX;
+  const int min_y = decoded.minY;
+  const int max_y = decoded.maxY;
+  
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
 
@@ -230,8 +229,8 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  LoadTexture(GL_TEXTURE_2D, max_x - min_x, max_y - min_y, o.width * 4, &m_u, &m_v, false,
-              rgba.data() + min_x + min_y * o.width);
+  LoadTexture(GL_TEXTURE_2D, max_x - min_x, max_y - min_y, decoded.width * 4, &m_u, &m_v, false,
+              decoded.rgba.data() + min_x + min_y * decoded.width);
 
   glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -244,12 +243,12 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o)
   m_pma = !!USE_PREMULTIPLIED_ALPHA;
 }
 
-std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+std::shared_ptr<COverlay> COverlay::Create(const SQuads& quads, float width, float height)
 {
-  return std::make_shared<COverlayGlyphGLES>(images, width, height);
+  return std::make_shared<COverlayGlyphGLES>(quads, width, height);
 }
 
-COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float height)
+COverlayGlyphGLES::COverlayGlyphGLES(const SQuads& quads, float width, float height)
 {
   m_width = 1.0;
   m_height = 1.0;
@@ -257,10 +256,6 @@ COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float heigh
   m_pos = POSITION_RELATIVE;
   m_x = 0.0f;
   m_y = 0.0f;
-
-  SQuads quads;
-  if (!convert_quad(images, quads, static_cast<int>(width)))
-    return;
 
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
@@ -277,7 +272,7 @@ COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float heigh
   m_vertex.resize(quads.quad.size() * 4);
 
   VERTEX* vt = m_vertex.data();
-  SQuad* vs = quads.quad.data();
+  const SQuad* vs = quads.quad.data();
 
   for (size_t i = 0; i < quads.quad.size(); i++)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
@@ -28,8 +28,10 @@ public:
      *  \param o The overlay image
      *  \param rSource The video source rect size
      */
-  explicit COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSource);
-  explicit COverlayTextureGLES(const CDVDOverlaySpu& o);
+  explicit COverlayTextureGLES(const CDVDOverlayImage& o,
+                               const SBitmapRenderResult& decoded,
+                               CRect& rSource);
+  explicit COverlayTextureGLES(const CDVDOverlaySpu& o, const SBitmapRenderResult& decoded);	 
   ~COverlayTextureGLES() override;
 
   void Render(SRenderState& state) override;
@@ -43,7 +45,7 @@ public:
 class COverlayGlyphGLES : public COverlay
 {
 public:
-  COverlayGlyphGLES(ASS_Image* images, float width, float height);
+  COverlayGlyphGLES(const SQuads& quads, float width, float height);
 
   ~COverlayGlyphGLES() override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1169,14 +1169,6 @@ void CRenderManager::DiscardBuffer()
 {
   std::unique_lock lock2(m_presentlock);
 
-  // A seek is about to jump the presentation pts elsewhere; any in-flight
-  // or completed-but-unconsumed async subtitle render targets the old
-  // position and must not be matched against the new one. This is
-  // narrower than the full m_overlays.Flush() (CRenderManager::Flush) -
-  // it leaves buffer slots, the texture cache, and subtitle-position
-  // calibration state untouched, since those aren't seek-scoped.
-  m_overlays.FlushAsyncSubtitleState();
-
   while(!m_queued.empty())
   {
     m_discard.push_back(m_queued.front());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -352,13 +352,20 @@ void CRenderManager::FrameMove()
   m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->VideoBypassesFramebuffer() ||
                                 firstFrame);
 
-  // Run libass for the current PTS and cache the output for ConvertLibass
-  // to use during the render pass. PrepareOverlays MarkDirty's on libass
-  // changes and on PGS/DVB/SPU arrival/disappearance.
-  m_overlays.PrepareOverlays(m_presentsource);
+  // Submit this frame's subtitle decode requests to the async workers and
+  // fetch whatever is ready; never blocks. Also hand over the pts of the
+  // next queued slot (if any) so that request has a full tick to
+  // complete before it is actually presented - see design notes at the
+  // top of OverlayRenderer.cpp. No distinct "next" pts is available when
+  // paused/trick-play/nothing queued; PrepareOverlays falls back to the
+  // current slot's own pts in that case.
+  double lookaheadPts = DVD_NOPTS_VALUE;
+  if (!m_queued.empty() && m_queued.front() != m_presentsource)
+    lookaheadPts = m_overlays.GetOverlayPts(m_queued.front());
+  m_overlays.PrepareOverlays(m_presentsource, lookaheadPts);
 }
 
-void CRenderManager::PreInit()
+  void CRenderManager::PreInit()
 {
   {
     std::unique_lock lock(m_statelock);
@@ -382,6 +389,12 @@ void CRenderManager::PreInit()
   {
     CreateRenderer();
   }
+
+  // Create the subtitle async decode worker(s), if not already running
+  // from a previous session on this CRenderManager. Cheap (thread
+  // creation only); deliberately done here rather than lazily on first
+  // use, so the one-time cost lands during session startup.
+  m_overlays.PreInit();
 
   UpdateLatencyTweak();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1169,6 +1169,14 @@ void CRenderManager::DiscardBuffer()
 {
   std::unique_lock lock2(m_presentlock);
 
+  // A seek is about to jump the presentation pts elsewhere; any in-flight
+  // or completed-but-unconsumed async subtitle render targets the old
+  // position and must not be matched against the new one. This is
+  // narrower than the full m_overlays.Flush() (CRenderManager::Flush) -
+  // it leaves buffer slots, the texture cache, and subtitle-position
+  // calibration state untouched, since those aren't seek-scoped.
+  m_overlays.FlushAsyncSubtitleState();
+
   while(!m_queued.empty())
   {
     m_discard.push_back(m_queued.front());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Not ready for review but opinions on suitability of the design are welcome.
Pushed for AI feedback and to check that the AI-assisted GL/GLES changes build.

Decouple subtitle rendering from the main thread to avoid playback stutter with complex animated ass subs.

A dedicated thread waits for a request to decode subtitles for a pts, does the work (the expensive part, like ass_render_frame) and pushes the result into a list.

Rendering frame N looks for the closest available decoded subtitle in the results list and pushes a request to decode subs for frame N+1 (or N while paused).
Rendering frame N multiple times (ex. 24fps source > 60Hz display) skips the decode and renders the already decoded subtitle.

When libass decoding takes longer than the time available on main thread for presentation of a frame, some intermediate subtitle pts will be skipped but stuttering of the video is avoided.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

complex animated ass subs make video playback stutter, even on desktop cpu.
some ass sub frames take hundreds of milliseconds to render, worst case I've seen takes 3 seconds! on a desktop cpu.
low power boxes will benefit the most (at the cost of jerky subtitle animations since frames will be skipped)