### PR TITLE
RetroPlayer: Fix black screen after selecting "Reset" in the in-game OSD

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/RetroPlayer/rendering/test test/retroplayer_rendering
 xbmc/cores/VideoPlayer/Buffers/test test/videoplayer_buffers
 xbmc/cores/VideoPlayer/test       test/videoplayer
 xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers

--- a/xbmc/cores/RetroPlayer/playback/test/PlaybackTestEnvironment.h
+++ b/xbmc/cores/RetroPlayer/playback/test/PlaybackTestEnvironment.h
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ServiceBroker.h"
+#include "ServiceManager.h"
+#include "application/Application.h"
+#include "cores/RetroPlayer/guibridge/GUIGameMessenger.h"
+#include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/rendering/RPRenderManager.h"
+#include "games/GameServices.h"
+#include "games/controllers/ControllerManager.h"
+#include "input/InputManager.h"
+#include "interfaces/AnnouncementManager.h"
+#include "peripherals/Peripherals.h"
+#include "settings/SettingsComponent.h"
+#include "windowing/WinSystem.h"
+
+namespace KODI::RETRO
+{
+class CPlaybackTestEnvironment
+{
+public:
+  CPlaybackTestEnvironment()
+    : m_controllers(CServiceBroker::GetAddonMgr()),
+      m_peripherals(m_input, m_controllers),
+      m_previousWinSystem(CServiceBroker::GetWinSystem())
+  {
+    auto services = std::make_unique<GAME::CGameServices>(
+        m_controllers, m_guiRenderer, m_peripherals,
+        *CServiceBroker::GetSettingsComponent()->GetProfileManager(), m_input,
+        CServiceBroker::GetAddonMgr(), CServiceBroker::GetFileExtensionProvider());
+    auto& registered = CServices::GameServices(*g_application.m_ServiceManager);
+    m_previousServices = std::move(registered);
+    registered = std::move(services);
+    CServiceBroker::RegisterWinSystem(&m_winSystem);
+    m_processInfo = std::make_unique<CProcessInfo>();
+    m_renderer = std::make_unique<CRPRenderManager>(*m_processInfo);
+    m_messenger = std::make_unique<CGUIGameMessenger>(*m_processInfo);
+  }
+
+  ~CPlaybackTestEnvironment()
+  {
+    m_messenger.reset();
+    m_renderer.reset();
+    m_processInfo.reset();
+    if (m_previousWinSystem)
+      CServiceBroker::RegisterWinSystem(m_previousWinSystem);
+    else
+      CServiceBroker::UnregisterWinSystem();
+    CServices::GameServices(*g_application.m_ServiceManager) = std::move(m_previousServices);
+  }
+
+  CRPRenderManager& Renderer() { return *m_renderer; }
+  CGUIGameMessenger& Messenger() { return *m_messenger; }
+
+private:
+  class CServices : public CServiceManager
+  {
+  public:
+    static std::unique_ptr<GAME::CGameServices>& GameServices(CServiceManager& manager)
+    {
+      return manager.*&CServices::m_gameServices;
+    }
+  };
+
+  class CWinSystem : public CWinSystemBase
+  {
+  public:
+    CRenderSystemBase* GetRenderSystem() override { return nullptr; }
+    bool CreateNewWindow(const std::string&, bool, RESOLUTION_INFO&) override { return true; }
+    bool ResizeWindow(int, int, int, int) override { return true; }
+    bool SetFullScreen(bool, RESOLUTION_INFO&, bool) override { return true; }
+    void Register(IDispResource*) override {}
+    void Unregister(IDispResource*) override {}
+  };
+
+  class CProcessInfo : public CRPProcessInfo
+  {
+  public:
+    CProcessInfo() : CRPProcessInfo("test") {}
+  };
+
+  class CAnnouncements
+  {
+  public:
+    CAnnouncements() : m_previous(CServiceBroker::GetAnnouncementManager())
+    {
+      CServiceBroker::RegisterAnnouncementManager(
+          std::make_shared<ANNOUNCEMENT::CAnnouncementManager>());
+    }
+    ~CAnnouncements()
+    {
+      if (m_previous)
+        CServiceBroker::RegisterAnnouncementManager(m_previous);
+      else
+        CServiceBroker::UnregisterAnnouncementManager();
+    }
+
+  private:
+    std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_previous;
+  };
+
+  CAnnouncements m_announcements;
+  CInputManager m_input;
+  GAME::CControllerManager m_controllers;
+  PERIPHERALS::CPeripherals m_peripherals;
+  CGUIGameRenderManager m_guiRenderer;
+  CWinSystem m_winSystem;
+  CWinSystemBase* m_previousWinSystem;
+  std::unique_ptr<GAME::CGameServices> m_previousServices;
+  std::unique_ptr<CProcessInfo> m_processInfo;
+  std::unique_ptr<CRPRenderManager> m_renderer;
+  std::unique_ptr<CGUIGameMessenger> m_messenger;
+};
+} // namespace KODI::RETRO

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -608,6 +608,10 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForPool(
 
   std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
 
+  // Serialize with teardown so an old deferred flush cannot invalidate a new renderer's pool.
+  if (m_bFlush)
+    return renderer;
+
   // Get compatible renderer for this buffer pool
   for (const auto& it : m_renderers)
   {

--- a/xbmc/cores/RetroPlayer/rendering/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestRPRenderManager.cpp)
+
+core_add_test_library(retroplayer_rendering_test)

--- a/xbmc/cores/RetroPlayer/rendering/test/TestRPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/test/TestRPRenderManager.cpp
@@ -1,0 +1,199 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/buffers/BaseRenderBufferPool.h"
+#include "cores/RetroPlayer/buffers/video/RenderBufferSysMem.h"
+#include "cores/RetroPlayer/playback/test/PlaybackTestEnvironment.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h"
+#include "cores/RetroPlayer/streams/RetroPlayerVideo.h"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::RETRO;
+
+namespace
+{
+class CTestBuffer : public CRenderBufferSysMem
+{
+public:
+  bool UploadTexture() override { return true; }
+};
+
+class CTestPool : public CBaseRenderBufferPool
+{
+public:
+  bool IsCompatible(const CRenderVideoSettings&) const override
+  {
+    if (auto callback = std::exchange(onCompatibilityCheck, {}))
+      callback();
+    return true;
+  }
+
+  mutable std::function<void()> onCompatibilityCheck;
+
+protected:
+  IRenderBuffer* CreateRenderBuffer(void*) override { return new CTestBuffer; }
+};
+
+class CTestRenderer : public CRPBaseRenderer
+{
+public:
+  using CRPBaseRenderer::CRPBaseRenderer;
+  bool Supports(RENDERFEATURE) const override { return false; }
+  SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
+
+protected:
+  void RenderInternal(bool, uint8_t) override {}
+};
+
+class CTestRendererFactory : public IRendererFactory
+{
+public:
+  explicit CTestRendererFactory(std::shared_ptr<CTestPool> pool) : m_pool(std::move(pool)) {}
+  std::string RenderSystemName() const override { return "test"; }
+  CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
+                                  CRenderContext& context,
+                                  std::shared_ptr<IRenderBufferPool> pool) override
+  {
+    return new CTestRenderer(settings, context, std::move(pool));
+  }
+  RenderBufferPoolVector CreateBufferPools(CRenderContext&) override { return {m_pool}; }
+
+private:
+  std::shared_ptr<CTestPool> m_pool;
+};
+
+class CScopedRendererFactories : public CRPProcessInfo
+{
+public:
+  class CRegistration
+  {
+  public:
+    explicit CRegistration(std::shared_ptr<CTestPool> pool)
+    {
+      std::unique_lock lock(m_createSection);
+      m_previous = std::move(m_rendererFactories);
+      m_rendererFactories.clear();
+      m_rendererFactories.emplace_back(std::make_unique<CTestRendererFactory>(std::move(pool)));
+    }
+    ~CRegistration()
+    {
+      std::unique_lock lock(m_createSection);
+      m_rendererFactories = std::move(m_previous);
+    }
+
+  private:
+    std::vector<std::unique_ptr<IRendererFactory>> m_previous;
+  };
+};
+} // namespace
+
+class TestRPRenderManager : public testing::Test
+{
+protected:
+  void TearDown() override
+  {
+    m_environment.Renderer().Flush();
+    m_environment.Renderer().Deinitialize();
+    m_environment.Renderer().FrameMove();
+  }
+
+  void Configure()
+  {
+    ASSERT_TRUE(m_environment.Renderer().Configure(AV_PIX_FMT_BGR0, 160, 144, 0.0f, 256, 224));
+  }
+
+  void RenderControl()
+  {
+    // With no submitted frame, this exercises renderer creation without GPU drawing.
+    m_environment.Renderer().RenderControl(false, false, CRect{}, nullptr);
+  }
+
+  void ExpectVideoBuffer()
+  {
+    VideoStreamBuffer buffer{};
+    ASSERT_TRUE(m_environment.Renderer().GetVideoBuffer(160, 144, buffer));
+    EXPECT_NE(buffer.data, nullptr);
+  }
+
+  void Start()
+  {
+    m_environment.Renderer().Initialize();
+    Configure();
+    m_environment.Renderer().FrameMove();
+    RenderControl();
+    ASSERT_TRUE(m_pool->IsConfigured());
+    ExpectVideoBuffer();
+  }
+
+  void Reset()
+  {
+    auto& manager = m_environment.Renderer();
+    manager.Flush();
+    manager.Deinitialize();
+    manager.Initialize();
+    Configure();
+  }
+
+  std::shared_ptr<CTestPool> m_pool = std::make_shared<CTestPool>();
+  CScopedRendererFactories::CRegistration m_factories{m_pool};
+  CPlaybackTestEnvironment m_environment;
+};
+
+TEST_F(TestRPRenderManager, InitialStartup)
+{
+  m_environment.Renderer().Initialize();
+  Configure();
+  RenderControl();
+  m_environment.Renderer().FrameMove();
+  RenderControl();
+  ExpectVideoBuffer();
+}
+
+TEST_F(TestRPRenderManager, ResetWithFlushBeforeRendering)
+{
+  Start();
+  Reset();
+  m_environment.Renderer().FrameMove();
+  EXPECT_FALSE(m_pool->IsConfigured());
+  RenderControl();
+  ExpectVideoBuffer();
+}
+
+TEST_F(TestRPRenderManager, ResetWithRenderingBeforeFlush)
+{
+  Start();
+  Reset();
+  RenderControl();
+  m_environment.Renderer().FrameMove();
+
+  for (unsigned int frame = 0; frame < 3; ++frame)
+  {
+    RenderControl();
+    EXPECT_TRUE(m_pool->IsConfigured());
+    ExpectVideoBuffer();
+    m_environment.Renderer().FrameMove();
+  }
+}
+
+TEST_F(TestRPRenderManager, ResetDuringRendererLookup)
+{
+  Start();
+  // Interrupt lookup after its state check, before it acquires the renderer mutex.
+  m_pool->onCompatibilityCheck = [this] { Reset(); };
+  RenderControl();
+  m_environment.Renderer().FrameMove();
+  RenderControl();
+  ExpectVideoBuffer();
+}


