### PR TITLE
[Video][Bluray] Parse Aspect Ratio from M2TS files.

### DIFF
--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -171,6 +171,7 @@ constexpr unsigned int DOLBY_VISION_RPU_HEADER = 0x7C01;
 constexpr unsigned int DOLBY_VISION_EL_HEADER = 0x7E01;
 
 constexpr unsigned int H265_EXTENDED_SAR = 255;
+// Table E-1 - sample aspect ratios (width:height of a sample), indexed by aspect_ratio_idc
 inline constexpr std::array ASPECT_RATIOS{
     0.0f,          1.0f,           12.0f / 11.0f, 10.0f / 11.0f, 16.0f / 11.0f, 40.0f / 33.0f,
     24.0f / 11.0f, 20.0f / 11.0f,  32.0f / 11.0f, 80.0f / 33.0f, 18.0f / 11.0f, 15.0f / 11.0f,
@@ -192,6 +193,7 @@ inline constexpr std::array VC1_SEQUENCE_HEADER_START_CODE = {std::byte{0x00}, s
                                                               std::byte{0x01}, std::byte{0x0F}};
 
 constexpr unsigned int VC1_EXTENDED_SAR = 15;
+// Table 44 - sample aspect ratios (width:height of a sample), indexed by ASPECT_RATIO
 inline constexpr std::array VC1_ASPECT_RATIOS{
     0.0f,          1.0f,           12.0f / 11.0f, 10.0f / 11.0f, 16.0f / 11.0f, 40.0f / 33.0f,
     24.0f / 11.0f, 20.0f / 11.0f,  32.0f / 11.0f, 80.0f / 33.0f, 18.0f / 11.0f, 15.0f / 11.0f,
@@ -201,8 +203,12 @@ inline constexpr std::array VC1_ASPECT_RATIOS{
 inline constexpr std::array MPEG2_SEQUENCE_HEADER_START_CODE = {std::byte{0x00}, std::byte{0x00},
                                                                 std::byte{0x01}, std::byte{0xB3}};
 
-inline constexpr std::array MPEG2_DISPLAY_ASPECT_RATIOS{0.0f, 1.0f, 3.0f / 4.0f, 9.0f / 16.0f,
-                                                        1.0f / 2.21f};
+// Table 6-3 - unlike H.264/HEVC/VC-1, MPEG-2 signals the display aspect ratio the coded frame is
+// to be shown at (index 1 being square samples rather than a ratio), so the sample aspect ratio
+// has to be derived from it and the coded frame size
+constexpr unsigned int MPEG2_SQUARE_SAMPLES = 1;
+inline constexpr std::array MPEG2_DISPLAY_ASPECT_RATIOS{0.0f, 0.0f, 4.0f / 3.0f, 16.0f / 9.0f,
+                                                        2.21f};
 
 // Structures for parsers
 
@@ -1287,19 +1293,38 @@ void ParseScalingListData(BitReader& br)
   }
 }
 
-void ParseShortTermRefPicSet(BitReader& br, unsigned int idx, unsigned int numSets)
+// A set coded as a prediction of an earlier one ends with a flag per delta POC of the set it
+// references, so skipping it needs that set's NumDeltaPocs. That count is only known for sets coded
+// explicitly - deriving it for a predicted set means reproducing the DeltaPoc derivation of the
+// H.265 specification (7.4.8), which this parser has no other use for. Returns false when the count
+// is needed but unknown, leaving the reader mid-set with nothing after it readable.
+bool ParseShortTermRefPicSet(BitReader& br,
+                             unsigned int idx,
+                             unsigned int numSets,
+                             std::vector<std::optional<unsigned int>>& numDeltaPocs)
 {
   if (idx != 0 && br.ReadBits(1) == 1) // inter_ref_pic_set_prediction_flag
   {
+    unsigned int refIdx{idx - 1};
     if (idx == numSets)
-      br.SkipUE(); // delta_idx_minus1
+      refIdx = idx - (br.ReadUE() + 1); // delta_idx_minus1
     br.SkipBits(1); // delta_rps_sign
     br.SkipUE(); // abs_delta_rps_minus1
-    return;
+
+    if (refIdx >= numDeltaPocs.size() || !numDeltaPocs[refIdx])
+      return false;
+
+    for (unsigned int j = 0; j <= *numDeltaPocs[refIdx]; j++)
+    {
+      if (br.ReadBits(1) == 0) // used_by_curr_pic_flag
+        br.SkipBits(1); // use_delta_flag
+    }
+
+    return true;
   }
 
-  unsigned int numNegative{br.ReadUE()};
-  unsigned int numPositive{br.ReadUE()};
+  const unsigned int numNegative{br.ReadUE()};
+  const unsigned int numPositive{br.ReadUE()};
 
   for (unsigned int i = 0; i < numNegative; i++)
   {
@@ -1312,6 +1337,11 @@ void ParseShortTermRefPicSet(BitReader& br, unsigned int idx, unsigned int numSe
     br.SkipUE(); // delta_poc_s1_minus1
     br.SkipBits(1); // used_by_curr_pic_s1_flag
   }
+
+  if (idx < numDeltaPocs.size())
+    numDeltaPocs[idx] = numNegative + numPositive;
+
+  return true;
 }
 
 float ParseVUI(BitReader& br)
@@ -1323,9 +1353,9 @@ float ParseVUI(BitReader& br)
     unsigned int aspectRatioIdc{br.ReadBits(8)};
     if (aspectRatioIdc == H265_EXTENDED_SAR)
     {
-      unsigned int width{br.ReadBits(16)};
-      unsigned int height{br.ReadBits(16)};
-      ar = (width > 0) ? static_cast<float>(height) / static_cast<float>(width) : 0.0f;
+      unsigned int sarWidth{br.ReadBits(16)};
+      unsigned int sarHeight{br.ReadBits(16)};
+      ar = (sarHeight > 0) ? static_cast<float>(sarWidth) / static_cast<float>(sarHeight) : 0.0f;
     }
     else if (aspectRatioIdc < ASPECT_RATIOS.size())
       ar = ASPECT_RATIOS[aspectRatioIdc];
@@ -1407,9 +1437,18 @@ bool ParseH265SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
     br.SkipBits(1); // pcm_loop_filter_disabled_flag
   }
 
-  unsigned int num_short_term_ref_pic_sets{br.ReadUE()};
+  const unsigned int num_short_term_ref_pic_sets{br.ReadUE()};
+  std::vector<std::optional<unsigned int>> numDeltaPocs(num_short_term_ref_pic_sets);
   for (unsigned int i = 0; i < num_short_term_ref_pic_sets; i++)
-    ParseShortTermRefPicSet(br, i, num_short_term_ref_pic_sets);
+  {
+    if (!ParseShortTermRefPicSet(br, i, num_short_term_ref_pic_sets, numDeltaPocs))
+    {
+      // The frame size and bit depth read above still stand, but the VUI can no longer be located
+      // and a sample aspect ratio read from the wrong position would override the .clpi's
+      streamInfo->completed = true;
+      return true;
+    }
+  }
 
   if (br.ReadBits(1) == 1) // long_term_ref_pics_present_flag
   {
@@ -1425,7 +1464,7 @@ bool ParseH265SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
   br.SkipBits(1); // strong_intra_smoothing_enabled_flag
 
   if (br.ReadBits(1) == 1) // vui_parameters_present_flag
-    streamInfo->aspectRatio = ParseVUI(br);
+    streamInfo->sampleAspectRatio = ParseVUI(br);
 
   streamInfo->completed = true;
 
@@ -1527,7 +1566,7 @@ bool ParseH264SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
                        (frame_crop_top_offset + frame_crop_bottom_offset) * cropUnitY;
 
   if (br.ReadBits(1) == 1) // vui_parameters_present_flag
-    streamInfo->aspectRatio = ParseVUI(br);
+    streamInfo->sampleAspectRatio = ParseVUI(br);
 
   streamInfo->completed = true;
 
@@ -1898,14 +1937,14 @@ bool ParseVC1(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamInfo)
       if (aspect_ratio == VC1_EXTENDED_SAR)
       {
         header = GetDWord(buffer, offset + 10);
-        unsigned int aspect_horiz_size{GetBits(header, 32, 8)};
-        unsigned int aspect_vert_size{GetBits(header, 24, 8)};
-        streamInfo->aspectRatio = (aspect_vert_size > 0) ? static_cast<float>(aspect_horiz_size) /
-                                                               static_cast<float>(aspect_vert_size)
-                                                         : 0.0f;
+        // Both fields are the ratio's terms minus one, so neither can be zero
+        const unsigned int aspect_horiz_size{GetBits(header, 32, 8) + 1};
+        const unsigned int aspect_vert_size{GetBits(header, 24, 8) + 1};
+        streamInfo->sampleAspectRatio =
+            static_cast<float>(aspect_horiz_size) / static_cast<float>(aspect_vert_size);
       }
       else
-        streamInfo->aspectRatio = VC1_ASPECT_RATIOS[aspect_ratio];
+        streamInfo->sampleAspectRatio = VC1_ASPECT_RATIOS[aspect_ratio];
     }
   }
 
