### PR TITLE
[Video] Improve audio language display in library.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24978,7 +24978,37 @@ msgctxt "#39212"
 msgid "Do not turn on subtitles that are in the same language as the audio being played. Forced subtitles are not affected."
 msgstr ""
 
-#empty strings from id 39213 to 39899
+#. Title of the setting that chooses which audio stream a library list describes
+#: system/settings/settings.xml
+msgctxt "#39213"
+msgid "Language details to display"
+msgstr ""
+
+#. Help text for setting "Language details to display" of label #39213
+#: system/settings/settings.xml
+msgctxt "#39214"
+msgid "Which audio stream the language, codec and channel count shown against an item describe.[CR][Player][Default] The language that will normally be played.[CR][Media default] The default language for the media. If not set, then the best audio stream is shown.[CR][Best] The best audio stream as determined by codec quality and channel count."
+msgstr ""
+
+#. Value of the setting "Language details to display" - describe the stream that will be played
+#: system/settings/settings.xml
+msgctxt "#39215"
+msgid "Player"
+msgstr ""
+
+#. Value of the setting "Language details to display" - describe the media's default stream
+#: system/settings/settings.xml
+msgctxt "#39216"
+msgid "Media default"
+msgstr ""
+
+#. Value of the setting "Language details to display" - describe the technically best stream
+#: system/settings/settings.xml
+msgctxt "#39217"
+msgid "Best"
+msgstr ""
+
+#empty strings from id 39218 to 39899
 
 #. List formatting: pattern used to join a list of exactly two items, e.g. "A and B"
 #. STR_LIST_AND_TWO

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1265,6 +1265,18 @@
             <hidevalue>false</hidevalue>
           </control>
         </setting>
+        <setting id="videolibrary.languagedetails" type="integer" label="39213" help="39214">
+          <level>0</level>
+          <default>0</default> <!-- VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER -->
+          <constraints>
+            <options>
+              <option label="39215">0</option> <!-- VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER -->
+              <option label="39216">1</option> <!-- VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT -->
+              <option label="39217">2</option> <!-- VIDEOLIBRARY_LANGUAGE_DETAILS_BEST -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videolibrary.groupmoviesets" type="boolean" label="20458" help="36145">
           <level>1</level>
           <default>false</default>

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -969,20 +969,6 @@ const CLanguageTag& CLangInfo::GetAudioLanguage(bool allowFallback) const
   return m_audioLanguage;
 }
 
-std::string CLangInfo::GetPreferredAudioLanguage() const
-{
-  const std::string setting{CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
-      CSettings::SETTING_LOCALE_AUDIOLANGUAGE)};
-
-  if (StringUtils::EqualsNoCase(setting, audioLanguageMediaDefault) ||
-      StringUtils::EqualsNoCase(setting, audioLanguageOriginal))
-    return "";
-
-  // Resolves "default" to the UI language. Narrowed to the notation the stream details
-  // carry, which is what the caller compares against.
-  return GetAudioLanguage(true).AsIso6392B();
-}
-
 void CLangInfo::SetAudioLanguage(const std::string& language)
 {
   m_audioLanguage = LanguageFromSetting(language, specialAudioLangSettings);

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -134,14 +134,6 @@ public:
   const KODI::UTILS::CLanguageTag& GetAudioLanguage(bool allowFallback) const;
 
   /*!
-   * \brief Get the audio language the user prefers, as an ISO 639 code
-   *
-   * \return The preferred language, or an empty string when the preference cannot be expressed
-   *         as a language, ie. when it is "media default" or "original language"
-   */
-  std::string GetPreferredAudioLanguage() const;
-
-  /*!
    * \brief Set the audio language.
    * \param language The language can either be a two char language code,
    *        or a three char language code, or a language name in english,

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -236,62 +236,32 @@ class PredicateAudioFilter
 {
 private:
   int currentAudioStream;
-  bool preferStereo;
+  StreamUtils::AudioPreferences preferences;
+
 public:
   explicit PredicateAudioFilter(int audioStream, bool preferStereo)
-    : currentAudioStream(audioStream)
-    , preferStereo(preferStereo)
+    : currentAudioStream(audioStream),
+      preferences(StreamUtils::AudioPreferences::Current())
   {
+    // Follows from the audio output layout rather than a setting
+    preferences.preferStereo = preferStereo;
   };
   bool operator()(const SelectionStream& lh, const SelectionStream& rh)
   {
+    // A stream remembered from a previous watch outranks everything
     PREDICATE_RETURN(lh.type_index == currentAudioStream
                      , rh.type_index == currentAudioStream);
 
-    const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-    if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE),
-                                   LANGINFO::audioLanguageMediaDefault))
-    {
-      if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE),
-                                     LANGINFO::audioLanguageOriginal))
-      {
-        const CLanguageTag& audioLanguage{g_langInfo.GetAudioLanguage(true)};
-        PREDICATE_RETURN(lh.language.Matches(audioLanguage), rh.language.Matches(audioLanguage));
-      }
-      else
-      {
-        PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_ORIGINAL,
-          rh.flags & StreamFlags::FLAG_ORIGINAL);
-      }
-
-      bool hearingimp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_AUDIOHEARING);
-      PREDICATE_RETURN(!hearingimp ? !(lh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) : lh.flags & StreamFlags::FLAG_HEARING_IMPAIRED
-                       , !hearingimp ? !(rh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) : rh.flags & StreamFlags::FLAG_HEARING_IMPAIRED);
-
-      bool visualimp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_AUDIOVISUAL);
-      PREDICATE_RETURN(!visualimp ? !(lh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED) : lh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED
-                       , !visualimp ? !(rh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED) : rh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED);
-    }
-
-    if (settings->GetBool(CSettings::SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG))
-    {
-      PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_DEFAULT,
-                       rh.flags & StreamFlags::FLAG_DEFAULT);
-    }
-
-    if (preferStereo)
-      PREDICATE_RETURN(lh.channels == 2, rh.channels == 2);
-
-    // Order the remaining candidates the same way the library does
-    const int quality{
-        StreamUtils::CompareAudioQuality(lh.codec, lh.channels, rh.codec, rh.channels)};
-    if (quality != 0)
-      return quality > 0;
-
-    PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_DEFAULT,
-                     rh.flags & StreamFlags::FLAG_DEFAULT);
-    return false;
+    // Everything below this is shared with the library
+    return StreamUtils::CompareAudioPreference({.language = lh.language,
+                                                .codec = lh.codec,
+                                                .channels = lh.channels,
+                                                .flags = lh.flags},
+                                               {.language = rh.language,
+                                                .codec = rh.codec,
+                                                .channels = rh.channels,
+                                                .flags = rh.flags},
+                                               preferences) > 0;
   };
 };
 

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -9,7 +9,6 @@
 #include "guilib/guiinfo/VideoGUIInfo.h"
 
 #include "FileItem.h"
-#include "LangInfo.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -50,19 +49,6 @@
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace KODI;
-
-namespace
-{
-/*!
- * \brief Get the index of the audio stream
- *
- * Playback starts with the best stream in the preferred audio language
- */
-int GetDescribedAudioStreamIndex(const CStreamDetails& details)
-{
-  return details.GetPreferredAudioStreamIndex(g_langInfo.GetPreferredAudioLanguage());
-}
-} // unnamed namespace
 
 CVideoGUIInfo::CVideoGUIInfo()
   : m_appPlayer(CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>())
