### PR TITLE
[Win32] Move disc probing to later in the initialisation pipeline.

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -220,6 +220,7 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
   CLog::Log(LOGINFO, "[Media Detection] starting service for optical media detection");
   m_DetectDVDType->Create(false);
 #endif
+  m_mediaManager->ScanForPresentMedia();
 
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
@@ -254,6 +255,7 @@ void CServiceManager::DeinitStageThree()
   m_DetectDVDType->StopThread();
   m_DetectDVDType.reset();
 #endif
+  m_mediaManager->StopScanForPresentMedia();
   m_playerCoreFactory.reset();
   m_PVRManager->Deinit();
   m_contextMenuManager->Deinit();

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -25,6 +25,17 @@
 
 bool CWin32StorageProvider::xbevent = false;
 
+namespace
+{
+class CPresentMediaScanner : public CThread
+{
+public:
+  CPresentMediaScanner() : CThread("PresentMediaScanner") {}
+
+  void Process() override { CWin32StorageProvider::ScanDrivesForPresentMedia(); }
+};
+} // namespace
+
 std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
   return std::make_unique<CWin32StorageProvider>();
@@ -39,17 +50,38 @@ void CWin32StorageProvider::Initialize()
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
   else
     CLog::LogF(LOGDEBUG, "No optical drive found.");
+}
 
+void CWin32StorageProvider::ScanForPresentMedia()
+{
 #ifdef HAS_OPTICAL_DRIVE
-  // A disc already present in a drive at startup is added as a source but does
-  // NOT autorun, matching Linux
+  m_presentMediaScanner = std::make_unique<CPresentMediaScanner>();
+  m_presentMediaScanner->Create(false);
+#endif
+}
+
+void CWin32StorageProvider::StopScanForPresentMedia()
+{
+  // Destroying the thread waits for the scan to finish
+  m_presentMediaScanner.reset();
+}
+
+void CWin32StorageProvider::ScanDrivesForPresentMedia()
+{
+#ifdef HAS_OPTICAL_DRIVE
+  std::vector<CMediaSource> vShare;
+  GetDrivesByType(vShare, DVD_DRIVES);
+
   for (const auto& it : vShare)
   {
-    if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) ==
+    if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) !=
         DriveState::CLOSED_MEDIA_PRESENT)
-    {
-      CServiceBroker::GetMediaManager().AddOpticalSource(it.strPath);
-    }
+      continue;
+
+    // Read the disc here, off the application thread. Adding the source is the application
+    // thread's to do, so the pump does it once this has cached the answers.
+    CServiceBroker::GetMediaManager().GetDiskLabel(it.strPath);
+    QueueStorageEvent(StorageEventType::PRESENT_AT_STARTUP, GetStorageDevice(it.strPath));
   }
 #endif
 }
@@ -429,6 +461,13 @@ bool CWin32StorageProvider::PumpDriveChangeEvents(IStorageEventsCallback* callba
           break;
         case StorageEventType::UNSAFELY_REMOVED:
           callback->OnStorageUnsafelyRemoved(ev.device);
+          break;
+        case StorageEventType::PRESENT_AT_STARTUP:
+#ifdef HAS_OPTICAL_DRIVE
+          // A disc already present in a drive at startup is added as a source but does
+          // NOT autorun, matching Linux
+          CServiceBroker::GetMediaManager().AddOpticalSource(ev.device.path);
+#endif
           break;
       }
     }

--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -10,7 +10,9 @@
 
 #include "storage/IStorageProvider.h"
 #include "threads/CriticalSection.h"
+#include "threads/Thread.h"
 
+#include <memory>
 #include <vector>
 
 #include <Cfgmgr32.h>
@@ -31,6 +33,13 @@ public:
   virtual void Initialize();
   virtual void Stop() { }
 
+  virtual void ScanForPresentMedia();
+  virtual void StopScanForPresentMedia();
+
+  // Reads the discs the drives hold at startup. Runs on m_presentMediaScanner, and so touches
+  // nothing of this object's own.
+  static void ScanDrivesForPresentMedia();
+
   virtual void GetLocalDrives(std::vector<CMediaSource>& localDrives);
   virtual void GetRemovableDrives(std::vector<CMediaSource>& removableDrives);
   virtual std::string GetFirstOpticalDeviceFileName();
@@ -47,6 +56,8 @@ public:
     ADDED,
     SAFELY_REMOVED,
     UNSAFELY_REMOVED,
+    //! A disc that was already in the drive when Kodi started
+    PRESENT_AT_STARTUP,
   };
 
   // Build a StorageDevice descriptor from a drive root (eg. "D:")
@@ -73,4 +84,6 @@ private:
 
   inline static std::vector<StorageEvent> m_events;
   inline static CCriticalSection m_eventsSection;
