### PR TITLE
ActiveAE: throttle "large audio sync error" log spam

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2106,15 +2106,15 @@ bool CActiveAE::RunStages()
         if (isTrueHDPassthrough)
           error *= 0.45;
 
-        if (error > maxError)
+        if (error > maxError || error < -maxError)
         {
-          CLog::Log(LOGWARNING, "ActiveAE - large audio sync error: {:f}", error);
-          error = maxError;
-        }
-        else if (error < -maxError)
-        {
-          CLog::Log(LOGWARNING, "ActiveAE - large audio sync error: {:f}", error);
-          error = -maxError;
+          auto now = std::chrono::steady_clock::now();
+          if (now - (*it)->m_lastSyncErrorLogTime >= 1s)
+          {
+            CLog::Log(LOGWARNING, "ActiveAE - large audio sync error: {:f}", error);
+            (*it)->m_lastSyncErrorLogTime = now;
+          }
+          error = (error > maxError) ? maxError : -maxError;
         }
         (*it)->m_syncError.Add(error);
       }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -216,6 +216,7 @@ protected:
   double m_lastPts;
   double m_lastPtsJump;
   std::chrono::milliseconds m_errorInterval{1000};
+  std::chrono::steady_clock::time_point m_lastSyncErrorLogTime{};
 
   // only accessed by engine
   std::unique_ptr<CActiveAEBufferPool> m_inputBuffers;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Under a sustained audio sync fault (e.g. bad passthrough source, misbehaving tuner input, stuck sink), the sync-error branch in CActiveAE::RunStages() can be hit on every audio buffer — potentially thousands of times per second. Because the logged error value differs each call, the generic duplicate-message log collapser can't catch it, so the log fills with near-identical ActiveAE - large audio sync error: {:f} lines, drowning out other diagnostics.

This PR:

- Merges the two branches (error > maxError / error < -maxError) that only differed in clamp direction, into one.
- Adds a per-stream m_lastSyncErrorLogTime (std::chrono::steady_clock::time_point) and only logs the warning if at least one second has passed since the last log for that stream.
- Leaves the actual sync correction (m_syncError.Add(error) and the error clamping) untouched and running at full rate — only the logging is throttled.

## Motivation and context
Log spam like this makes it hard to spot other issues in the log during an active sync problem, and can bloat log output on long-running sessions or storage-constrained platforms.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [x] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
