### PR TITLE
[test][games] Remove timing-sensitive controller test

### DIFF
--- a/xbmc/games/controllers/input/test/TestControllerActivity.cpp
+++ b/xbmc/games/controllers/input/test/TestControllerActivity.cpp
@@ -62,34 +62,6 @@ TEST(TestControllerActivity, MotionPersistsWithButton)
 }
 
 //
-// Spec: Mouse motion should reset the timeout when moved again
-//
-TEST(TestControllerActivity, MotionTimeoutReset)
-{
-  CControllerActivity activity;
-
-  activity.OnMouseMotion("pointer", 1, 0);
-  activity.OnInputFrame();
-  EXPECT_FLOAT_EQ(activity.GetActivation(), 1.0f);
-
-  // Wait briefly before moving again. Keep the delay tiny so that a
-  // slow scheduler can't accidentally exceed the timeout.
-  std::this_thread::sleep_for(5ms);
-  activity.OnMouseMotion("pointer", 2, 0);
-  activity.OnInputFrame();
-
-  // Verify we're still active shortly after the second motion. Use a
-  // minimal wait to prevent hitting the timeout on busy VMs.
-  std::this_thread::sleep_for(5ms);
-  EXPECT_FLOAT_EQ(activity.GetActivation(), 1.0f);
-
-  // Sleep long past the timeout so the activity definitely expires
-  // even on slower machines.
-  std::this_thread::sleep_for(150ms);
-  EXPECT_FLOAT_EQ(activity.GetActivation(), 0.0f);
-}
-
-//
 // Spec: Activation should persist with multiple held buttons
 //
 TEST(TestControllerActivity, MotionPersistsMultipleButtons)


### PR DESCRIPTION
## Description

Removes `TestControllerActivity.MotionTimeoutReset`.

This test was introduced in #26876 and later "fixed" in #27984.

But it can still fail when the system is super-overloaded, so let's get rid of it instead of adopting better timing infrastructure.

## Motivation and context

The test relies on 5 ms sleeps around a 50 ms mouse-motion timeout. Under heavy CI load, scheduler jitter can delay the test thread long enough for the timeout to expire, causing intermittent failures unrelated to the code under test.

Kodi previously hit the same class of failure in `MultiplePointers`; commit 3dfdf22753c0974c277005c84d24aeddd750a581 from #27984 removed a similar timing-sensitive assertion.

Increasing the timing margin would only reduce the probability of failure, not make the test deterministic, so remove the timing-dependent test instead.

## How has this been tested?

Built `kodi-test` successfully and ran:

`--gtest_filter=TestControllerActivity.*`

All 4 remaining `TestControllerActivity` tests pass.

`git diff --check` also passes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