@@ -1918,26 +1957,29 @@ bool ParseVC1(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamInfo)
 
 bool ParseMPEG2(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamInfo)
 {
-  if (auto result{std::ranges::search(buffer, MPEG2_SEQUENCE_HEADER_START_CODE)};
-      result.empty() || buffer.end() - result.begin() < 8)
+  auto result{std::ranges::search(buffer, MPEG2_SEQUENCE_HEADER_START_CODE)};
+  if (result.empty() || buffer.end() - result.begin() < 8)
     return false;
 
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Parsing MPEG2 Sequence Header");
 
-  unsigned int header{GetDWord(buffer, 4)};
+  const unsigned int offset{static_cast<unsigned int>(result.begin() - buffer.begin()) + 4};
+
+  unsigned int header{GetDWord(buffer, offset)};
   unsigned int horizontal_size_value{GetBits(header, 32, 12)};
   unsigned int vertical_size_value{GetBits(header, 20, 12)};
   streamInfo->width = horizontal_size_value;
   streamInfo->height = vertical_size_value;
 
-  if (unsigned int aspect_ratio_information{GetBits(header, 8, 4)}; aspect_ratio_information < 2)
-    streamInfo->aspectRatio = MPEG2_DISPLAY_ASPECT_RATIOS[aspect_ratio_information];
+  if (const unsigned int aspect_ratio_information{GetBits(header, 8, 4)};
+      aspect_ratio_information == MPEG2_SQUARE_SAMPLES)
+    streamInfo->sampleAspectRatio = 1.0f;
   else if (aspect_ratio_information < MPEG2_DISPLAY_ASPECT_RATIOS.size())
-    streamInfo->aspectRatio = vertical_size_value > 0
-                                  ? MPEG2_DISPLAY_ASPECT_RATIOS[aspect_ratio_information] *
-                                        static_cast<float>(horizontal_size_value) /
-                                        static_cast<float>(vertical_size_value)
-                                  : 0.0f;
+    streamInfo->sampleAspectRatio = horizontal_size_value > 0
+                                        ? MPEG2_DISPLAY_ASPECT_RATIOS[aspect_ratio_information] *
+                                              static_cast<float>(vertical_size_value) /
+                                              static_cast<float>(horizontal_size_value)
+                                        : 0.0f;
 
   streamInfo->bitDepth = 8;
 
@@ -2159,6 +2201,33 @@ bool CM2TSParser::GetStreamsFromFile(const std::string& path,
                  "Not all stream details determined from {} after {} packets ({} bytes) - may "
                  "need MAX_PACKETS_TO_PARSE ({}) increase.",
                  clipFile, packetCount, totalBytesRead, MAX_PACKETS_TO_PARSE);
+
+    for (const TSVideoStreamInfo& videoStream : GetVideoStreams(streams))
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Clip {} - video stream PID 0x{} type 0x{} ({}) - {}x{}, sample aspect ratio "
+                  "{:.4f} (display aspect ratio {:.4f}), {} bit, HDR10 {}, HDR10+ {}, Dolby Vision "
+                  "{}, enhancement layer {}, 3D {}, headers parsed {}",
+                  clip, fmt::format("{:04x}", videoStream.pid),
+                  fmt::format("{:02x}", static_cast<int>(videoStream.streamType)),
+                  GetStreamTypeName(videoStream.streamType), videoStream.width, videoStream.height,
+                  videoStream.sampleAspectRatio, GetDisplayAspectRatio(videoStream),
+                  videoStream.bitDepth, videoStream.hdr10, videoStream.hdr10Plus,
+                  videoStream.dolbyVision, videoStream.isEnhancementLayer, videoStream.is3d,
+                  videoStream.seen);
+
+      // A zero sample aspect ratio means the sequence/picture parameter set was never successfully
+      // parsed - the parsers have several early exits (no start code found, truncated header,
+      // unsupported profile) and some streams simply do not signal one
+      if (videoStream.sampleAspectRatio == 0.0f)
+        CLog::LogF(LOGDEBUG,
+                   "Clip {} - no sample aspect ratio determined for video stream PID 0x{} type "
+                   "0x{} ({}) - headers parsed {}, completed {}",
+                   clip, fmt::format("{:04x}", videoStream.pid),
+                   fmt::format("{:02x}", static_cast<int>(videoStream.streamType)),
+                   GetStreamTypeName(videoStream.streamType), videoStream.seen,
+                   videoStream.completed);
+    }
 
     // Report the details determined for each audio stream
     for (const TSAudioStreamInfo& audioStream : GetAudioStreams(streams))