@@ -512,14 +498,13 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         return true;
       }
       case LISTITEM_AUDIO_CODEC:
-        value =
-            tag->m_streamDetails.GetAudioCodec(GetDescribedAudioStreamIndex(tag->m_streamDetails));
+        value = tag->m_streamDetails.GetAudioCodec(tag->GetDescribedAudioStreamIndex());
         return true;
       case LISTITEM_AUDIO_CHANNELS:
       {
         const auto formatted{CGUIInfoUtils::FormatAudioChannels(
-            info.GetData3(), tag->m_streamDetails.GetAudioChannels(
-                                 GetDescribedAudioStreamIndex(tag->m_streamDetails)))};
+            info.GetData3(),
+            tag->m_streamDetails.GetAudioChannels(tag->GetDescribedAudioStreamIndex()))};
 
         if (formatted.has_value())
         {
@@ -529,8 +514,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         break;
       }
       case LISTITEM_AUDIO_LANGUAGE:
-        value = tag->m_streamDetails.GetAudioLanguage(
-            GetDescribedAudioStreamIndex(tag->m_streamDetails));
+        value = tag->m_streamDetails.GetAudioLanguage(tag->GetDescribedAudioStreamIndex());
         return true;
       case LISTITEM_SUBTITLE_LANGUAGE:
         value = tag->m_streamDetails.GetSubtitleLanguage();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -68,6 +68,7 @@ public:
   static constexpr auto SETTING_WINDOW_WIDTH = "window.width";
   static constexpr auto SETTING_WINDOW_HEIGHT = "window.height";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS = "videolibrary.showunwatchedplots";
+  static constexpr auto SETTING_VIDEOLIBRARY_LANGUAGEDETAILS = "videolibrary.languagedetails";
   static constexpr auto SETTING_VIDEOLIBRARY_ACTORTHUMBS = "videolibrary.actorthumbs";
   static constexpr auto SETTING_MYVIDEOS_FLATTEN = "myvideos.flatten";
   static constexpr auto SETTING_VIDEOLIBRARY_FLATTENVERSIONS = "videolibrary.flattenversions";
@@ -495,6 +496,11 @@ public:
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
   static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
+  // values for SETTING_VIDEOLIBRARY_LANGUAGEDETAILS
+  // Which audio stream the language, codec and channel count shown against an item describe
+  static const int VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER = 0; // the stream that will be played
+  static const int VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT = 1; // the media default stream
+  static const int VIDEOLIBRARY_LANGUAGE_DETAILS_BEST = 2; // the technically best stream
   // values for SETTING_VIDEOLIBRARY_ARTWORK_LEVEL
   static const int VIDEOLIBRARY_ARTWORK_LEVEL_ALL = 0;
   static const int VIDEOLIBRARY_ARTWORK_LEVEL_BASIC = 1;

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -622,16 +622,12 @@ StreamFlags CStreamDetails::GetSubtitleFlags(int idx) const
     return StreamFlags::FLAG_NONE;
 }
 
