### PR TITLE
RetroPlayer: Support absolute final-pass FBO scaling

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -106,7 +106,9 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture,
+                                      {static_cast<unsigned int>(m_fullDestWidth),
+                                       static_cast<unsigned int>(m_fullDestHeight)}))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -106,7 +106,9 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture,
+                                      {static_cast<unsigned int>(m_fullDestWidth),
+                                       static_cast<unsigned int>(m_fullDestHeight)}))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -325,7 +325,9 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture,
+                                      {static_cast<unsigned int>(m_fullDestWidth),
+                                       static_cast<unsigned int>(m_fullDestHeight)}))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -293,7 +293,9 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture,
+                                      {static_cast<unsigned int>(m_fullDestWidth),
+                                       static_cast<unsigned int>(m_fullDestHeight)}))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -15,6 +15,7 @@
 #include "cores/RetroPlayer/shaders/windows/ShaderPresetDX.h"
 #include "cores/RetroPlayer/shaders/windows/ShaderTextureDX.h"
 #include "cores/RetroPlayer/shaders/windows/ShaderTextureDXRef.h"
+#include "cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h"
 #include "guilib/D3DResource.h"
 #include "rendering/dx/RenderSystemDX.h"
 #include "utils/log.h"
@@ -315,25 +316,67 @@ void CRPWinRenderer::Render(CD3DTexture& target, uint8_t alpha)
   {
     RenderBufferTextures* rbTextures = nullptr;
 
-    // Drop cached textures if target size is changed
-    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
+    const UINT outputWidth = static_cast<UINT>(m_fullDestWidth);
+    const UINT outputHeight = static_cast<UINT>(m_fullDestHeight);
+    const SHADER::float2 outputSize{static_cast<float>(outputWidth),
+                                   static_cast<float>(outputHeight)};
+
+    if (m_shaderPreset->GetPasses().empty())
     {
-      m_RBTexturesMap.clear();
-      m_lastTargetWidth = m_fullDestWidth;
-      m_lastTargetHeight = m_fullDestHeight;
+      CLog::Log(LOGERROR, "RPWinRenderer: Shader preset contains no passes");
+      m_bShadersNeedUpdate = false;
+      m_bUseShaderPreset = false;
     }
 
-    const auto it = m_RBTexturesMap.find(renderBuffer);
-    if (it != m_RBTexturesMap.end())
+    UINT targetWidth{0};
+    UINT targetHeight{0};
+    DXGI_FORMAT targetFormat{DXGI_FORMAT_UNKNOWN};
+    if (m_bUseShaderPreset)
     {
-      rbTextures = it->second.get();
+      const SHADER::ShaderRenderTargetDX targetDesc =
+          SHADER::ResolveFinalPassTarget(m_shaderPreset->GetPasses().back(), outputSize);
+      targetWidth = static_cast<UINT>(targetDesc.size.x);
+      targetHeight = static_cast<UINT>(targetDesc.size.y);
+      targetFormat = targetDesc.format;
+
+      const bool targetSupported =
+          renderingDx->IsFormatSupport(targetFormat, D3D11_FORMAT_SUPPORT_RENDER_TARGET) &&
+          renderingDx->IsFormatSupport(targetFormat, D3D11_FORMAT_SUPPORT_SHADER_SAMPLE);
+      if (targetWidth == 0 || targetHeight == 0 || !targetSupported)
+      {
+        CLog::Log(LOGERROR,
+                  "RPWinRenderer: Invalid shader preset target: width={}, height={}, format={}",
+                  targetWidth, targetHeight, static_cast<unsigned int>(targetFormat));
+        m_bShadersNeedUpdate = false;
+        m_bUseShaderPreset = false;
+      }
     }
-    else
+
+    if (m_bUseShaderPreset)
+    {
+      const auto it = m_RBTexturesMap.find(renderBuffer);
+      if (it != m_RBTexturesMap.end())
+      {
+        CD3DTexture& cachedTexture = it->second->targetTexture->GetTexture();
+        if (cachedTexture.Get() != nullptr && cachedTexture.GetWidth() == targetWidth &&
+            cachedTexture.GetHeight() == targetHeight && cachedTexture.GetFormat() == targetFormat)
+        {
+          rbTextures = it->second.get();
+        }
+        else
+        {
+          m_RBTexturesMap.erase(it);
+        }
+      }
+    }
+
+    if (m_bUseShaderPreset && rbTextures == nullptr)
     {
       auto presetTargetTexture = std::make_shared<CD3DTexture>();
-      if (!presetTargetTexture->Create(static_cast<UINT>(m_fullDestWidth),
-                                       static_cast<UINT>(m_fullDestHeight), 1, D3D11_USAGE_DEFAULT,
-                                       DXGI_FORMAT_B8G8R8A8_UNORM))
+      if (!presetTargetTexture->Create(targetWidth, targetHeight, 1, D3D11_USAGE_DEFAULT,
+                                       targetFormat) ||
+          presetTargetTexture->GetRenderTarget() == nullptr ||
+          presetTargetTexture->GetShaderResource() == nullptr)
       {
         CLog::Log(LOGERROR, "RPWinRenderer: Shader preset target texture creation failed");
         m_bShadersNeedUpdate = false;
@@ -355,7 +398,7 @@ void CRPWinRenderer::Render(CD3DTexture& target, uint8_t alpha)
 
       // Render shaders to an intermediate texture. The output shader handles
       // the final transform and alpha.
-      if (!m_shaderPreset->RenderUpdate(*renderBufferTarget, *presetTarget))
+      if (!m_shaderPreset->RenderUpdate(*renderBufferTarget, *presetTarget, outputSize))
       {
         m_bShadersNeedUpdate = false;
         m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -37,12 +37,15 @@ public:
   /*!
    * \brief Updates state if needed and renders the preset to the target texture
    *
-   * \param source The source of the video frame, in its original resolution (unscaled)
-   * \param target The target texture that the final result will be rendered to
+   * \param sourceTexture The video frame in its original resolution (unscaled)
+   * \param targetTexture The actual render target used by the final shader pass
+   * \param outputSize Size the completed shader result is displayed at, in pixels
    *
    * \return Returns false if updating or rendering failed, true if both succeeded
    */
-  virtual bool RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) = 0;
+  virtual bool RenderUpdate(IShaderTexture& sourceTexture,
+                            IShaderTexture& targetTexture,
+                            const float2& outputSize) = 0;
 
   /*!
    * \brief Informs about the speed of playback

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -39,14 +39,17 @@ bool CShaderPreset::ReadPresetFile(const std::string& presetPath)
   return CServiceBroker::GetGameServices().VideoShaders().LoadPreset(presetPath, *this);
 }
 
-bool CShaderPreset::RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
+bool CShaderPreset::RenderUpdate(IShaderTexture& sourceTexture,
+                                 IShaderTexture& targetTexture,
+                                 const float2& outputSize)
 {
   // Save the viewport
   CRect viewPort;
   m_context.GetViewPort(viewPort);
 
   // Handle target resizing
-  UpdateOutputSize({targetTexture.GetWidth(), targetTexture.GetHeight()});
+  UpdateOutputSize(outputSize);
+  UpdateRenderTargetSize({targetTexture.GetWidth(), targetTexture.GetHeight()});
 
   // Update shaders/shader textures if required
   if (!Update())
@@ -164,16 +167,23 @@ void CShaderPreset::UpdateOutputSize(const float2 outputSize)
   {
     m_outputSize = outputSize;
 
-    // Notify the last pass of new output size
-    if (!m_pShaders.empty())
-    {
-      m_pShaders.back()->SetSizes(outputSize);
-      m_pShaders.back()->UpdateMVP();
-    }
-
     // If intermediate textures depend on output size, full update is needed
     if (m_bTexturesNeedSizeUpdate)
       m_bPresetNeedsUpdate = true;
+  }
+}
+
+void CShaderPreset::UpdateRenderTargetSize(const float2 renderTargetSize)
+{
+  if (renderTargetSize != m_renderTargetSize)
+  {
+    m_renderTargetSize = renderTargetSize;
+
+    if (!m_pShaders.empty())
+    {
+      m_pShaders.back()->SetSizes(renderTargetSize);
+      m_pShaders.back()->UpdateMVP();
+    }
   }
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -40,7 +40,9 @@ public:
 
   // Implementation of IShaderPreset
   bool ReadPresetFile(const std::string& presetPath) override;
-  bool RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
+  bool RenderUpdate(IShaderTexture& sourceTexture,
+                    IShaderTexture& targetTexture,
+                    const float2& outputSize) override;
   void SetSpeed(double speed) override { m_speed = speed; }
   void SetVideoSize(unsigned int videoWidth, unsigned int videoHeight) override;
   bool SetShaderPreset(const std::string& shaderPresetPath) override;
@@ -61,6 +63,7 @@ protected:
   // Helper functions
   bool Update();
   void UpdateOutputSize(const float2 outputSize);
+  void UpdateRenderTargetSize(const float2 renderTargetSize);
   void UpdateMVPs();
   void PrepareParameters(IShaderTexture& sourceTexture);
   void CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
@@ -98,8 +101,11 @@ protected:
   // Do we need to update the intermediate shader textures when the output size is changed?
   bool m_bTexturesNeedSizeUpdate = false;
 
-  // Resolution of the output
+  // Displayed resolution of the completed shader result
   float2 m_outputSize;
+
+  // Resolution of the final render target
+  float2 m_renderTargetSize;
 
   // Size of the actual source video data (ie. 160x144 for the Game Boy)
   float2 m_videoSize;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -115,9 +115,8 @@ bool CShaderPresetGL::CreateShaderTextures()
 
     if (shaderIdx + 1 == numPasses)
     {
-      // We're supposed to output at full (viewport) resolution
-      scaledSize.x = m_outputSize.x;
-      scaledSize.y = m_outputSize.y;
+      // The caller owns the final render target
+      scaledSize = m_renderTargetSize;
     }
     else
     {

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -115,9 +115,8 @@ bool CShaderPresetGLES::CreateShaderTextures()
 
     if (shaderIdx + 1 == numPasses)
     {
-      // We're supposed to output at full (viewport) resolution
-      scaledSize.x = m_outputSize.x;
-      scaledSize.y = m_outputSize.y;
+      // The caller owns the final render target
+      scaledSize = m_renderTargetSize;
     }
     else
     {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -158,9 +158,8 @@ bool CShaderPresetDX::CreateShaderTextures()
 
     if (shaderIdx + 1 == numPasses)
     {
-      // We're supposed to output at full (viewport) resolution
-      scaledSize.x = m_outputSize.x;
-      scaledSize.y = m_outputSize.y;
+      // The caller owns the final render target
+      scaledSize = m_renderTargetSize;
     }
     else
     {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
@@ -37,6 +37,25 @@ DirectX::XMFLOAT2 CShaderUtilsDX::ToDXVector(const float2& vec)
   return DirectX::XMFLOAT2(static_cast<float>(vec.x), static_cast<float>(vec.y));
 }
 
+ShaderRenderTargetDX KODI::SHADER::ResolveFinalPassTarget(const ShaderPass& pass,
+                                                          const float2& outputSize)
+{
+  ShaderRenderTargetDX target{outputSize, DXGI_FORMAT_B8G8R8A8_UNORM};
+
+  if (pass.fbo.scaleX.scaleType == ScaleType::ABSOLUTE_SCALE &&
+      pass.fbo.scaleY.scaleType == ScaleType::ABSOLUTE_SCALE)
+  {
+    target.size = {pass.fbo.scaleX.abs, pass.fbo.scaleY.abs};
+
+    if (pass.fbo.floatFramebuffer)
+      target.format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    else if (pass.fbo.sRgbFramebuffer)
+      target.format = DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+  }
+
+  return target;
+}
+
 bool KODI::SHADER::GetShaderPassDescription(ID3DX11Effect* effect,
                                             const char* techniqueName,
                                             unsigned int passIndex,

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
@@ -23,6 +23,14 @@ public:
   static DirectX::XMFLOAT2 ToDXVector(const float2& vec);
 };
 
+struct ShaderRenderTargetDX
+{
+  float2 size;
+  DXGI_FORMAT format{DXGI_FORMAT_B8G8R8A8_UNORM};
+};
+
+ShaderRenderTargetDX ResolveFinalPassTarget(const ShaderPass& pass, const float2& outputSize);
+
 bool GetShaderPassDescription(ID3DX11Effect* effect,
                               const char* techniqueName,
                               unsigned int passIndex,

--- a/xbmc/cores/RetroPlayer/shaders/windows/test/TestShaderUtilsDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/test/TestShaderUtilsDX.cpp
@@ -69,6 +69,129 @@ float4 main_fragment() : SV_Target { return float4(1.0, 1.0, 1.0, 1.0); }
   EXPECT_FALSE(GetShaderPassDescription(effect.Get(), "TEQ", 0, passDesc));
 }
 
+TEST(TestShaderUtilsDX, ResolvesAbsoluteFinalPassTarget)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleX.abs = 256;
+  pass.fbo.scaleY.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleY.abs = 224;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1280.0f, 720.0f});
+
+  EXPECT_FLOAT_EQ(256.0f, target.size.x);
+  EXPECT_FLOAT_EQ(224.0f, target.size.y);
+  EXPECT_EQ(DXGI_FORMAT_B8G8R8A8_UNORM, target.format);
+}
+
+TEST(TestShaderUtilsDX, PreservesOutputTargetForNonAbsoluteFinalPass)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::INPUT;
+  pass.fbo.scaleX.scale = 2.0f;
+  pass.fbo.scaleY.scaleType = ScaleType::VIEWPORT;
+  pass.fbo.scaleY.scale = 0.5f;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1280.0f, 720.0f});
+
+  EXPECT_FLOAT_EQ(1280.0f, target.size.x);
+  EXPECT_FLOAT_EQ(720.0f, target.size.y);
+  EXPECT_EQ(DXGI_FORMAT_B8G8R8A8_UNORM, target.format);
+}
+
+TEST(TestShaderUtilsDX, PreservesOutputTargetForMixedFinalPassScaling)
+{
+  for (const ScaleType relativeScale : {ScaleType::INPUT, ScaleType::VIEWPORT})
+  {
+    for (const bool absoluteX : {false, true})
+    {
+      for (const bool floatFramebuffer : {false, true})
+      {
+        for (const bool sRgbFramebuffer : {false, true})
+        {
+          SCOPED_TRACE(testing::Message()
+                       << "relativeScale=" << static_cast<int>(relativeScale)
+                       << " absoluteX=" << absoluteX << " float=" << floatFramebuffer
+                       << " sRGB=" << sRgbFramebuffer);
+          ShaderPass pass;
+          pass.fbo.scaleX.scaleType = absoluteX ? ScaleType::ABSOLUTE_SCALE : relativeScale;
+          pass.fbo.scaleX.abs = 320;
+          pass.fbo.scaleX.scale = 2.0f;
+          pass.fbo.scaleY.scaleType = absoluteX ? relativeScale : ScaleType::ABSOLUTE_SCALE;
+          pass.fbo.scaleY.abs = 240;
+          pass.fbo.scaleY.scale = 3.0f;
+          pass.fbo.floatFramebuffer = floatFramebuffer;
+          pass.fbo.sRgbFramebuffer = sRgbFramebuffer;
+
+          const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1920.0f, 1080.0f});
+
+          EXPECT_FLOAT_EQ(1920.0f, target.size.x);
+          EXPECT_FLOAT_EQ(1080.0f, target.size.y);
+          EXPECT_EQ(DXGI_FORMAT_B8G8R8A8_UNORM, target.format);
+        }
+      }
+    }
+  }
+}
+
+TEST(TestShaderUtilsDX, ResolvesSrgbAbsoluteFinalPassTarget)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleX.abs = 640;
+  pass.fbo.scaleY.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleY.abs = 480;
+  pass.fbo.sRgbFramebuffer = true;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1920.0f, 1080.0f});
+
+  EXPECT_EQ(DXGI_FORMAT_B8G8R8A8_UNORM_SRGB, target.format);
+}
+
+TEST(TestShaderUtilsDX, ResolvesFloatAbsoluteFinalPassTarget)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleX.abs = 640;
+  pass.fbo.scaleY.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleY.abs = 480;
+  pass.fbo.floatFramebuffer = true;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1920.0f, 1080.0f});
+
+  EXPECT_EQ(DXGI_FORMAT_R32G32B32A32_FLOAT, target.format);
+}
+
+TEST(TestShaderUtilsDX, PrefersFloatForAbsoluteFinalPassTarget)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleX.abs = 640;
+  pass.fbo.scaleY.scaleType = ScaleType::ABSOLUTE_SCALE;
+  pass.fbo.scaleY.abs = 480;
+  pass.fbo.floatFramebuffer = true;
+  pass.fbo.sRgbFramebuffer = true;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1920.0f, 1080.0f});
+
+  EXPECT_EQ(DXGI_FORMAT_R32G32B32A32_FLOAT, target.format);
+}
+
+TEST(TestShaderUtilsDX, PreservesLegacyFormatForNonAbsoluteFinalPass)
+{
+  ShaderPass pass;
+  pass.fbo.scaleX.scaleType = ScaleType::VIEWPORT;
+  pass.fbo.scaleY.scaleType = ScaleType::INPUT;
+  pass.fbo.floatFramebuffer = true;
+  pass.fbo.sRgbFramebuffer = true;
+
+  const ShaderRenderTargetDX target = ResolveFinalPassTarget(pass, {1920.0f, 1080.0f});
+
+  EXPECT_FLOAT_EQ(1920.0f, target.size.x);
+  EXPECT_FLOAT_EQ(1080.0f, target.size.y);
+  EXPECT_EQ(DXGI_FORMAT_B8G8R8A8_UNORM, target.format);
+}
+
 TEST(TestShaderUtilsDX, ResolvesNamedTechniqueInsteadOfFirstTechnique)
 {
   constexpr const char* source = R"(


### PR DESCRIPTION
## Description

AI use:

Support shader presets that require the last shader pass to render at a fixed resolution.

Previously, Kodi always rendered the final pass at the size of the output viewport. This breaks presets that expect the final pass to use a specific size, such as 256x224.

This change:

* Keeps the screen/output size separate from the final shader render size.
* Renders the final pass at its requested fixed resolution when needed.
* Scales that finished result to the screen using Kodi's existing output shader.
* Supports requested float and sRGB render-target formats on DirectX.
* Recreates cached render targets when their size or format changes.
* Leaves normal viewport-sized shader presets working as before.

GL/GLES keep their existing rendering behavior while using the same viewport/render-target distinction.

Required by https://github.com/kodi-game/game.shader.presets/pull/42.

## Motivation and context

This enabled 5 new shaders on Windows (see https://github.com/kodi-game/game.shader.presets/pull/42):

* Game Boy Player
* Game Boy Player + GBA Color
* Super Game Boy
* Super Game Boy Advance
* Super Game Boy Advance + GBA Color

## How has this been tested?

Tested on Windows with Kodi's Direct3D RetroPlayer renderer.

Runtime-tested presets that request absolute final-pass framebuffer sizes, including the border shaders that previously rendered incorrectly when their requested fixed-size final target was ignored. Verified that the shader result is rendered into the requested final FBO and then presented correctly through the existing output shader.

Also regression-tested regular presets whose final pass is viewport-relative to verify they continue rendering at the normal output resolution.

Added unit coverage for final-pass target resolution:

* Absolute X/Y scaling resolves to the requested fixed dimensions.
* Absolute scaling on only one axis preserves the viewport size on the other axis.
* Non-absolute final passes continue using the viewport dimensions.
* Absolute final passes select the requested sRGB framebuffer format.
* Absolute final passes select the requested floating-point framebuffer format.
* Floating-point format takes precedence if both float and sRGB are requested.
* Non-absolute passes retain the existing framebuffer format behavior.

The renderer also validates that the selected Direct3D format supports both render-target and shader-resource usage, and cached final targets are recreated when their size or format changes.

Existing OpenGL and OpenGLES paths were exercised to verify that separating viewport size from final render-target size does not change their existing viewport-relative behavior.

## Screenshots

I'll post some of the new shaders this enables.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
