### PR TITLE
[Video] Add setting to always extract stream details when a video file is played.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25393,3 +25393,15 @@ msgstr ""
 msgctxt "#40804"
 msgid "{0:.1f} dB"
 msgstr ""
+
+#. Setting #40805 Always update video information when played
+#: system/settings/settings.xml
+msgctxt "#40805"
+msgid "Always update video information when file played"
+msgstr ""
+
+#. Description of setting with label #40805 "Always update video information when played"
+#: system/settings/settings.xml
+msgctxt "#40806"
+msgid "Re-extract and overwrite metadata information such as codec and aspect ratio every time a video is played."
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1225,6 +1225,14 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="myvideos.extractflagsalways" type="boolean" label="40805" help="40806" parent="myvideos.extractflags">
+          <dependencies>
+            <dependency type="visible" setting="myvideos.extractflags" operator="is">true</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="myvideos.extractchapterthumbs" type="boolean" label="37044" help="37045">
           <level>2</level>
           <default>true</default>

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -30,6 +30,7 @@
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/SaveFileStateJob.h"
@@ -56,8 +57,22 @@ void CApplicationPlayerCallback::OnPlayBackEnded()
 
 namespace
 {
+bool AlwaysUpdateStreamDetails()
+{
+  const auto settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
+  return settings->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
+         settings->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTFLAGSALWAYS);
+}
+
 bool ShouldUpdateStreamDetails(const CFileItem& file)
 {
+  // Creating a video info tag for an audio item would make its play state be saved as a video
+  if (MUSIC::IsAudio(file) && !VIDEO::IsVideo(file))
+    return false;
+
+  if (AlwaysUpdateStreamDetails() && VIDEO::IsVideo(file))
+    return true;
+
   // If a title/playlist hasn't been selected for a bluray/dvds then the stream details may not be known
   const bool isDiscOrStream{VIDEO::IsBDFile(file) || VIDEO::IsDVDFile(file) || file.IsDiscImage() ||
                             URIUtils::IsBlurayMenuPath(file.GetDynPath()) ||
@@ -321,6 +336,17 @@ void UpdateStackAndItem(const CFileItem& file,
   }
   else
   {
+    if (file.GetProperty("update_stream_details").asBoolean(false))
+    {
+      fileItem.GetVideoInfoTag()->m_streamDetails = file.GetVideoInfoTag()->m_streamDetails;
+
+      // The library displays the duration of the whole stack, not of the part just played
+      fileItem.GetVideoInfoTag()->m_streamDetails.SetVideoDuration(
+          0, static_cast<int>(
+                 std::chrono::duration_cast<std::chrono::seconds>(stackHelper->GetStackTotalTime())
+                     .count()));
+    }
+
     stackHelper->SetCurrentPartFinished(
         IsFinished(bookmark.timeInSeconds, bookmark.totalTimeInSeconds));
 
@@ -378,6 +404,11 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
     // Update the stack
     if (stackHelper->GetStack(file) != nullptr)
       UpdateStackAndItem(file, fileItem, bookmark, stackHelper);
+
+    // Details stored by an earlier scan rank above the player's, so an explicit refresh has to
+    // override the source precedence to have any effect
+    if (AlwaysUpdateStreamDetails() && file.GetProperty("update_stream_details").asBoolean(false))
+      fileItem.SetProperty("force_stream_details_update", true);
 
     if (WithinPercentOfEnd(bookmark, advancedSettings->m_videoIgnorePercentAtEnd) ||
         IsFinished(bookmark.timeInSeconds, bookmark.totalTimeInSeconds))

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -151,6 +151,7 @@ public:
   static constexpr auto SETTING_MYVIDEOS_PLAYACTION = "myvideos.playaction";
   static constexpr auto SETTING_MYVIDEOS_USETAGS = "myvideos.usetags";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTFLAGS = "myvideos.extractflags";
+  static constexpr auto SETTING_MYVIDEOS_EXTRACTFLAGSALWAYS = "myvideos.extractflagsalways";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS = "myvideos.extractchapterthumbs";
   static constexpr auto SETTING_MYVIDEOS_REPLACELABELS = "myvideos.replacelabels";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTTHUMB = "myvideos.extractthumb";

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -195,13 +195,14 @@ void CSaveFileState::DoWork(CFileItem& item,
             !item.IsLiveTV())
         {
           CFileItem dbItem(item);
+          const bool forceUpdate{item.GetProperty("force_stream_details_update").asBoolean(false)};
 
           // Check whether the item's db streamdetails need updating
           if (!videodatabase.GetStreamDetails(dbItem) ||
               (dbItem.GetVideoInfoTag()->m_streamDetails !=
                    item.GetVideoInfoTag()->m_streamDetails &&
-               dbItem.GetVideoInfoTag()->m_streamDetails.ShouldUpdateWithNewDetails(
-                   item.GetVideoInfoTag()->m_streamDetails)))
+               (forceUpdate || dbItem.GetVideoInfoTag()->m_streamDetails.ShouldUpdateWithNewDetails(
+                                   item.GetVideoInfoTag()->m_streamDetails))))
           {
             videodatabase.BeginTransaction();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Turning this new option on will flag steamdetails for update whenever the item is played (note an update only actually happens if they differ).

This can overwrite details from an NFO.

The default is off.

Found in Settings -> Media -> Videos

<img width="500" alt="image" src="https://github.com/user-attachments/assets/58b715ed-bdea-4e1d-98be-19b9f132b387" />

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It came up in an earlier discussion about stream details and the primacy of NFOs.

Once streamdetails are set, they are never usually updated. I noticed when doing some testing in Kodi v21 that the ffmpeg version did not detect newer audio streams, HDR etc.. correctly.

These streamdetails will not automatically be updated in v22.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Aliens UHD played in v21
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b0cc6471-2496-48d7-be6e-26f474eba753" />

After upgrade to v22
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8d790797-99a8-4772-a5d7-424a50b98000" />

After playing in v22 (with this setting off) - ie. no change, streamdetails still inaccurate
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f68e5689-98cc-4547-820d-bd96e06eb683" />

After playing in v22 with this setting on - note updated
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ddec1540-0dd4-45fa-b6ee-42df9b7a2a81" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