-int CStreamDetails::GetPreferredAudioStreamIndex(const std::string& language) const
+int CStreamDetails::GetPreferredAudioStreamIndex(
+    const StreamUtils::AudioPreferences& preferences) const
 {
-  if (language.empty())
-    return 0;
-
-  const KODI::UTILS::CLanguageTag preferred{KODI::UTILS::CLanguageTag::Parse(language)};
-
   int index{0};
   int bestIndex{0};
-  const CStreamDetailAudio* best{nullptr};
+  StreamUtils::AudioCandidate best;
 
   for (const auto& iter : m_vecItems)
   {
@@ -640,14 +636,20 @@ int CStreamDetails::GetPreferredAudioStreamIndex(const std::string& language) co
 
     index++;
 
+    // The details store a language code, so it is parsed here rather than inside the comparison,
+    // which would otherwise pay for it once per stream compared rather than once per stream
     const auto* audio{static_cast<const CStreamDetailAudio*>(iter.get())};
-    if (!KODI::UTILS::CLanguageTag::Parse(audio->m_strLanguage).Matches(preferred))
-      continue;
+    const StreamUtils::AudioCandidate candidate{
+        .language = KODI::UTILS::CLanguageTag::Parse(audio->m_strLanguage),
+        .codec = audio->m_strCodec,
+        .channels = audio->m_iChannels,
+        .flags = audio->m_flags};
 
-    if (!best || StreamUtils::CompareAudioQuality(audio->m_strCodec, audio->m_iChannels,
-                                                  best->m_strCodec, best->m_iChannels) > 0)
+    // Strictly better only, so that streams the preferences cannot separate keep the order the
+    // source presented them in (same stability std::stable_sort gives the player)
+    if (bestIndex == 0 || StreamUtils::CompareAudioPreference(candidate, best, preferences) > 0)
     {
-      best = audio;
+      best = candidate;
       bestIndex = index;
     }
   }
@@ -673,6 +675,25 @@ int CStreamDetails::GetFirstAudioChannels() const
 std::string CStreamDetails::GetFirstSubtitleLanguage() const
 {
   return GetSubtitleLanguage(1);
+}
+
+int CStreamDetails::GetDefaultAudioStreamIndex() const
+{
+  int index{0};
+
+  for (const auto& iter : m_vecItems)
+  {
+    if (iter->m_eType != CStreamDetail::AUDIO)
+      continue;
+
+    index++;
+
+    if (static_cast<const CStreamDetailAudio*>(iter.get())->m_flags & StreamFlags::FLAG_DEFAULT)
+      return index;
+  }
+
+  // The media nominates nothing, so the best listen it has to offer is the only answer left
+  return 0;
 }
 
 void CStreamDetails::Archive(CArchive& ar)

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -11,6 +11,7 @@
 #include "ISerializable.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "utils/IArchivable.h"
+#include "utils/StreamUtils.h"
 
 #include <algorithm>
 #include <array>
@@ -302,13 +303,24 @@ public:
   StreamFlags GetSubtitleFlags(int idx = 0) const;
 
   /*!
-   * \brief Get the index of the best audio stream in the given language.
+   * \brief Get the index of the audio stream playback is likely to start on.
    *
-   * \param language The preferred audio language as an ISO 639 code, empty for no preference
-   * \return The 1-based index of the best stream in that language, or 0 (meaning the technically
-   *         best stream, see GetAudioCodec()) when no preference was given or no stream matches
+   * Applies StreamUtils::CompareAudioPreference(), so the stream named here is the stream the
+   * player picks, save for the two tiers the library cannot see: a stream remembered from a
+   * previous watch, and a stereo audio layout.
+   *
+   * \param preferences The settings in force, see StreamUtils::AudioPreferences::Current()
+   * \return The 1-based index of that stream, or 0 when there are no audio streams
    */
-  int GetPreferredAudioStreamIndex(const std::string& language) const;
+  int GetPreferredAudioStreamIndex(const StreamUtils::AudioPreferences& preferences) const;
+
+  /*!
+   * \brief Get the index of the audio stream the media nominates as its default.
+   *
+   * \return The 1-based index of the first stream flagged as default, or 0 (meaning the
+   *         technically best stream, see GetAudioCodec()) when the media nominates none
+   */
+  int GetDefaultAudioStreamIndex() const;
 
   /*!
    * \brief Get the language of the first audio stream in the order the source lists them.

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -8,17 +8,127 @@
 
 #include "StreamUtils.h"
 
+#include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 
 #include <algorithm>
 #include <array>
+#include <string>
 
 extern "C"
 {
 #include <libavcodec/avcodec.h>
 #include <libavcodec/defs.h>
+}
+
+namespace
+{
+/*!
+ * \brief Decide one tier of CompareAudioPreference().
+ *
+ * Mirrors the player's PREDICATE_RETURN: a tier only has an opinion when the two streams
+ * differ on it, and the stream the property holds for comes first.
+ */
+int CompareTier(bool lh, bool rh)
+{
+  if (lh == rh)
+    return 0;
+  return lh ? 1 : -1;
+}
+} // unnamed namespace
+
+StreamUtils::AudioPreferences StreamUtils::AudioPreferences::Current()
+{
+  const std::shared_ptr<CSettings> settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
+  const std::string setting{settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE)};
+
+  AudioPreferences preferences;
+  preferences.mediaDefault =
+      StringUtils::EqualsNoCase(setting, KODI::LANGINFO::audioLanguageMediaDefault);
+  preferences.preferOriginal =
+      StringUtils::EqualsNoCase(setting, KODI::LANGINFO::audioLanguageOriginal);
+
+  // Only a preference naming a language has one to match on, and the two above do not, which is
+  // why they are read separately. GetAudioLanguage() resolves "default" to the UI language.
+  if (!preferences.mediaDefault && !preferences.preferOriginal)
+    preferences.language = g_langInfo.GetAudioLanguage(true);
+
+  preferences.preferHearingImpaired =
+      settings->GetBool(CSettings::SETTING_ACCESSIBILITY_AUDIOHEARING);
+  preferences.preferVisualImpaired =
+      settings->GetBool(CSettings::SETTING_ACCESSIBILITY_AUDIOVISUAL);
+  preferences.preferDefaultFlag =
+      settings->GetBool(CSettings::SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG);
+
+  return preferences;
+}
+
+int StreamUtils::CompareAudioPreference(const AudioCandidate& lh,
+                                        const AudioCandidate& rh,
+                                        const AudioPreferences& preferences)
+{
+  int result{0};
+
+  // "Media default" means the user has asked for none of this to be considered
+  if (!preferences.mediaDefault)
+  {
+    if (preferences.preferOriginal)
+    {
+      result =
+          CompareTier(lh.flags & StreamFlags::FLAG_ORIGINAL, rh.flags & StreamFlags::FLAG_ORIGINAL);
+    }
+    else
+    {
+      result = CompareTier(lh.language.Matches(preferences.language),
+                           rh.language.Matches(preferences.language));
+    }
+    if (result != 0)
+      return result;
+
+    // The impaired flags cut both ways: a listener who has not asked for a described or
+    // captioned mix should be steered away from one just as firmly
+    result = CompareTier(static_cast<bool>(lh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) ==
+                             preferences.preferHearingImpaired,
+                         static_cast<bool>(rh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) ==
+                             preferences.preferHearingImpaired);
+    if (result != 0)
+      return result;
+
+    result = CompareTier(static_cast<bool>(lh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED) ==
+                             preferences.preferVisualImpaired,
+                         static_cast<bool>(rh.flags & StreamFlags::FLAG_VISUAL_IMPAIRED) ==
+                             preferences.preferVisualImpaired);
+    if (result != 0)
+      return result;
+  }
+
+  if (preferences.preferDefaultFlag)
+  {
+    result =
+        CompareTier(lh.flags & StreamFlags::FLAG_DEFAULT, rh.flags & StreamFlags::FLAG_DEFAULT);
+    if (result != 0)
+      return result;
+  }
+
+  if (preferences.preferStereo)
+  {
+    result = CompareTier(lh.channels == 2, rh.channels == 2);
+    if (result != 0)
+      return result;
+  }
+
+  result =
+      CompareAudioQuality(std::string{lh.codec}, lh.channels, std::string{rh.codec}, rh.channels);
+  if (result != 0)
+    return result;
+
+  // Two equally good streams, so let the media's own idea of a default settle it
+  return CompareTier(lh.flags & StreamFlags::FLAG_DEFAULT, rh.flags & StreamFlags::FLAG_DEFAULT);
 }
 
 int StreamUtils::GetCodecPriority(const std::string &codec)

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -8,14 +8,85 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
+#include "utils/LanguageTag.h"
+
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 static constexpr int MP4_BOX_HEADER_SIZE = 8;
 
 class StreamUtils
 {
 public:
+  /*!
+   * \brief The settings that decide which audio stream playback starts with.
+   *
+   * Read once and reused for every comparison, so that a setting changed midway through
+   * cannot make a sort order inconsistent, and so a sort does not pay for a settings lookup
+   * per comparison.
+   */
+  struct AudioPreferences
+  {
+    //! \brief The language wanted. Empty when the preference is not a language.
+    KODI::UTILS::CLanguageTag language;
+
+    //! \brief The preference is "original language": prefer whichever stream is flagged original.
+    bool preferOriginal{false};
+
+    //! \brief The preference is "media default"
+    bool mediaDefault{false};
+
+    bool preferHearingImpaired{false};
+    bool preferVisualImpaired{false};
+    bool preferDefaultFlag{false};
+
+    //! \brief Prefer a stereo stream. This follows from the audio output layout rather than a
+    //!        setting, so only the player can fill it in; the library leaves it false.
+    bool preferStereo{false};
+
+    /*!
+     * \brief Read the settings as they currently stand.
+     * \note preferStereo is not a setting and is left false. The player sets it afterwards.
+     */
+    static AudioPreferences Current();
+  };
+
+  /*!
+   * \brief One audio stream
+   *
+   * Used by player's SelectionStream and library's CStreamDetailAudio
+   */
+  struct AudioCandidate
+  {
+    KODI::UTILS::CLanguageTag language;
+    std::string_view codec;
+    int channels{0};
+    StreamFlags flags{StreamFlags::FLAG_NONE};
+  };
+
+  /*!
+   * \brief Compare two audio streams the way playback picks the stream it starts on.
+   *
+   * The tiers, in order: the wanted language (or the original flag when that is the
+   * preference), the hearing and visual impaired flags, the default flag when the user asked
+   * for it, a stereo layout, technical quality, and finally the default flag as a tiebreak.
+   *
+   * \param lh The first stream
+   * \param rh The second stream
+   * \param preferences The settings in force, see AudioPreferences::Current()
+   * \return A positive value when the first stream is the better match, a negative value when
+   *         the second is, and zero when these properties cannot separate the two
+   *
+   * \note This is a strict weak ordering, as CSelectionStreams::Get() hands it to
+   *       std::stable_sort. Every tier is a property each stream decides for itself, never one
+   *       that depends on the pair.
+   */
+  static int CompareAudioPreference(const AudioCandidate& lh,
+                                    const AudioCandidate& rh,
+                                    const AudioPreferences& preferences);
+
   static int GetCodecPriority(const std::string& codec);
 
   /*!

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -758,6 +758,37 @@ CStreamDetails MakeAudioStreams(
   details.DetermineBestStreams();
   return details;
 }
+
+// As above, with the stream flags the scanner would have stored alongside each stream.
+CStreamDetails MakeFlaggedAudioStreams(
+    const std::vector<std::tuple<std::string, std::string, int, StreamFlags>>& streams)
+{
+  CStreamDetails details;
+  for (const auto& [language, codec, channels, flags] : streams)
+  {
+    auto* audio = new CStreamDetailAudio();
+    audio->m_strLanguage = language;
+    audio->m_strCodec = codec;
+    audio->m_iChannels = channels;
+    audio->m_flags = flags;
+    audio->SetSource(CStreamDetail::MEDIA);
+    details.AddStream(audio);
+  }
+  details.DetermineBestStreams();
+  return details;
+}
+
+// The settings as they stand when the user has asked for a particular audio language, or, for an
+// empty language, has left the choice to the media.
+StreamUtils::AudioPreferences ForLanguage(std::string_view language)
+{
+  StreamUtils::AudioPreferences preferences;
+  if (language.empty())
+    preferences.mediaDefault = true;
+  else
+    preferences.language = KODI::UTILS::CLanguageTag::Parse(std::string{language});
+  return preferences;
+}
 } // namespace
 
 TEST(TestStreamDetails, PreferredAudio_BestStreamInThePreferredLanguage)
@@ -767,11 +798,13 @@ TEST(TestStreamDetails, PreferredAudio_BestStreamInThePreferredLanguage)
   const CStreamDetails details{
       MakeAudioStreams({{"ger", "truehd", 8}, {"eng", "ac3", 6}, {"eng", "dtshd_ma", 6}})};
 
-  EXPECT_EQ(3, details.GetPreferredAudioStreamIndex("eng"));
-  EXPECT_EQ("dtshd_ma", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("eng")));
+  EXPECT_EQ(3, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+  EXPECT_EQ("dtshd_ma",
+            details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
 
-  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex("ger"));
-  EXPECT_EQ("truehd", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("ger")));
+  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex(ForLanguage("ger")));
+  EXPECT_EQ("truehd",
+            details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage("ger"))));
 }
 
 TEST(TestStreamDetails, PreferredAudio_IndexCountsAllAudioStreams)
@@ -781,8 +814,9 @@ TEST(TestStreamDetails, PreferredAudio_IndexCountsAllAudioStreams)
   const CStreamDetails details{
       MakeAudioStreams({{"fra", "ac3", 6}, {"jpn", "ac3", 6}, {"eng", "ac3", 6}})};
 
-  EXPECT_EQ(3, details.GetPreferredAudioStreamIndex("eng"));
-  EXPECT_EQ("eng", details.GetAudioLanguage(details.GetPreferredAudioStreamIndex("eng")));
+  EXPECT_EQ(3, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+  EXPECT_EQ("eng",
+            details.GetAudioLanguage(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
 }
 
 TEST(TestStreamDetails, PreferredAudio_LanguageIsMatchedAcrossISO639Forms)
@@ -791,8 +825,8 @@ TEST(TestStreamDetails, PreferredAudio_LanguageIsMatchedAcrossISO639Forms)
   // the two must be compared rather than string matched.
   const CStreamDetails details{MakeAudioStreams({{"ger", "ac3", 6}, {"en", "truehd", 6}})};
 
-  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex("eng"));
-  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex("deu"));
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex(ForLanguage("deu")));
 }
 
 TEST(TestStreamDetails, PreferredAudio_FallsBackToTheBestStream)
@@ -800,20 +834,22 @@ TEST(TestStreamDetails, PreferredAudio_FallsBackToTheBestStream)
   const CStreamDetails details{MakeAudioStreams({{"ger", "ac3", 6}, {"fra", "truehd", 6}})};
 
   // Nothing in the preferred language, so there is no better answer than the best listen the
-  // file has to offer, which index 0 is.
-  EXPECT_EQ(0, details.GetPreferredAudioStreamIndex("eng"));
-  EXPECT_EQ("truehd", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("eng")));
+  // file has to offer. The index names that stream rather than the 0 that stands for it, since
+  // the flag tiers can pick a stream the technical ranking would not have.
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+  EXPECT_EQ("truehd",
+            details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
 
   // As when the preference cannot be expressed as a language at all
-  EXPECT_EQ(0, details.GetPreferredAudioStreamIndex(""));
-  EXPECT_EQ("truehd", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("")));
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(ForLanguage("")));
+  EXPECT_EQ("truehd", details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage(""))));
 }
 
 TEST(TestStreamDetails, PreferredAudio_NoAudioStreams)
 {
   const CStreamDetails details{MakeAudioStreams({})};
-  EXPECT_EQ(0, details.GetPreferredAudioStreamIndex("eng"));
-  EXPECT_EQ("", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("eng")));
+  EXPECT_EQ(0, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+  EXPECT_EQ("", details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
 }
 
 TEST(TestStreamDetails, FirstAudio_CodecAndChannelsComeFromTheFirstStream)
@@ -833,8 +869,9 @@ TEST(TestStreamDetails, FirstAudio_CodecAndChannelsComeFromTheFirstStream)
   EXPECT_EQ(8, details.GetAudioChannels());
 
   // nor the stream the user's language preference would pick
-  EXPECT_EQ("dtshd_ma", details.GetAudioCodec(details.GetPreferredAudioStreamIndex("eng")));
-  EXPECT_EQ(6, details.GetAudioChannels(details.GetPreferredAudioStreamIndex("eng")));
+  EXPECT_EQ("dtshd_ma",
+            details.GetAudioCodec(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
+  EXPECT_EQ(6, details.GetAudioChannels(details.GetPreferredAudioStreamIndex(ForLanguage("eng"))));
 }
 
 TEST(TestStreamDetails, FirstAudio_CodecAndChannelsWhenThereIsNoSuchStream)
@@ -1031,4 +1068,135 @@ TEST(TestStreamDetails, SerializeWidensLanguageToBcp47)
   subtitle.m_strLanguage = "";
   subtitle.Serialize(value);
   EXPECT_EQ(value["language"].asString(), "");
+}
+
+TEST(TestStreamDetails, PreferredAudio_OriginalLanguageFollowsTheFlag)
+{
+  // "Original language" is not a language the library can match on, so before flags were stored
+  // it fell back to the technically best stream. The player picks the flagged stream, and now
+  // so does the library.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"eng", "truehd", 8, StreamFlags::FLAG_NONE},
+                               {"jpn", "ac3", 6, StreamFlags::FLAG_ORIGINAL}})};
+
+  StreamUtils::AudioPreferences preferences;
+  preferences.preferOriginal = true;
+
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(preferences));
+  EXPECT_EQ("jpn", details.GetAudioLanguage(details.GetPreferredAudioStreamIndex(preferences)));
+
+  // Without that preference the better stream is still the one described
+  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex(ForLanguage("")));
+}
+
+TEST(TestStreamDetails, PreferredAudio_DefaultFlagWhenTheUserAsksForIt)
+{
+  // The disc's own default is a modest track, so it is only described when the user has asked
+  // for default streams to be honoured.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"eng", "ac3", 2, StreamFlags::FLAG_DEFAULT},
+                               {"eng", "truehd", 8, StreamFlags::FLAG_NONE}})};
+
+  StreamUtils::AudioPreferences preferences{ForLanguage("eng")};
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(preferences));
+
+  preferences.preferDefaultFlag = true;
+  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex(preferences));
+  EXPECT_EQ("ac3", details.GetAudioCodec(details.GetPreferredAudioStreamIndex(preferences)));
+}
+
+TEST(TestStreamDetails, PreferredAudio_DefaultFlagBreaksAQualityTie)
+{
+  // Two streams of the same quality, so the media's own default settles it even when the user
+  // has not asked for default streams to be preferred. This is the player's last tier.
+  const CStreamDetails details{MakeFlaggedAudioStreams(
+      {{"eng", "ac3", 6, StreamFlags::FLAG_NONE}, {"eng", "ac3", 6, StreamFlags::FLAG_DEFAULT}})};
+
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+}
+
+TEST(TestStreamDetails, PreferredAudio_ImpairedStreamsAreAvoidedUnlessWanted)
+{
+  // A described or captioned mix is not what most listeners want, so it is passed over however
+  // good it is - and chosen when the accessibility setting asks for it.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"eng", "truehd", 8, StreamFlags::FLAG_VISUAL_IMPAIRED},
+                               {"eng", "ac3", 2, StreamFlags::FLAG_NONE},
+                               {"eng", "dts", 6, StreamFlags::FLAG_HEARING_IMPAIRED}})};
+
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(ForLanguage("eng")));
+
+  StreamUtils::AudioPreferences visual{ForLanguage("eng")};
+  visual.preferVisualImpaired = true;
+  EXPECT_EQ(1, details.GetPreferredAudioStreamIndex(visual));
+
+  StreamUtils::AudioPreferences hearing{ForLanguage("eng")};
+  hearing.preferHearingImpaired = true;
+  EXPECT_EQ(3, details.GetPreferredAudioStreamIndex(hearing));
+}
+
+TEST(TestStreamDetails, PreferredAudio_MediaDefaultIgnoresLanguageAndImpairedFlags)
+{
+  // "Media default" means the user has asked for none of the language or impaired reasoning,
+  // leaving quality and the default flag to decide.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"eng", "ac3", 6, StreamFlags::FLAG_NONE},
+                               {"jpn", "truehd", 8, StreamFlags::FLAG_HEARING_IMPAIRED}})};
+
+  StreamUtils::AudioPreferences preferences;
+  preferences.mediaDefault = true;
+  preferences.language = KODI::UTILS::CLanguageTag::Parse("eng"); // must be disregarded
+
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(preferences));
+}
+
+TEST(TestStreamDetails, PreferredAudio_LanguageOutranksTheDefaultFlag)
+{
+  // Tier order matters: a stream in the wanted language wins even against the media's default,
+  // which is how the player orders the two.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"ger", "truehd", 8, StreamFlags::FLAG_DEFAULT},
+                               {"eng", "ac3", 2, StreamFlags::FLAG_NONE}})};
+
+  StreamUtils::AudioPreferences preferences{ForLanguage("eng")};
+  preferences.preferDefaultFlag = true;
+
+  EXPECT_EQ(2, details.GetPreferredAudioStreamIndex(preferences));
+}
+
+TEST(TestStreamDetails, DefaultAudio_NamesTheStreamTheMediaNominates)
+{
+  // The media's own default, which is not the best stream nor the one a language preference
+  // would pick, so all three settings have somewhere different to point.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"ger", "truehd", 8, StreamFlags::FLAG_NONE},
+                               {"fra", "ac3", 2, StreamFlags::FLAG_DEFAULT},
+                               {"eng", "dts", 6, StreamFlags::FLAG_NONE}})};
+
+  EXPECT_EQ(2, details.GetDefaultAudioStreamIndex());
+  EXPECT_EQ("fra", details.GetAudioLanguage(details.GetDefaultAudioStreamIndex()));
+  EXPECT_EQ("ac3", details.GetAudioCodec(details.GetDefaultAudioStreamIndex()));
+}
+
+TEST(TestStreamDetails, DefaultAudio_FallsBackToTheBestStream)
+{
+  // Nothing is nominated, so index 0 - the best stream - is the only answer left. This is what
+  // a file scanned before flags were stored looks like, as well as one that genuinely has none.
+  const CStreamDetails details{MakeAudioStreams({{"ger", "ac3", 6}, {"fra", "truehd", 6}})};
+
+  EXPECT_EQ(0, details.GetDefaultAudioStreamIndex());
+  EXPECT_EQ("truehd", details.GetAudioCodec(details.GetDefaultAudioStreamIndex()));
+
+  const CStreamDetails none{MakeAudioStreams({})};
+  EXPECT_EQ(0, none.GetDefaultAudioStreamIndex());
+}
+
+TEST(TestStreamDetails, DefaultAudio_FirstNominationWins)
+{
+  // A media that flags more than one stream is nominating the first of them, not the best.
+  const CStreamDetails details{
+      MakeFlaggedAudioStreams({{"eng", "ac3", 2, StreamFlags::FLAG_DEFAULT},
+                               {"ger", "truehd", 8, StreamFlags::FLAG_DEFAULT}})};
+
+  EXPECT_EQ(1, details.GetDefaultAudioStreamIndex());
 }

--- a/xbmc/utils/test/TestStreamUtils.cpp
+++ b/xbmc/utils/test/TestStreamUtils.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "utils/LanguageTag.h"
 #include "utils/StreamUtils.h"
 
 #include <string>
@@ -292,6 +293,152 @@ TEST(TestStreamUtils, CompareAudioQuality_UnknownChannelCountSentinelsRankEquall
   // And an unknown count still loses to any known one, however it is spelled
   EXPECT_LT(StreamUtils::CompareAudioQuality("truehd", -1, "ac3", 1), 0);
   EXPECT_LT(StreamUtils::CompareAudioQuality("truehd", 0, "ac3", 1), 0);
+}
+
+TEST(TestStreamUtils, CompareAudioPreference_IsAStrictWeakOrdering)
+{
+  // CSelectionStreams::Get() hands this to std::stable_sort, which is undefined behaviour unless
+  // it is a strict weak ordering. Every tier has to be a property each stream decides for itself,
+  // never one that depends on the pair, so walk the whole relation for a set of preferences that
+  // turns every tier on at once.
+  const std::vector<StreamUtils::AudioCandidate> candidates{
+      {.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+       .codec = "truehd",
+       .channels = 8,
+       .flags = StreamFlags::FLAG_DEFAULT},
+      {.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+       .codec = "ac3",
+       .channels = 2,
+       .flags = StreamFlags::FLAG_NONE},
+      {.language = KODI::UTILS::CLanguageTag::Parse("ger"),
+       .codec = "dtshd_ma",
+       .channels = 6,
+       .flags = StreamFlags::FLAG_ORIGINAL},
+      {.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+       .codec = "dts",
+       .channels = 6,
+       .flags = StreamFlags::FLAG_HEARING_IMPAIRED},
+      {.language = KODI::UTILS::CLanguageTag::Parse("jpn"),
+       .codec = "truehd",
+       .channels = 8,
+       .flags = StreamFlags::FLAG_VISUAL_IMPAIRED},
+      {.language = KODI::UTILS::CLanguageTag::Parse(""),
+       .codec = "",
+       .channels = 0,
+       .flags = StreamFlags::FLAG_NONE},
+      {.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+       .codec = "ac3",
+       .channels = 2,
+       .flags = StreamFlags::FLAG_DEFAULT},
+      {.language = KODI::UTILS::CLanguageTag::Parse("fra"),
+       .codec = "flac",
+       .channels = 2,
+       .flags = static_cast<StreamFlags>(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL)},
+      {.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+       .codec = "truehd",
+       .channels = 8,
+       .flags = StreamFlags::FLAG_NONE},
+      {.language = KODI::UTILS::CLanguageTag::Parse("und"),
+       .codec = "opus",
+       .channels = 6,
+       .flags = StreamFlags::FLAG_NONE},
+  };
+
+  StreamUtils::AudioPreferences preferences;
+  preferences.language = KODI::UTILS::CLanguageTag::Parse("eng");
+  preferences.preferHearingImpaired = true;
+  preferences.preferVisualImpaired = true;
+  preferences.preferDefaultFlag = true;
+  preferences.preferStereo = true;
+
+  const auto compare{[&candidates, &preferences](size_t i, size_t j) {
+    return StreamUtils::CompareAudioPreference(candidates[i], candidates[j], preferences);
+  }};
+  const auto better{[&compare](size_t i, size_t j) { return compare(i, j) > 0; }};
+
+  for (size_t i = 0; i < candidates.size(); ++i)
+  {
+    // Irreflexive - nothing is a better match than itself
+    EXPECT_FALSE(better(i, i)) << i;
+
+    for (size_t j = 0; j < candidates.size(); ++j)
+    {
+      // Antisymmetric - the result must simply invert when the arguments swap
+      EXPECT_EQ(compare(i, j), -compare(j, i)) << i << " vs " << j;
+
+      for (size_t k = 0; k < candidates.size(); ++k)
+      {
+        // Transitive - no cycles, for either "better than" or "equally good"
+        if (better(i, j) && better(j, k))
+        {
+          EXPECT_TRUE(better(i, k))
+              << i << " > " << j << " > " << k << " but not " << i << " > " << k;
+        }
+
+        if (!better(i, j) && !better(j, i) && !better(j, k) && !better(k, j))
+        {
+          EXPECT_TRUE(!better(i, k) && !better(k, i)) << i << " == " << j << " == " << k;
+        }
+      }
+    }
+  }
+}
+
+TEST(TestStreamUtils, CompareAudioPreference_TiersApplyInThePlayersOrder)
+{
+  const StreamUtils::AudioCandidate english{.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+                                            .codec = "ac3",
+                                            .channels = 2,
+                                            .flags = StreamFlags::FLAG_NONE};
+  const StreamUtils::AudioCandidate german{
+      .language = KODI::UTILS::CLanguageTag::Parse("ger"),
+      .codec = "truehd",
+      .channels = 8,
+      .flags = static_cast<StreamFlags>(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL)};
+
+  // The wanted language outranks the original flag, the default flag and quality alike
+  StreamUtils::AudioPreferences wantsEnglish;
+  wantsEnglish.language = KODI::UTILS::CLanguageTag::Parse("eng");
+  wantsEnglish.preferDefaultFlag = true;
+  EXPECT_GT(StreamUtils::CompareAudioPreference(english, german, wantsEnglish), 0);
+
+  // Asking for the original language instead moves the decision onto the flag
+  StreamUtils::AudioPreferences wantsOriginal;
+  wantsOriginal.preferOriginal = true;
+  EXPECT_LT(StreamUtils::CompareAudioPreference(english, german, wantsOriginal), 0);
+
+  // Media default takes language, original and impaired out of it, leaving quality
+  StreamUtils::AudioPreferences mediaDefault;
+  mediaDefault.mediaDefault = true;
+  mediaDefault.language = KODI::UTILS::CLanguageTag::Parse("eng"); // must be disregarded
+  EXPECT_LT(StreamUtils::CompareAudioPreference(english, german, mediaDefault), 0);
+
+  // A stereo layout is preferred over quality, but still yields to the default flag
+  StreamUtils::AudioPreferences stereo;
+  stereo.mediaDefault = true;
+  stereo.preferStereo = true;
+  EXPECT_GT(StreamUtils::CompareAudioPreference(english, german, stereo), 0);
+
+  stereo.preferDefaultFlag = true;
+  EXPECT_LT(StreamUtils::CompareAudioPreference(english, german, stereo), 0);
+}
+
+TEST(TestStreamUtils, CompareAudioPreference_DefaultFlagBreaksAQualityTie)
+{
+  // The player's last tier, which applies whether or not the user asked for default streams
+  const StreamUtils::AudioCandidate plain{.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+                                          .codec = "ac3",
+                                          .channels = 6,
+                                          .flags = StreamFlags::FLAG_NONE};
+  const StreamUtils::AudioCandidate flagged{.language = KODI::UTILS::CLanguageTag::Parse("eng"),
+                                            .codec = "ac3",
+                                            .channels = 6,
+                                            .flags = StreamFlags::FLAG_DEFAULT};
+
+  const StreamUtils::AudioPreferences preferences;
+  EXPECT_LT(StreamUtils::CompareAudioPreference(plain, flagged, preferences), 0);
+  EXPECT_GT(StreamUtils::CompareAudioPreference(flagged, plain, preferences), 0);
+  EXPECT_EQ(0, StreamUtils::CompareAudioPreference(plain, plain, preferences));
 }
 
 TEST(TestStreamUtils, NormalizeAudioCodecName)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -8,12 +8,12 @@
 
 #include "VideoInfoTag.h"
 
-#include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "imagefiles/ImageFileURL.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
 #include "utils/LangCodeExpander.h"
@@ -886,6 +886,23 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["specialsortepisode"] = m_iSpecialSortEpisode;
 }
 
+int CVideoInfoTag::GetDescribedAudioStreamIndex() const
+{
+  switch (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOLIBRARY_LANGUAGEDETAILS))
+  {
+    case CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT:
+      return m_streamDetails.GetDefaultAudioStreamIndex();
+
+    case CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_BEST:
+      return 0; // idx 0 is the technically best stream
+
+    case CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER:
+    default:
+      return m_streamDetails.GetPreferredAudioStreamIndex(StreamUtils::AudioPreferences::Current());
+  }
+}
+
 void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
 {
   switch (field)
@@ -1050,10 +1067,8 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
     case Field::AUDIO_CODEC:
     case Field::AUDIO_LANGUAGE:
     {
-      // Order by the stream the GUI describes, which is the one playback will start with,
-      // rather than by the technically best stream the list does not show
-      const int idx{
-          m_streamDetails.GetPreferredAudioStreamIndex(g_langInfo.GetPreferredAudioLanguage())};
+      // Order by the stream the GUI describes, rather than by a stream the list does not show
+      const int idx{GetDescribedAudioStreamIndex()};
       if (field == Field::AUDIO_CHANNELS)
         sortable[Field::AUDIO_CHANNELS] = m_streamDetails.GetAudioChannels(idx);
       else if (field == Field::AUDIO_CODEC)

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -82,6 +82,16 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   void ToSortable(SortItem& sortable, Field field) const override;
+
+  /*!
+   * \brief Get the index of the audio stream to describe this item by.
+   *
+   * Which stream that is follows the "Language details to display" setting, so the label a
+   * list shows and the key it sorts on are chosen once rather than in each caller.
+   *
+   * \return An index into m_streamDetails, as GetAudioCodec() and friends take
+   */
+  int GetDescribedAudioStreamIndex() const;
   int GetDatabaseId() const;
   CRating GetRating(std::string type = "") const;
   const std::string& GetDefaultRating() const;

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -265,6 +265,8 @@ protected:
     m_settingOriginal = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
         CSettings::SETTING_LOCALE_AUDIOLANGUAGE);
     m_audioLanguageOriginal = g_langInfo.GetAudioLanguage(false).AsBcp47();