--- a/xbmc/filesystem/bluray/M2TSParser.h
+++ b/xbmc/filesystem/bluray/M2TSParser.h
@@ -71,7 +71,7 @@ struct TSVideoStreamInfo : TSStreamInfo
   unsigned int height{0};
   unsigned int width{0};
   unsigned int bitDepth{0};
-  float aspectRatio{0.0};
+  float sampleAspectRatio{0.0}; // width:height of a sample, not the display aspect ratio
   bool is3d{false};
 
   bool hdr10{false};
@@ -79,6 +79,18 @@ struct TSVideoStreamInfo : TSStreamInfo
   bool dolbyVision{false};
   bool isEnhancementLayer{false};
 };
+
+// The ratio the frame is to be displayed at, which is the coded frame's ratio scaled by the shape
+// of a sample (see DVDDemuxFFmpeg, which derives fAspect the same way). Zero when the elementary
+// stream did not signal a sample aspect ratio or the frame size is unknown.
+inline float GetDisplayAspectRatio(const TSVideoStreamInfo& videoStream)
+{
+  if (videoStream.sampleAspectRatio <= 0.0f || videoStream.width == 0 || videoStream.height == 0)
+    return 0.0f;
+
+  return static_cast<float>(videoStream.width) / static_cast<float>(videoStream.height) *
+         videoStream.sampleAspectRatio;
+}
 
 using StreamMap = std::unordered_map<unsigned int, std::shared_ptr<TSStreamInfo>>;
 

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -31,6 +31,7 @@ namespace XFILE
 namespace
 {
 VideoStreamInfo PopulateVideoStreamInfo(const StreamInformation& stream,
+                                        ASPECT_RATIO aspect,
                                         const TSVideoStreamInfo* bsvi)
 {
   VideoStreamInfo vsi{};
@@ -127,18 +128,28 @@ VideoStreamInfo PopulateVideoStreamInfo(const StreamInformation& stream,
     vsi.hdrType = StreamHdrType::HDR_TYPE_NONE; // Not stored in BLURAY_TITLE_INFO
   }
 
-  switch (stream.aspect)
+  // The display aspect ratio the elementary stream signals is the accurate one, as it accounts for
+  // anamorphic encodings the .clpi's 4:3/16:9 frame flag cannot express. Fall back to that flag
+  // when the m2ts has not been analysed or the stream signalled no sample aspect ratio.
+  if (const float dar{bsvi ? GetDisplayAspectRatio(*bsvi) : 0.0f}; dar > 0.0f)
   {
-    using enum ASPECT_RATIO;
-    case RATIO_4_3:
-      vsi.videoAspectRatio = 4.0f / 3.0f;
-      break;
-    case RATIO_16_9:
-      vsi.videoAspectRatio = 16.0f / 9.0f;
-      break;
-    default:
-      vsi.videoAspectRatio = 0.0f;
-      break;
+    vsi.videoAspectRatio = dar;
+  }
+  else
+  {
+    switch (aspect)
+    {
+      using enum ASPECT_RATIO;
+      case RATIO_4_3:
+        vsi.videoAspectRatio = 4.0f / 3.0f;
+        break;
+      case RATIO_16_9:
+        vsi.videoAspectRatio = 16.0f / 9.0f;
+        break;
+      default:
+        vsi.videoAspectRatio = 0.0f;
+        break;
+    }
   }
 
   return vsi;
@@ -273,10 +284,42 @@ void LogDefaultStreams(const BlurayPlaylistInformation& b)
   logStream(playItem->presentationGraphicStreams, "subtitle");
 }
 
+// The aspect ratio is carried by the .clpi's program information and not by the play item's stream
+// number table, so the streams taken from the table have to pick it up from the clip they belong
+// to. Keyed by packet identifier, which is what the two have in common.
+using AspectRatioMap = std::map<unsigned int, ASPECT_RATIO>;
+
+AspectRatioMap GetClipAspectRatios(const BlurayPlaylistInformation& b)
+{
+  AspectRatioMap aspectRatios;
+
+  // Must be the clip the stream number table (and the M2TS analysis) describes, otherwise the
+  // packet identifiers will not correspond - see GetLongestPlayItem.
+  const ClipInformation* playItemClip{GetLongestPlayItemClip(b)};
+  if (!playItemClip)
+    return aspectRatios;
+
+  const auto it{std::ranges::find(b.clips, playItemClip->clip, &ClipInformation::clip)};
+  if (it == b.clips.end())
+    return aspectRatios;
+
+  for (const ProgramInformation& program : it->programs)
+  {
+    for (const StreamInformation& stream : program.streams)
+    {
+      if (stream.aspect != ASPECT_RATIO{})
+        aspectRatios.try_emplace(stream.packetIdentifier, stream.aspect);
+    }
+  }
+
+  return aspectRatios;
+}
+
 // Add one elementary stream to the playlist, refined by the M2TS analysis in s where it has been
 // done (s is empty when stream details were deferred).
 void AddStream(const StreamInformation& stream,
                const StreamMap& s,
+               const AspectRatioMap& aspectRatios,
                unsigned int playlist,
                const DefaultStreams& defaults,
                PlaylistInformation& p)
@@ -291,9 +334,20 @@ void AddStream(const StreamInformation& stream,
     case VIDEO_H264:
     case VIDEO_H264_MVC:
     case VIDEO_HEVC:
+    {
+      // The stream carries the aspect ratio itself when it came from the .clpi
+      ASPECT_RATIO aspect{stream.aspect};
+      if (aspect == ASPECT_RATIO{})
+      {
+        if (const auto ar{aspectRatios.find(stream.packetIdentifier)}; ar != aspectRatios.end())
+          aspect = ar->second;
+      }
+
       p.videoStreams.emplace_back(PopulateVideoStreamInfo(
-          stream, bs != s.end() ? dynamic_cast<TSVideoStreamInfo*>(bs->second.get()) : nullptr));
+          stream, aspect,
+          bs != s.end() ? dynamic_cast<TSVideoStreamInfo*>(bs->second.get()) : nullptr));
       break;
+    }
     case AUDIO_LPCM:
     case AUDIO_AC3:
     case AUDIO_DTS:
