### PR TITLE
RetroPlayer: Harden DirectX shader resource handling

### DIFF
--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -76,8 +76,9 @@ public:
    * \param pShaderTextures Intermediate textures used for all shader passes
    * \param pShaders All shader passes
    * \param frameCount Number of frames that have passed
+   * \return False if parameter preparation failed, true otherwise
    */
-  virtual void PrepareParameters(
+  virtual bool PrepareParameters(
       IShaderTexture& sourceTexture,
       const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
       const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -52,7 +52,8 @@ bool CShaderPreset::RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& 
   if (!Update())
     return false;
 
-  PrepareParameters(sourceTexture);
+  if (!PrepareParameters(sourceTexture))
+    return false;
 
   // Apply all passes
   IShaderTexture* currentTexture = &sourceTexture;
@@ -183,16 +184,18 @@ void CShaderPreset::UpdateMVPs()
     videoShader->UpdateMVP();
 }
 
-void CShaderPreset::PrepareParameters(IShaderTexture& sourceTexture)
+bool CShaderPreset::PrepareParameters(IShaderTexture& sourceTexture)
 {
   // Prepare parameters for all shader passes
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     std::unique_ptr<IShader>& videoShader = m_pShaders[shaderIdx];
-    videoShader->PrepareParameters(sourceTexture, m_pShaderTextures, m_pShaders,
-                                   static_cast<uint64_t>(m_frameCount));
+    if (!videoShader->PrepareParameters(sourceTexture, m_pShaderTextures, m_pShaders,
+                                        static_cast<uint64_t>(m_frameCount)))
+      return false;
   }
+  return true;
 }
 
 void CShaderPreset::CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -62,7 +62,7 @@ protected:
   bool Update();
   void UpdateOutputSize(const float2 outputSize);
   void UpdateMVPs();
-  void PrepareParameters(IShaderTexture& sourceTexture);
+  bool PrepareParameters(IShaderTexture& sourceTexture);
   void CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
                            const float2& prevSize,
                            float2& scaledSize);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -211,7 +211,7 @@ void CShaderGL::SetSizes(const float2& nextSize,
     m_inputTextureSize = prevTextureSize;
 }
 