+
+  std::unique_ptr<CThread> m_presentMediaScanner;
 };

--- a/xbmc/storage/IStorageProvider.h
+++ b/xbmc/storage/IStorageProvider.h
@@ -70,6 +70,22 @@ public:
   virtual void Initialize() = 0;
   virtual void Stop() = 0;
 
+  /*!
+   * \brief Start making the media already in the drives at startup available as sources.
+   *
+   * Reading a disc spins the drive up and opens it with two libraries in turn, so a platform
+   * that answers here does the reading in the background and the sources appear once it has.
+   * Platforms whose media detection runs on a thread already have nothing to do here.
+   */
+  virtual void ScanForPresentMedia() {}
+
+  /*!
+   * \brief Wait for any scan started by ScanForPresentMedia() to finish.
+   *
+   * Called before the services the scan uses (GUI, localized strings, disc caches) go away.
+   */
+  virtual void StopScanForPresentMedia() {}
+
   virtual void GetLocalDrives(std::vector<CMediaSource>& localDrives) = 0;
   virtual void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) = 0;
   virtual std::string GetFirstOpticalDeviceFileName()

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -75,6 +75,20 @@ void CMediaManager::Stop()
   m_platformStorage.reset();
 }
 
+void CMediaManager::ScanForPresentMedia()
+{
+  std::unique_lock lock(m_CritSecStorageProvider);
+  if (m_platformStorage)
+    m_platformStorage->ScanForPresentMedia();
+}
+
+void CMediaManager::StopScanForPresentMedia()
+{
+  std::unique_lock lock(m_CritSecStorageProvider);
+  if (m_platformStorage)
+    m_platformStorage->StopScanForPresentMedia();
+}
+
 void CMediaManager::Initialize()
 {
   if (!m_platformStorage)
@@ -473,6 +487,7 @@ bool CMediaManager::IsAudio(const std::string& devicePath)
 bool CMediaManager::HasOpticalDrive()
 {
 #ifdef HAS_OPTICAL_DRIVE
+  std::unique_lock waitLock(m_muAutoSource);
   if (!m_strFirstAvailDrive.empty())
     return true;
 #endif
@@ -558,9 +573,12 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
 
   std::string mediaPath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath);
 
-  auto cached = m_mapDiscInfo.find(mediaPath);
-  if (cached != m_mapDiscInfo.end())
-    return cached->second.name;
+  {
+    std::unique_lock lock(m_discInfoSection);
+    const auto cached = m_mapDiscInfo.find(mediaPath);
+    if (cached != m_mapDiscInfo.end())
+      return cached->second.name;
+  }
 
   // try to minimize the chance of a "device not ready" dialog
   std::string drivePath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath, true);
@@ -568,13 +586,9 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
       DriveState::CLOSED_MEDIA_PRESENT)
     return "";
 
-  UTILS::DISCS::DiscInfo info;
-  info = GetDiscInfo(mediaPath);
+  UTILS::DISCS::DiscInfo info{GetCachedDiscInfo(mediaPath)};
   if (!info.name.empty())
-  {
-    m_mapDiscInfo[mediaPath] = info;
     return info.name;
-  }
 
   std::string strDevice = TranslateDevicePath(devicePath);
   WCHAR cVolumenName[128];
@@ -587,7 +601,10 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   g_charsetConverter.wToUTF8(cVolumenName, strDevice);
   info.name = StringUtils::TrimRight(strDevice, " ");
   if (!info.name.empty())
+  {
+    std::unique_lock lock(m_discInfoSection);
     m_mapDiscInfo[mediaPath] = info;
+  }
 
   return info.name;
 #else
@@ -619,8 +636,10 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
   }
 #endif
 
-  UTILS::DISCS::DiscInfo info = GetDiscInfo(mediaPath);
-  if (info.empty())
+  // A cached entry with an unknown type holds only the volume label GetDiskLabel() fell back
+  // to, so it identifies nothing
+  UTILS::DISCS::DiscInfo info = GetCachedDiscInfo(mediaPath);
+  if (info.type == UTILS::DISCS::DiscType::UNKNOWN)
   {
     CLog::Log(LOGDEBUG, "GetDiskUniqueId: Retrieving ID for path {} failed, ID is empty.",
               CURL::GetRedacted(mediaPath));
@@ -703,7 +722,6 @@ std::shared_ptr<IDiscDriveHandler> CMediaManager::GetDiscDriveHandler()
 
 void CMediaManager::SetHasOpticalDrive(bool bstatus)
 {
-  std::unique_lock waitLock(m_muAutoSource);
   m_bOpticalDrivePresent = bstatus;
 }
 
@@ -767,13 +785,22 @@ void CMediaManager::ProcessEvents()
     // so we have to refresh m_strFirstAvailDrive when this happens after Initialize
     // was called (e.x. the disc was inserted after the start of xbmc)
     // else TranslateDevicePath wouldn't give the correct device
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
+    const std::string firstAvailDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstAvailDrive;
+    }
 #elif defined(TARGET_WINDOWS)
     // On Windows, virtual drives can appear or disappear at any time.
     // Re-scan to get the current state of optical drives and update
     // m_bhasoptical and m_strFirstAvailDrive accordingly.
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
-    SetHasOpticalDrive(!m_strFirstAvailDrive.empty());
+    // Other threads (eg. the startup disc scan) read m_strFirstAvailDrive via TranslateDevicePath
+    const std::string firstAvailDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstAvailDrive;
+    }
+    SetHasOpticalDrive(!firstAvailDrive.empty());
 #endif
 #endif
 