@@ -361,6 +415,7 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
   }
 
   const DefaultStreams defaults{GetDefaultStreams(b)};
+  const AspectRatioMap aspectRatios{GetClipAspectRatios(b)};
 
   // The PlayItem's stream number table is what the playlist exposes, and in stream number order.
   // The clip's program list is everything the m2ts carries.
@@ -379,7 +434,7 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
          {&playItem->videoStreams, &playItem->audioStreams, &playItem->presentationGraphicStreams})
     {
       for (const StreamInformation& stream : *streams)
-        AddStream(stream, s, b.playlist, defaults, p);
+        AddStream(stream, s, aspectRatios, b.playlist, defaults, p);
     }
     return;
   }
@@ -411,7 +466,7 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
   if (streamClip && !streamClip->programs.empty())
   {
     for (const StreamInformation& stream : streamClip->programs[0].streams)
-      AddStream(stream, s, b.playlist, defaults, p);
+      AddStream(stream, s, aspectRatios, b.playlist, defaults, p);
   }
 }
 } // namespace XFILE

--- a/xbmc/filesystem/test/TestStreamParser.cpp
+++ b/xbmc/filesystem/test/TestStreamParser.cpp
@@ -10,6 +10,7 @@
 #include "filesystem/bluray/PlaylistStructure.h"
 #include "filesystem/bluray/StreamParser.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -36,7 +37,9 @@ ClipInformation MakeClip(unsigned int clip)
   clipInfo.streamsRead = true;
 
   ProgramInformation program;
