### PR TITLE
[wayland] Reapply window geometry when decorations are toggled

### DIFF
--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -825,6 +825,10 @@ void CWinSystemWayland::ApplyShellSurfaceState(IShellSurface::StateBitset state)
 {
   m_windowDecorator->SetState(m_configuredSize, m_scale, state);
   m_shellSurfaceState = state;
+  // Enabling or disabling decorations changes the window geometry even when the
+  // configured size stays the same, in which case ApplySizeUpdate() does not
+  // reapply it and a stale decorated geometry would offset the whole window
+  ApplyWindowGeometry();
 }
 
 void CWinSystemWayland::OnConfigure(std::uint32_t serial, CSizeInt size, IShellSurface::StateBitset state)


### PR DESCRIPTION
First of all, thank you for this project!

## Why

On compositors whose initial xdg_toplevel configure carries no state - sway does this when the fullscreen request has not been applied yet - Kodi started fullscreen comes up with the GUI offset downwards by the height of its window decoration, with the top border visible above it. It stays that way until the window is resized or fullscreen is toggled off and on.

The initial configure arrives with state "none", so CWindowDecorator enables decorations and CreateNewWindow commits a window geometry that includes them. The next configure carries fullscreen and decorations are disabled again, but the configured size is unchanged, so ApplySizeUpdate() never calls ApplyWindowGeometry() and the decorated geometry stays in effect.

```
Initial configure serial 88789: size 0x0 state none
CWindowDecorator::SetState: ... (main surface size 1910x1037), decorations active: true
CWindowDecorator::SetState: ... (main surface size 1920x1080), decorations active: false
```

This is not a substitute for xdg-decoration support (#15219), which would remove Kodi's own decorations on compositors offering that protocol. It fixes the existing decoration path, which stays in use everywhere else.

## Proposed fix

Reapply the window geometry in ApplyShellSurfaceState(), where decorations are switched on and off. The size-driven path already reapplies it, so this only covers a state change without a size change.

## Verification

Arch Linux, sway 1.12, Mesa 26.2, AMD iGPU, Wayland backend, output at scale 2, master at ed4362fc built with -DENABLE_PYTHON=OFF. With the patch reverted and the same binary rebuilt, Kodi starts with a 43 px offset; with the patch it starts correctly. Toggling fullscreen, windowed mode and moving between outputs of different scale behave as before.
