### PR TITLE
[depends][libmicrohttpd] adjust building for Apple platforms

### DIFF
--- a/cmake/modules/FindMicroHttpd.cmake
+++ b/cmake/modules/FindMicroHttpd.cmake
@@ -33,8 +33,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       endif()
       find_program(MAKE_EXECUTABLE make REQUIRED)
 
-      if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-        # blanket disable timespec_get use for apple platforms. timespec_get was introduced in
+      if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
+        # blanket disable timespec_get use for darwin_embedded. timespec_get was introduced in
         # __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) but older platforms
         # are failing to run.
         set(EXTRA_ARGS mhd_cv_have_func_timespec_get=no)

--- a/cmake/modules/FindMicroHttpd.cmake
+++ b/cmake/modules/FindMicroHttpd.cmake
@@ -37,7 +37,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
         # blanket disable timespec_get use for apple platforms. timespec_get was introduced in
         # __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) but older platforms
         # are failing to run.
-        set(EXTRA_ARGS mhd_cv_func_timespec_get=no)
+        set(EXTRA_ARGS mhd_cv_have_func_timespec_get=no)
       endif()
 
       set(CONFIGURE_COMMAND ./configure --prefix ${DEPENDS_PATH}

--- a/tools/depends/target/libmicrohttpd/Makefile
+++ b/tools/depends/target/libmicrohttpd/Makefile
@@ -15,8 +15,8 @@ ifeq ($(DEBUG_BUILD), yes)
   CONFIGURE+= --enable-asserts
 endif
 
-ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
-  # blanket disable timespec_get use for apple platforms. timespec_get was introduced in
+ifeq ($(OS), darwin_embedded)
+  # blanket disable timespec_get use for darwin_embedded. timespec_get was introduced in
   # __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) but older platforms
   # are failing to run.
   CONFIGURE+= mhd_cv_have_func_timespec_get=no

--- a/tools/depends/target/libmicrohttpd/Makefile
+++ b/tools/depends/target/libmicrohttpd/Makefile
@@ -19,7 +19,7 @@ ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
   # blanket disable timespec_get use for apple platforms. timespec_get was introduced in
   # __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) but older platforms
   # are failing to run.
-  CONFIGURE+= mhd_cv_func_timespec_get=no
+  CONFIGURE+= mhd_cv_have_func_timespec_get=no
 endif
 
 LIBDYLIB=$(PLATFORM)/src/microhttpd/.libs/$(LIBNAME).a


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1. using correct variable name for `timespec_get` detection
2. `timespec_get` is no longer disabled for macOS because deployment target allows using it now

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes running Kodi on iOS/tvOS < 13.0

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build for iOS, test on iOS 12 and 26

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
fixes running Kodi on iOS/tvOS < 13.0

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