@@ -817,8 +844,11 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
   {
 #ifdef TARGET_WINDOWS
     SetHasOpticalDrive(true); // In case drive appeared after startup (eg. virtual drive)
-    if (m_strFirstAvailDrive.empty())
-      m_strFirstAvailDrive = device.path;
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      if (m_strFirstAvailDrive.empty())
+        m_strFirstAvailDrive = device.path;
+    }
     AddOpticalSource(device.path);
 #endif
 
@@ -932,6 +962,26 @@ void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::Storag
       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13022), device.label);
 }
 
+UTILS::DISCS::DiscInfo CMediaManager::GetCachedDiscInfo(const std::string& mediaPath)
+{
+  {
+    std::unique_lock lock(m_discInfoSection);
+    const auto cached = m_mapDiscInfo.find(mediaPath);
+    if (cached != m_mapDiscInfo.end())
+      return cached->second;
+  }
+
+  // Not held while the disc is read, which takes seconds and which another thread may be doing
+  // for another drive
+  UTILS::DISCS::DiscInfo info{GetDiscInfo(mediaPath)};
+  if (info.empty())
+    return info;
+
+  std::unique_lock lock(m_discInfoSection);
+  m_mapDiscInfo[mediaPath] = info;
+  return info;
+}
+
 UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
 {
   UTILS::DISCS::DiscInfo info;
@@ -968,9 +1018,10 @@ void CMediaManager::RemoveDiscInfo(const std::string& devicePath)
 {
   std::string strDevice = TranslateDevicePath(devicePath, false);
 
-  auto it = m_mapDiscInfo.find(strDevice);
-  if (it != m_mapDiscInfo.end())
-    m_mapDiscInfo.erase(it);
+  {
+    std::unique_lock lock(m_discInfoSection);
+    m_mapDiscInfo.erase(strDevice);
+  }
 
 #ifdef HAVE_LIBBLURAY
   CServiceBroker::GetBlurayDiscCache()->ClearDisc(strDevice);

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -15,6 +15,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/DiscsUtils.h"
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <vector>
@@ -43,6 +44,18 @@ public:
 
   void Initialize();
   void Stop();
+
+  /*!
+   * \brief Make the media already in the drives at startup available as sources.
+   *
+   * The platform decides how: where a drive has to spin up first, it does not happen here.
+   */
+  void ScanForPresentMedia();
+
+  /*!
+   * \brief Wait for the scan started by ScanForPresentMedia() to finish.
+   */
+  void StopScanForPresentMedia();
 
   void LoadSources();
   bool SaveSources();
@@ -136,7 +149,7 @@ protected:
 #ifdef HAS_OPTICAL_DRIVE
   std::map<std::string,MEDIA_DETECT::CCdInfo*> m_mapCdInfo;
 #endif
-  bool m_bOpticalDrivePresent;
+  std::atomic<bool> m_bOpticalDrivePresent;
   std::string m_strFirstAvailDrive;
 
 private:
@@ -166,7 +179,17 @@ private:
 #endif
 
   void RemoveDiscInfo(const std::string& devicePath);
+
+  /*!
+   * \brief The disc in a drive, read on first ask and remembered until the drive is emptied.
+   * \param[in] mediaPath The path the disc is mounted at.
+   * \return What the disc says about itself, empty where it is not a disc Kodi recognizes.
+   */
+  UTILS::DISCS::DiscInfo GetCachedDiscInfo(const std::string& mediaPath);
+
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
+  //! Guards the cache, which the startup scan fills while the application thread reads it
+  CCriticalSection m_discInfoSection;
 #ifdef HAVE_LIBBLURAY
   HasBlurayPlaylist m_hasBlurayPlaylist{HasBlurayPlaylist::UNKNOWN};
 #endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Moves disc probing later.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Alternative to #29164.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