-void CShaderGL::PrepareParameters(
+bool CShaderGL::PrepareParameters(
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -263,6 +263,7 @@ void CShaderGL::PrepareParameters(
   m_TexCoords[3][1] = 0.0f;
 
   UpdateUniformInputs(sourceTexture, pShaderTextures, pShaders, frameCount);
+  return true;
 }
 
 void CShaderGL::UpdateMVP()

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -42,7 +42,7 @@ public:
   void SetSizes(const float2& nextSize,
                 const float2& prevSize = float2{},
                 const float2& prevTextureSize = float2{}) override;
-  void PrepareParameters(IShaderTexture& sourceTexture,
+  bool PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -207,7 +207,7 @@ void CShaderGLES::SetSizes(const float2& nextSize,
     m_inputTextureSize = prevTextureSize;
 }
 
-void CShaderGLES::PrepareParameters(
+bool CShaderGLES::PrepareParameters(
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -259,6 +259,7 @@ void CShaderGLES::PrepareParameters(
   m_TexCoords[3][1] = 0.0f;
 
   UpdateUniformInputs(sourceTexture, pShaderTextures, pShaders, frameCount);
+  return true;
 }
 
 void CShaderGLES::UpdateMVP()

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -42,7 +42,7 @@ public:
   void SetSizes(const float2& nextSize,
                 const float2& prevSize = float2{},
                 const float2& prevTextureSize = float2{}) override;
-  void PrepareParameters(IShaderTexture& sourceTexture,
+  bool PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
@@ -167,7 +167,11 @@ void CRPWinShader::SetTarget(CD3DTexture* target)
 
 bool CRPWinOutputShader::Create(RETRO::SCALINGMETHOD scalingMethod)
 {
-  CreateVertexBuffer(4, sizeof(CUSTOMVERTEX));
+  if (!CreateVertexBuffer(4, sizeof(CUSTOMVERTEX)))
+  {
+    CLog::LogF(LOGERROR, "Failed to create output shader buffers");
+    return false;
+  }
 
   DefinesMap defines;
   switch (scalingMethod)
@@ -204,12 +208,14 @@ void CRPWinOutputShader::Render(CD3DTexture& sourceTexture,
                                 unsigned int range /* = 0 */,
                                 uint8_t alpha /* = 0xFF */)
 {
-  PrepareParameters(sourceTexture.GetWidth(), sourceTexture.GetHeight(), sourceRect, points);
+  if (!PrepareParameters(sourceTexture.GetWidth(), sourceTexture.GetHeight(), sourceRect, points))
+    return;
+
   SetShaderParameters(sourceTexture, range, alpha, viewPort);
   Execute({&target}, 4);
 }
 
-void CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
+bool CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
                                            unsigned int sourceHeight,
                                            CRect sourceRect,
                                            const KODI::RETRO::ViewportCoordinates& points)
@@ -221,50 +227,53 @@ void CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
   if (m_sourceWidth != sourceWidth || m_sourceHeight != sourceHeight ||
       m_sourceRect != sourceRect || changed)
   {
-    m_sourceWidth = sourceWidth;
-    m_sourceHeight = sourceHeight;
-    m_sourceRect = sourceRect;
-
-    for (unsigned int i = 0; i < 4; ++i)
-      m_destPoints[i] = points[i];
-
     CUSTOMVERTEX* v = nullptr;
-    LockVertexBuffer(static_cast<void**>(static_cast<void*>(&v)));
+    if (!LockVertexBuffer(static_cast<void**>(static_cast<void*>(&v))))
+      return false;
 
-    v[0].x = m_destPoints[0].x;
-    v[0].y = m_destPoints[0].y;
+    v[0].x = points[0].x;
+    v[0].y = points[0].y;
     v[0].z = 0.0f;
-    v[0].tu = m_sourceRect.x1 / m_sourceWidth;
-    v[0].tv = m_sourceRect.y1 / m_sourceHeight;
+    v[0].tu = sourceRect.x1 / sourceWidth;
+    v[0].tv = sourceRect.y1 / sourceHeight;
     v[0].tu2 = 0.0f;
     v[0].tv2 = 0.0f;
 
-    v[1].x = m_destPoints[1].x;
-    v[1].y = m_destPoints[1].y;
+    v[1].x = points[1].x;
+    v[1].y = points[1].y;
     v[1].z = 0.0f;
-    v[1].tu = m_sourceRect.x2 / m_sourceWidth;
-    v[1].tv = m_sourceRect.y1 / m_sourceHeight;
+    v[1].tu = sourceRect.x2 / sourceWidth;
+    v[1].tv = sourceRect.y1 / sourceHeight;
     v[1].tu2 = 1.0f;
     v[1].tv2 = 0.0f;
 
-    v[2].x = m_destPoints[2].x;
-    v[2].y = m_destPoints[2].y;
+    v[2].x = points[2].x;
+    v[2].y = points[2].y;
     v[2].z = 0.0f;
-    v[2].tu = m_sourceRect.x2 / m_sourceWidth;
-    v[2].tv = m_sourceRect.y2 / m_sourceHeight;
+    v[2].tu = sourceRect.x2 / sourceWidth;
+    v[2].tv = sourceRect.y2 / sourceHeight;
     v[2].tu2 = 1.0f;
     v[2].tv2 = 1.0f;
 
-    v[3].x = m_destPoints[3].x;
-    v[3].y = m_destPoints[3].y;
+    v[3].x = points[3].x;
+    v[3].y = points[3].y;
     v[3].z = 0.0f;
-    v[3].tu = m_sourceRect.x1 / m_sourceWidth;
-    v[3].tv = m_sourceRect.y2 / m_sourceHeight;
+    v[3].tu = sourceRect.x1 / sourceWidth;
+    v[3].tv = sourceRect.y2 / sourceHeight;
     v[3].tu2 = 0.0f;
     v[3].tv2 = 1.0f;
 
-    UnlockVertexBuffer();
+    if (!UnlockVertexBuffer())
+      return false;
+
+    // Cache only successful updates so the output shader retries after failure
+    m_sourceWidth = sourceWidth;
+    m_sourceHeight = sourceHeight;
+    m_sourceRect = sourceRect;
+    m_destPoints = points;
   }
+
+  return true;
 }
 
 void CRPWinOutputShader::SetShaderParameters(CD3DTexture& sourceTexture,

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -67,7 +67,7 @@ public:
               uint8_t alpha = 0xFF);
 
 private:
-  void PrepareParameters(unsigned int sourceWidth,
+  bool PrepareParameters(unsigned int sourceWidth,
                          unsigned int sourceHeight,
                          CRect sourceRect,
                          const KODI::RETRO::ViewportCoordinates& points);

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -25,11 +25,7 @@ using namespace KODI::SHADER;
 
 CShaderDX::CShaderDX() = default;
 
-CShaderDX::~CShaderDX()
-{
-  if (m_pInputBuffer != nullptr)
-    m_pInputBuffer->Release();
-}
+CShaderDX::~CShaderDX() = default;
 
 bool CShaderDX::Create(unsigned int passIdx,
                        std::string passAlias,
@@ -114,7 +110,7 @@ void CShaderDX::SetSizes(const float2& nextSize,
     m_inputTextureSize = prevTextureSize;
 }
 
-void CShaderDX::PrepareParameters(
+bool CShaderDX::PrepareParameters(
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -123,8 +119,9 @@ void CShaderDX::PrepareParameters(
   // Set destination rectangle size
   m_destSize = m_outputSize;
 
-  CUSTOMVERTEX* v;
-  LockVertexBuffer(reinterpret_cast<void**>(&v));
+  CUSTOMVERTEX* v = nullptr;
+  if (!LockVertexBuffer(reinterpret_cast<void**>(&v)))
+    return false;
 
   // top left
   v[0].x = -m_outputSize.x / 2;
@@ -164,8 +161,10 @@ void CShaderDX::PrepareParameters(
   v[3].tu2 = 0.0f;
   v[3].tv2 = 1.0f;
 
-  UnlockVertexBuffer();
-  UpdateInputBuffer(frameCount);
+  if (!UnlockVertexBuffer())
+    return false;
+
+  return UpdateInputBuffer(frameCount);
 }
 
 void CShaderDX::UpdateMVP()
@@ -196,30 +195,45 @@ bool CShaderDX::CreateInputBuffer()
                                  D3D11_CPU_ACCESS_WRITE);
   D3D11_SUBRESOURCE_DATA initInputSubresource = {&inputInitData, 0, 0};
 
-  if (FAILED(pDevice->CreateBuffer(&cbInputDesc, &initInputSubresource, &m_pInputBuffer)))
+  Microsoft::WRL::ComPtr<ID3D11Buffer> inputBuffer;
+  const HRESULT result =
+      pDevice->CreateBuffer(&cbInputDesc, &initInputSubresource, inputBuffer.GetAddressOf());
+  if (FAILED(result))
   {
-    CLog::Log(LOGERROR, "CShaderDX::CreateInputBuffer: Failed to create constant buffer for video "
-                        "shader input data");
+    CLog::Log(LOGERROR,
+              "CShaderDX::CreateInputBuffer: Failed to create constant buffer for video shader "
+              "input data: result={}",
+              result);
     return false;
   }
 
+  m_pInputBuffer = std::move(inputBuffer);
   return true;
 }
 
-void CShaderDX::UpdateInputBuffer(uint64_t frameCount)
+bool CShaderDX::UpdateInputBuffer(uint64_t frameCount)
 {
+  if (!m_pInputBuffer)
+  {
+    CLog::Log(LOGERROR, "CShaderDX::UpdateInputBuffer: Constant buffer is unavailable");
+    return false;
+  }
+
   ID3D11DeviceContext1* pContext = DX::DeviceResources::Get()->GetD3DContext();
   cbInput input = GetInputData(frameCount);
-  cbInput* pData;
-  void** ppData = reinterpret_cast<void**>(&pData);
-  D3D11_MAPPED_SUBRESOURCE resource;
-
-  if (SUCCEEDED(pContext->Map(m_pInputBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource)))
+  D3D11_MAPPED_SUBRESOURCE resource{};
+  const HRESULT result =
+      pContext->Map(m_pInputBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+  if (FAILED(result))
   {
-    *ppData = resource.pData;
-    memcpy(*ppData, &input, sizeof(cbInput));
-    pContext->Unmap(m_pInputBuffer, 0);
+    CLog::Log(LOGERROR, "CShaderDX::UpdateInputBuffer: Failed to map constant buffer: result={}",
+              result);
+    return false;
   }
+
+  memcpy(resource.pData, &input, sizeof(cbInput));
+  pContext->Unmap(m_pInputBuffer.Get(), 0);
+  return true;
 }
 
 CShaderDX::cbInput CShaderDX::GetInputData(uint64_t frameCount) const
@@ -245,7 +259,7 @@ void CShaderDX::SetShaderParameters(const CD3DTexture& sourceTexture)
   m_effect.SetResources("decal", {const_cast<CD3DTexture&>(sourceTexture).GetAddressOfSRV()}, 1);
   m_effect.SetMatrix("modelViewProj", reinterpret_cast<const float*>(&m_MVP));
   //! @todo(optimization) Add frame_count to separate cbuffer
-  m_effect.SetConstantBuffer("input", m_pInputBuffer);
+  m_effect.SetConstantBuffer("input", m_pInputBuffer.Get());
 
   for (const auto& [paramName, paramValue] : m_shaderParameters)
     m_effect.SetFloatArray(paramName.c_str(), &paramValue, 1);

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -41,7 +41,7 @@ public:
   void SetSizes(const float2& nextSize,
                 const float2& prevSize = float2{},
                 const float2& prevTextureSize = float2{}) override;
-  void PrepareParameters(IShaderTexture& sourceTexture,
+  bool PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;
@@ -75,6 +75,9 @@ public:
    */
   bool CreateInputBuffer();
 
+protected:
+  virtual bool UpdateInputBuffer(uint64_t frameCount);
+
 private:
   struct cbInput
   {
@@ -85,7 +88,6 @@ private:
     float frame_direction;
   };
 
-  void UpdateInputBuffer(uint64_t frameCount);
   cbInput GetInputData(uint64_t frameCount = 0) const;
   void SetShaderParameters(const CD3DTexture& sourceTexture);
 
@@ -126,7 +128,7 @@ private:
   unsigned int m_frameCountMod{0};
 
   // Holds the data bound to the input cbuffer (cbInput here)
-  ID3D11Buffer* m_pInputBuffer{nullptr};
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_pInputBuffer;
 
   // Sampler state
   //ID3D11SamplerState* m_pSampler{nullptr};

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -85,7 +85,11 @@ bool CShaderPresetDX::CreateLayouts()
   for (std::unique_ptr<IShader>& videoShader : m_pShaders)
   {
     auto* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
-    videoShaderDX->CreateVertexBuffer(4, sizeof(CUSTOMVERTEX));
+    if (!videoShaderDX->CreateVertexBuffer(4, sizeof(CUSTOMVERTEX)))
+    {
+      CLog::Log(LOGERROR, "CShaderPresetDX::CreateLayouts: Failed to create shader vertex buffers");
+      return false;
+    }
 
     // Create input layout
     D3D11_INPUT_ELEMENT_DESC layout[] = {
@@ -113,7 +117,12 @@ bool CShaderPresetDX::CreateBuffers()
   for (std::unique_ptr<IShader>& videoShader : m_pShaders)
   {
     auto* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
-    videoShaderDX->CreateInputBuffer();
+    if (!videoShaderDX->CreateInputBuffer())
+    {
+      CLog::Log(LOGERROR,
+                "CShaderPresetDX::CreateBuffers: Failed to create shader constant buffer");
+      return false;
+    }
   }
 
   return true;
@@ -222,12 +231,12 @@ bool CShaderPresetDX::CreateSamplers()
   memcpy(sampDesc.BorderColor, &blackBorder, 4 * sizeof(FLOAT));
 
   ID3D11Device1* pDevice = DX::DeviceResources::Get()->GetD3DDevice();
-  if (FAILED(pDevice->CreateSamplerState(&sampDesc, &m_pSampNearest)))
+  if (FAILED(pDevice->CreateSamplerState(&sampDesc, m_pSampNearest.ReleaseAndGetAddressOf())))
     return false;
 
   D3D11_SAMPLER_DESC sampDescLinear = sampDesc;
   sampDescLinear.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
-  if (FAILED(pDevice->CreateSamplerState(&sampDescLinear, &m_pSampLinear)))
+  if (FAILED(pDevice->CreateSamplerState(&sampDescLinear, m_pSampLinear.ReleaseAndGetAddressOf())))
     return false;
 
   return true;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
@@ -11,6 +11,7 @@
 #include "cores/RetroPlayer/shaders/ShaderPreset.h"
 
 #include <d3d11.h>
+#include <wrl/client.h>
 
 namespace KODI
 {
@@ -46,10 +47,10 @@ protected:
 
 private:
   // Point/nearest neighbor sampler
-  ID3D11SamplerState* m_pSampNearest = nullptr;
+  Microsoft::WRL::ComPtr<ID3D11SamplerState> m_pSampNearest;
 
   // Linear sampler
-  ID3D11SamplerState* m_pSampLinear = nullptr;
+  Microsoft::WRL::ComPtr<ID3D11SamplerState> m_pSampLinear;
 };
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/windows/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/shaders/windows/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestShaderUtilsDX.cpp)
+set(SOURCES TestRPWinOutputShaderDX.cpp
+            TestShaderUtilsDX.cpp)
 
 core_add_test_library(retroplayer_shaders_windows_test)

--- a/xbmc/cores/RetroPlayer/shaders/windows/test/TestRPWinOutputShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/test/TestRPWinOutputShaderDX.cpp
@@ -1,0 +1,252 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/shaders/windows/RPWinOutputShader.h"
+#include "cores/RetroPlayer/shaders/windows/ShaderDX.h"
+#include "cores/RetroPlayer/shaders/windows/ShaderTextureDX.h"
+#include "cores/RetroPlayer/shaders/windows/ShaderTypesDX.h"
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <windows.h>
+
+using namespace KODI;
+using namespace KODI::SHADER;
+
+namespace
+{
+class CTestOutputShader : public CRPWinOutputShader
+{
+public:
+  bool createVertexBufferResult{true};
+  bool lockVertexBufferResult{true};
+  bool unlockVertexBufferResult{true};
+
+  unsigned int createVertexBufferCalls{0};
+  unsigned int loadEffectCalls{0};
+  unsigned int createInputLayoutCalls{0};
+  unsigned int lockVertexBufferCalls{0};
+  unsigned int unlockVertexBufferCalls{0};
+  unsigned int executeCalls{0};
+
+protected:
+  bool CreateVertexBuffer(unsigned int vertCount, unsigned int vertSize) override
+  {
+    ++createVertexBufferCalls;
+    return createVertexBufferResult;
+  }
+
+  bool LoadEffect(const std::string& filename, DefinesMap* defines) override
+  {
+    ++loadEffectCalls;
+    return true;
+  }
+
+  bool CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout,
+                         unsigned int numElements,
+                         const char* techniqueName) override
+  {
+    ++createInputLayoutCalls;
+    return true;
+  }
+
+  bool LockVertexBuffer(void** data) override
+  {
+    ++lockVertexBufferCalls;
+    if (!lockVertexBufferResult)
+      return false;
+
+    *data = m_vertices.data();
+    return true;
+  }
+
+  bool UnlockVertexBuffer() override
+  {
+    ++unlockVertexBufferCalls;
+    return unlockVertexBufferResult;
+  }
+
+  bool Execute(const std::vector<CD3DTexture*>& targets, unsigned int vertexIndexStep) override
+  {
+    ++executeCalls;
+    return true;
+  }
+
+private:
+  std::array<CUSTOMVERTEX, 4> m_vertices{};
+};
+
+class CTestShaderDX : public CShaderDX
+{
+public:
+  bool lockVertexBufferResult{true};
+  bool unlockVertexBufferResult{true};
+  bool updateInputBufferResult{true};
+
+  unsigned int lockVertexBufferCalls{0};
+  unsigned int unlockVertexBufferCalls{0};
+  unsigned int updateInputBufferCalls{0};
+
+protected:
+  bool LockVertexBuffer(void** data) override
+  {
+    ++lockVertexBufferCalls;
+    if (!lockVertexBufferResult)
+      return false;
+
+    *data = m_vertices.data();
+    return true;
+  }
+
+  bool UnlockVertexBuffer() override
+  {
+    ++unlockVertexBufferCalls;
+    return unlockVertexBufferResult;
+  }
+
+  bool UpdateInputBuffer(uint64_t frameCount) override
+  {
+    ++updateInputBufferCalls;
+    return updateInputBufferResult;
+  }
+
+private:
+  std::array<CUSTOMVERTEX, 4> m_vertices{};
+};
+} // namespace
+
+TEST(TestRPWinOutputShaderDX, CreateStopsWhenVertexBufferCreationFails)
+{
+  CTestOutputShader shader;
+  shader.createVertexBufferResult = false;
+
+  EXPECT_FALSE(shader.Create(RETRO::SCALINGMETHOD::LINEAR));
+  EXPECT_EQ(1u, shader.createVertexBufferCalls);
+  EXPECT_EQ(0u, shader.loadEffectCalls);
+  EXPECT_EQ(0u, shader.createInputLayoutCalls);
+}
+
+TEST(TestRPWinOutputShaderDX, RenderStopsAndRetriesWhenVertexBufferLockFails)
+{
+  CTestOutputShader shader;
+  shader.lockVertexBufferResult = false;
+
+  CD3DTexture sourceTexture;
+  CD3DTexture targetTexture;
+  RETRO::ViewportCoordinates points{};
+  points[0].x = 1.0f;
+  CRect viewPort;
+
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+  EXPECT_EQ(0u, shader.executeCalls);
+  EXPECT_EQ(0u, shader.unlockVertexBufferCalls);
+
+  shader.lockVertexBufferResult = true;
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+
+  EXPECT_EQ(2u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(2u, shader.executeCalls);
+}
+
+TEST(TestRPWinOutputShaderDX, RenderStopsAndRetriesWhenVertexBufferUnlockFails)
+{
+  CTestOutputShader shader;
+  shader.unlockVertexBufferResult = false;
+
+  CD3DTexture sourceTexture;
+  CD3DTexture targetTexture;
+  RETRO::ViewportCoordinates points{};
+  points[0].x = 1.0f;
+  CRect viewPort;
+
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+
+  EXPECT_EQ(2u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(2u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(0u, shader.executeCalls);
+
+  shader.unlockVertexBufferResult = true;
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+  EXPECT_EQ(3u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(3u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.executeCalls);
+
+  shader.Render(sourceTexture, CRect{}, points, viewPort, targetTexture);
+  EXPECT_EQ(3u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(3u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(2u, shader.executeCalls);
+}
+
+TEST(TestShaderDX, PrepareParametersFailsWhenVertexBufferLockFails)
+{
+  CTestShaderDX shader;
+  shader.SetSizes({320.0f, 240.0f});
+  shader.lockVertexBufferResult = false;
+
+  CShaderTextureDX source(std::make_shared<CD3DTexture>());
+  std::vector<std::unique_ptr<IShaderTexture>> shaderTextures;
+  std::vector<std::unique_ptr<IShader>> shaders;
+
+  EXPECT_FALSE(shader.PrepareParameters(source, shaderTextures, shaders, 1));
+  EXPECT_EQ(1u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(0u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(0u, shader.updateInputBufferCalls);
+}
+
+TEST(TestShaderDX, PrepareParametersFailsWhenVertexBufferUnlockFails)
+{
+  CTestShaderDX shader;
+  shader.SetSizes({320.0f, 240.0f});
+  shader.unlockVertexBufferResult = false;
+
+  CShaderTextureDX source(std::make_shared<CD3DTexture>());
+  std::vector<std::unique_ptr<IShaderTexture>> shaderTextures;
+  std::vector<std::unique_ptr<IShader>> shaders;
+
+  EXPECT_FALSE(shader.PrepareParameters(source, shaderTextures, shaders, 1));
+  EXPECT_EQ(1u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(0u, shader.updateInputBufferCalls);
+}
+
+TEST(TestShaderDX, PrepareParametersFailsWhenInputBufferUpdateFails)
+{
+  CTestShaderDX shader;
+  shader.SetSizes({320.0f, 240.0f});
+  shader.updateInputBufferResult = false;
+
+  CShaderTextureDX source(std::make_shared<CD3DTexture>());
+  std::vector<std::unique_ptr<IShaderTexture>> shaderTextures;
+  std::vector<std::unique_ptr<IShader>> shaders;
+
+  EXPECT_FALSE(shader.PrepareParameters(source, shaderTextures, shaders, 1));
+  EXPECT_EQ(1u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.updateInputBufferCalls);
+}
+
+TEST(TestShaderDX, PrepareParametersSucceedsWhenAllUpdatesSucceed)
+{
+  CTestShaderDX shader;
+  shader.SetSizes({320.0f, 240.0f});
+
+  CShaderTextureDX source(std::make_shared<CD3DTexture>());
+  std::vector<std::unique_ptr<IShaderTexture>> shaderTextures;
+  std::vector<std::unique_ptr<IShader>> shaders;
+
+  EXPECT_TRUE(shader.PrepareParameters(source, shaderTextures, shaders, 1));
+  EXPECT_EQ(1u, shader.lockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.unlockVertexBufferCalls);
+  EXPECT_EQ(1u, shader.updateInputBufferCalls);
+}

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -799,7 +799,7 @@ bool CD3DEffect::End()
 bool CD3DEffect::CreateEffect()
 {
   HRESULT hr;
-  ID3DBlob* pError = nullptr;
+  ComPtr<ID3DBlob> pError;
 
   std::vector<D3D_SHADER_MACRO> definemacros;
 
@@ -829,8 +829,10 @@ bool CD3DEffect::CreateEffect()
   dwShaderFlags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
 #endif
 
-  hr = D3DX11CompileEffectFromMemory(m_effectString.c_str(), m_effectString.length(), "", &definemacros[0], this,
-                                     dwShaderFlags, 0, DX::DeviceResources::Get()->GetD3DDevice(), m_effect.ReleaseAndGetAddressOf(), &pError);
+  hr = D3DX11CompileEffectFromMemory(
+      m_effectString.c_str(), m_effectString.length(), "", &definemacros[0], this, dwShaderFlags,
+      0, DX::DeviceResources::Get()->GetD3DDevice(), m_effect.ReleaseAndGetAddressOf(),
+      pError.GetAddressOf());
 
   if(hr == S_OK)
     return true;


### PR DESCRIPTION
## Description

AI use:

Harden RetroPlayer's DirectX shader resource handling.

* Propagate vertex and constant buffer creation failures instead of continuing with incomplete shader state.
* Skip rendering when vertex or constant buffers cannot be updated.
* Retry transient vertex-buffer update failures on later frames.
* Manage shader constant buffers and sampler states with `ComPtr`.
* Manage DirectX shader compiler diagnostics with `ComPtr` so error resources are released automatically.

## Motivation and context

Several DirectX resource failures were previously ignored. Shader initialization could continue after a buffer allocation failed, and rendering could continue after a vertex or constant buffer update failed.

Some DirectX resources also used manual or missing lifetime management.

This makes those failure paths explicit and keeps shader state valid when resource creation or updates fail.

## How has this been tested?

Added Windows shader tests covering:

* Output shader creation failing when its vertex buffer cannot be created.
* Rendering stopping and retrying after a vertex-buffer lock failure.
* Rendering stopping and retrying after a vertex-buffer unlock failure.
* Shader rendering being suppressed when parameter preparation fails.
* Rendering recovering once vertex and constant buffer updates succeed again.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
