### PR TITLE
[Estuary] Versions cleanup after PR29007

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -80,7 +80,7 @@
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="ListLabelVar">
-		<value condition="System.GetBool(videolibrary.flattenversions) + ListItem.HasVideoVersions + !ListItem.IsDefaultVideoVersionName">$INFO[ListItem.Label]$INFO[ListItem.VideoVersionName, [COLOR grey][,][/COLOR]]</value>
+		<value condition="System.GetBool(videolibrary.flattenversions) + ListItem.HasVideoVersions + !String.IsEqual(ListItem.VideoVersionName,$LOCALIZE[40400])">$INFO[ListItem.Label]$INFO[ListItem.VideoVersionName, [COLOR grey][,][/COLOR]]</value>
 		<value condition="ListItem.HasVideoVersions + Window.IsActive(videoplaylist)">$INFO[ListItem.Label]$INFO[ListItem.VideoVersionName, [I](,)[/I]]</value>
 		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
 		<value condition="String.IsEqual(ListItem.DbType,musicvideo) + Window.IsActive(videoplaylist)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
@@ -106,13 +106,12 @@
 		<value condition="Container.SortMethod(7) | Container.SortMethod(29)">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
 		<value condition="Window.IsActive(musicplaylist) | Window.IsActive(videoplaylist)">$INFO[ListItem.Duration]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(1)">$VAR[FirstLanguagesVar]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + Control.IsVisible(504)">$VAR[FirstLanguagesVar]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + !Control.IsVisible(504)">$INFO[ListItem.Duration]$VAR[FirstLanguagesVar, | ]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(32)">$INFO[ListItem.VideoResolution]$VAR[VideoResolutionTypeVar, ]$VAR[FirstLanguagesVar, | ]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(33)">$VAR[VideoCodecVar]$VAR[FirstLanguagesVar, | ]</value>
-		<value condition="$EXP[videoasset_true] + Container.SortMethod(36)">$VAR[AudioCodecVar]$VAR[FirstLanguagesVar, | ]</value>
-		<value condition="$EXP[videoasset_true]">$VAR[FirstLanguagesVar]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(1)"></value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + Control.IsVisible(504)"></value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + !Control.IsVisible(504)">$INFO[ListItem.Duration]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(32)">$INFO[ListItem.VideoResolution]$VAR[VideoResolutionTypeVar, ]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(33)">$VAR[VideoCodecVar]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(36)">$VAR[AudioCodecVar]</value>
 		<value condition="Container.SortMethod(9)">$INFO[ListItem.Duration]</value>
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
@@ -917,22 +916,19 @@
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
 	<variable name="MediaInfoListLabel2Var">
-		<value condition="ListItem.IsStereoscopic">3D$VAR[VideoCodecVar, | ]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[VideoAssetAudioPropertyVar]$VAR[VideoManagerFirstLanguagesVar]</value>
-		<value>$VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[VideoAssetAudioPropertyVar]$VAR[VideoManagerFirstLanguagesVar]</value>
-	</variable>
-	<variable name="FirstLanguagesVar">
-		<value condition="String.IsEmpty(ListItem.FirstAudioLanguage)">$INFO[ListItem.FirstSubtitleLanguage]</value>
-		<value>$INFO[ListItem.FirstAudioLanguage]$INFO[ListItem.FirstSubtitleLanguage, | ]</value>
+		<value condition="ListItem.IsStereoscopic">3D$VAR[VideoCodecVar, | ]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[VideoAssetAudioPropertyVar]$VAR[VideoLanguagesVar]</value>
+		<value>$VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[VideoAssetAudioPropertyVar]$VAR[VideoLanguagesVar]</value>
 	</variable>
 	<variable name="VideoAssetAudioPropertyVar">
 		<value condition="Window.IsVisible(managevideoversions) | Window.IsVisible(managevideoextras)">$VAR[FirstAudioCodecVar, | ]$INFO[ListItem.FirstAudioChannels(DefaultLayout), ]</value>
-		<value>$VAR[AudioCodecVar, | ]$VAR[AudioPropertyFlagVar, | ]</value>
+		<value>$VAR[AudioCodecVar, | ]$VAR[AudioChannelsVar, ]</value>
 	</variable>
 	<variable name="FirstAudioCodecVar">
 		<value>$MAP[DefaultAltAudioMap, ListItem.FirstAudioCodec]</value>
 	</variable>
-	<variable name="VideoManagerFirstLanguagesVar">
-		<value condition="Window.IsVisible(managevideoversions) | Window.IsVisible(managevideoextras)">$VAR[FirstLanguagesVar, | ]</value>
+	<variable name="VideoLanguagesVar">
+		<value condition="!String.IsEqual(ListItem.AudioLanguage,und) + [Window.IsVisible(managevideoversions) | Window.IsVisible(managevideoextras)]">$INFO[ListItem.FirstAudioLanguage, | ]</value>
+		<value condition="!String.IsEqual(ListItem.AudioLanguage,und)">$INFO[ListItem.AudioLanguage, | ]</value>
 	</variable>
 	<variable name="PVRInstanceName">
 		<value condition="Integer.IsGreater(PVR.ClientCount,1)">$INFO[ListItem.PVRClientName,[COLOR grey]$LOCALIZE[31137]:[/COLOR] ,]$INFO[ListItem.PVRInstanceName, (,)]</value>


### PR DESCRIPTION
## Description

After https://github.com/xbmc/xbmc/pull/29007 by @78andyp there were some things done incorrectly in the display of Versions.

## Motivation and context

Restore the established look for Versions.

### Versions before PR29007

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/800c5260-fc9a-4aca-8f80-90bc446b63e1" />

### Versions after PR29007

**Issue 1 (Red highlight)**

Incorrect usage of the Variable AudioPropertyFlagVar ment the channel info no longer immediatly followed the audio codec as before. The Variable was AudioPropertyFlagVar was only added for use by one of the flags, hence the name, however even this usage by flags will be become redundant after https://github.com/xbmc/xbmc/pull/29128

**Issue 2 (Blue highlight)**

Incorrect usage of Label2 to display language codes for audio & subtitle. Label2 should not be used in this manner, Label2 is always related to the sort method or a sensible default for the info displayed. Things should not be added here simple because it's empty in some cases.

<img width="1920" height="1080" alt="versions_afer_pr_1" src="https://github.com/user-attachments/assets/a54dccc5-7336-4420-8a4b-5f67303cbffa" />

In this case where Video Resolution is used as Sort Method the language codes look completely out of place.

<img width="1920" height="1080" alt="versions_afer_pr_2" src="https://github.com/user-attachments/assets/7379b667-5b21-453f-846e-5bea06d9256b" />

### Versions with code contained here

**Issue 1  -** fixed by removing use of Variable AudioPropertyFlagVar and a pipe seperator used before the audio language to keep the existing style. Note - subtitle language code will be shown via a flag once https://github.com/xbmc/xbmc/pull/29128 goes in.

**Issue 2**  - Variable ListLabel2Var restored to what is was before PR29007 to remove the out of place lanuage codes.

<img width="1920" height="1080" alt="Versions Cleaned Up" src="https://github.com/user-attachments/assets/ea20998a-ecfa-4c86-b96b-83043620f3d8" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