-  program.streams.emplace_back(MakeStream(ENCODING_TYPE::VIDEO_H264, 0x1011, ""));
+  StreamInformation video{MakeStream(ENCODING_TYPE::VIDEO_H264, 0x1011, "")};
+  video.aspect = ASPECT_RATIO::RATIO_16_9; // only the .clpi carries this
+  program.streams.emplace_back(std::move(video));
   program.streams.emplace_back(MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng"));
   program.streams.emplace_back(MakeStream(ENCODING_TYPE::AUDIO_AC3, 0x1101, "jpn"));
   program.streams.emplace_back(MakeStream(ENCODING_TYPE::SUB_PG, 0x1200, "eng"));
@@ -188,4 +191,48 @@ TEST(TestStreamParser, PlaylistWithoutAStreamNumberTableFallsBackToTheClip)
   CStreamParser::ConvertBlurayPlaylistInformation(b, deferred, {}, StreamDetails::DEFER);
   EXPECT_TRUE(deferred.audioStreams.empty());
   EXPECT_TRUE(deferred.pgStreams.empty());
+}
+
+TEST(TestStreamParser, AspectRatioComesFromTheClipWhenTheM2TSHasNotBeenAnalysed)
+{
+  // The aspect ratio is carried by the .clpi's program information and not by the play item's
+  // stream number table, so the video stream the table describes has to pick it up from the clip
+  BlurayPlaylistInformation b{MakePlaylist(100, 30, {}, {})};
+
+  PlaylistInformation p;
+  CStreamParser::ConvertBlurayPlaylistInformation(b, p, {}, StreamDetails::INCLUDE);
+
+  ASSERT_EQ(p.videoStreams.size(), 1U);
+  EXPECT_FLOAT_EQ(p.videoStreams[0].videoAspectRatio, 16.0f / 9.0f);
+}
+
+TEST(TestStreamParser, TheM2TSDisplayAspectRatioIsPreferredToTheClipsFrameFlag)
+{
+  // 2.35:1 anamorphically encoded in a 1920x1080 frame - the .clpi can only say the frame is 16:9,
+  // so the ratio the elementary stream signals is the one to report
+  BlurayPlaylistInformation b{MakePlaylist(100, 30, {}, {})};
+
+  auto video{std::make_shared<TSVideoStreamInfo>()};
+  video->pid = 0x1011;
+  video->streamType = ENCODING_TYPE::VIDEO_H264;
+  video->width = 1920;
+  video->height = 1080;
+  video->sampleAspectRatio = 4.0f / 3.0f;
+
+  const StreamMap streams{{video->pid, video}};
+
+  PlaylistInformation p;
+  CStreamParser::ConvertBlurayPlaylistInformation(b, p, streams, StreamDetails::INCLUDE);
+
+  ASSERT_EQ(p.videoStreams.size(), 1U);
+  EXPECT_FLOAT_EQ(p.videoStreams[0].videoAspectRatio, 1920.0f / 1080.0f * 4.0f / 3.0f);
+
+  // A stream that signals no sample aspect ratio falls back to the clip's frame flag
+  video->sampleAspectRatio = 0.0f;
+
+  PlaylistInformation unsignalled;
+  CStreamParser::ConvertBlurayPlaylistInformation(b, unsignalled, streams, StreamDetails::INCLUDE);
+
+  ASSERT_EQ(unsignalled.videoStreams.size(), 1U);
+  EXPECT_FLOAT_EQ(unsignalled.videoStreams[0].videoAspectRatio, 16.0f / 9.0f);
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly parse M2TS files for aspect ratio.

Note - Every disc reports SAR 1:1 in a 1920x1080 or 3840x2160 frame.

2.35:1 is not encoded anywhere on a Blu-ray. Scope films are stored full-frame with square pixels and the black bars baked into the picture. There's no anamorphic flag, no active-format descriptor in practice — the .clpi says 16:9, the SPS says 16:9, and the disc is 16:9.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Aspect ratio was 0.0 in streamdetails for discs parsed via M2TSParser.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