### PR DESCRIPTION
## Description

Fix the "Reset" button in the in-game OSD causing a black screen on my NVIDIA Shield.

AI use:

Defer RetroPlayer renderer creation while a render flush is pending.

During a game reset, the video stream can be recreated before the rendering thread processes the previous stream's deferred flush. A replacement renderer could then be configured first and have its buffer pool invalidated by the old flush, leaving rendering permanently unable to acquire buffers.

Check `m_bFlush` in `GetRendererForPool()` while holding the renderer teardown mutex so renderer creation waits until the pending flush completes.

Deterministic tests cover startup, both reset orderings, and teardown during renderer lookup.

## Motivation and context

Fixes an intermittent reset failure where RetroPlayer repeatedly logged:

```text
RetroPlayer[RENDER]: Unable to get render buffer for frame
```

The failing ordering was:

```text
pending flush
→ stream teardown/reinitialize
→ replacement renderer created
→ old flush invalidates its buffer pool
→ renderer remains configured
```

The deferred flushing behavior dates back to #14053.

## How has this been tested?

* Added four deterministic `TestRPRenderManager` tests with no sleeps or scheduler-dependent timing
* Both regression cases fail before the fix and pass afterward
* 96 selected RetroPlayer tests pass
* Debug Kodi build passes on macOS ARM64
* SameBoy hardware reset tested repeatedly on macOS
* SameBoy hardware reset tested successfully on Android ARM64 / OpenGLES; the stream and renderer are recreated and fresh render buffers are allocated after reset
* `git diff --check` and formatting checks pass

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)