+    m_languageDetailsOriginal = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_VIDEOLIBRARY_LANGUAGEDETAILS);
   }
 
   void TearDown() override
@@ -272,6 +274,13 @@ protected:
     CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(
         CSettings::SETTING_LOCALE_AUDIOLANGUAGE, m_settingOriginal);
     g_langInfo.SetAudioLanguage(m_audioLanguageOriginal);
+    DescribeStream(m_languageDetailsOriginal);
+  }
+
+  static void DescribeStream(int languageDetails)
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetInt(
+        CSettings::SETTING_VIDEOLIBRARY_LANGUAGEDETAILS, languageDetails);
   }
 
   static void PreferLanguage(const std::string& language)
@@ -299,8 +308,31 @@ protected:
     return tag;
   }
 
+  // Three tracks that give each setting a different answer: the disc nominates the French one,
+  // the German one is technically the best, and an English speaker would hear the English one.
+  static CVideoInfoTag MakeTagWhereEverySettingDiffers()
+  {
+    CVideoInfoTag tag;
+    for (const auto& [language, codec, channels, flags] :
+         {std::tuple{"ger", "truehd", 8, StreamFlags::FLAG_NONE},
+          std::tuple{"fra", "ac3", 2, StreamFlags::FLAG_DEFAULT},
+          std::tuple{"eng", "dts", 6, StreamFlags::FLAG_NONE}})
+    {
+      auto* audio = new CStreamDetailAudio();
+      audio->m_strLanguage = language;
+      audio->m_strCodec = codec;
+      audio->m_iChannels = channels;
+      audio->m_flags = flags;
+      audio->SetSource(CStreamDetail::MEDIA);
+      tag.m_streamDetails.AddStream(audio);
+    }
+    tag.m_streamDetails.DetermineBestStreams();
+    return tag;
+  }
+
   std::string m_settingOriginal;
   std::string m_audioLanguageOriginal;
+  int m_languageDetailsOriginal{CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER};
 };
 
 TEST_F(AudioSortKeyTester, OrdersByThePreferredLanguageStream)
@@ -332,4 +364,50 @@ TEST_F(AudioSortKeyTester, FallsBackToTheBestStreamWithoutALanguagePreference)
   SortItem sortable;
   tag.ToSortable(sortable, Field::AUDIO_CODEC);
   EXPECT_EQ("truehd", sortable[Field::AUDIO_CODEC].asString());
+}
+
+TEST_F(AudioSortKeyTester, DescribedStreamFollowsTheLanguageDetailsSetting)
+{
+  // Each option names a different one of the three tracks, so a wrong reading of the setting
+  // cannot pass by coincidence.
+  const CVideoInfoTag tag{MakeTagWhereEverySettingDiffers()};
+  PreferLanguage("eng");
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_PLAYER);
+  EXPECT_EQ("eng", tag.m_streamDetails.GetAudioLanguage(tag.GetDescribedAudioStreamIndex()));
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT);
+  EXPECT_EQ("fra", tag.m_streamDetails.GetAudioLanguage(tag.GetDescribedAudioStreamIndex()));
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_BEST);
+  EXPECT_EQ("ger", tag.m_streamDetails.GetAudioLanguage(tag.GetDescribedAudioStreamIndex()));
+}
+
+TEST_F(AudioSortKeyTester, DefaultFallsBackToTheBestStreamWhenNothingIsNominated)
+{
+  // Neither track carries the default flag, so "Default" has nothing to name and the best
+  // stream is the only answer left.
+  const CVideoInfoTag tag{MakeTagWithTwoAudioStreams()};
+  PreferLanguage("eng");
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT);
+  EXPECT_EQ("ger", tag.m_streamDetails.GetAudioLanguage(tag.GetDescribedAudioStreamIndex()));
+}
+
+TEST_F(AudioSortKeyTester, SortKeyFollowsTheLanguageDetailsSetting)
+{
+  // The sort key has to move with the label, or a list orders on a value it does not show.
+  const CVideoInfoTag tag{MakeTagWhereEverySettingDiffers()};
+  PreferLanguage("eng");
+  SortItem sortable;
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_DEFAULT);
+  tag.ToSortable(sortable, Field::AUDIO_CODEC);
+  EXPECT_EQ("ac3", sortable[Field::AUDIO_CODEC].asString());
+  tag.ToSortable(sortable, Field::AUDIO_CHANNELS);
+  EXPECT_EQ(2, sortable[Field::AUDIO_CHANNELS].asInteger());
+
+  DescribeStream(CSettings::VIDEOLIBRARY_LANGUAGE_DETAILS_BEST);
+  tag.ToSortable(sortable, Field::AUDIO_LANGUAGE);
+  EXPECT_EQ("ger", sortable[Field::AUDIO_LANGUAGE].asString());
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#29007 partially synchronised the audio language displayed in the media details for items in the library with that which would be played. There were 3 limitations:
1. StreamFlags - FLAG_DEFAULT, FLAG_ORIGINAL, FLAG_HEARING_IMPAIRED, FLAG_VISUAL_IMPAIRED are not known to the GUI.
2. The choice when the item was watched previouly - this is saved in the settings table in the database and not known to the GUI.
3. Prefer stereo - depends on the live AE sink having a stereo layout which is only known at play time.

#29061 extended the streamdetails table to store the StreamFlags - to tackle limitation 1.

This PR now pulls the two together. It extends the code shared between VideoPlayer and VideoGUIInfo in StreamUtils - to determine the audio track to be both played and displayed.

There were differing options about the GUI changes so I've made a futher change:

1) I've added an option in Settings -> Media -> Videos:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/17143ff6-6f65-450b-8c9e-7fc0f89f4fb7" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/87c589e9-9665-4679-9ccd-12623354a2b7" />

This allows the user to choose which language will be displayed in the GUI. It does not alter the language played.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
