### PR TITLE
[Disc][Win32] Drive state cache.

### DIFF
--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -180,7 +180,7 @@ void CVirtualDirectory::GetSources(std::vector<CMediaSource>& shares) const
     CMediaSource& share = shares[i];
     if (share.m_iDriveType == SourceType::OPTICAL_DISC)
     {
-      if (CServiceBroker::GetMediaManager().IsAudio(share.strPath))
+      if (CServiceBroker::GetMediaManager().IsAudio(share.strPath, true))
       {
         share.strStatus = "Audio-CD";
         share.strPath = "cdda://local/";

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -510,7 +510,7 @@ bool CSystemGUIInfo::GetBool(bool& value,
 #ifdef HAS_OPTICAL_DRIVE
       if (CServiceBroker::GetMediaManager().IsDiscInDrive())
       {
-        MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();
+        MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo("", true);
         value =
             pCdInfo && (pCdInfo->IsAudio(1) || pCdInfo->IsCDExtra(1) || pCdInfo->IsMixedMode(1));
       }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -413,7 +413,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem, bool first)
 
 void CGUIWindowMusicBase::UpdateButtons()
 {
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNRIP, CServiceBroker::GetMediaManager().IsAudio());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNRIP, CServiceBroker::GetMediaManager().IsAudio("", true));
 
   CONTROL_ENABLE_ON_CONDITION(
       CONTROL_BTNSCAN, !(m_vecItems->IsVirtualDirectoryRoot() || MUSIC::IsMusicDb(*m_vecItems)));

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -91,8 +91,8 @@ CWIN32Util::~CWIN32Util(void)
 int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
 {
 #ifdef TARGET_WINDOWS_STORE
-  CLog::LogF(LOGDEBUG, "is not implemented");
-  CLog::LogF(LOGDEBUG, "Could not determine tray status {}", GetLastError());
+  if (bStatusEx)
+    CLog::LogF(LOGDEBUG, "Tray status is not implemented");
   return -1;
 #else
   using KODI::PLATFORM::WINDOWS::ToW;
@@ -105,8 +105,6 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
   T_SPDT_SBUF sptd_sb = {}; // SCSI Pass Through Direct variable.
   byte DataBuf[8] = {}; // Buffer for holding data to/from drive.
 
-  CLog::LogF(LOGDEBUG, "Requesting status for drive {}.", strPath);
-
   hDevice = CreateFile( strPathW.c_str(),                  // drive
                         0,                                // no access to the drive
                         FILE_SHARE_READ,                  // share mode
@@ -117,11 +115,12 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
 
   if (hDevice == INVALID_HANDLE_VALUE)                    // cannot open the drive
   {
-    CLog::LogF(LOGERROR, "Failed to CreateFile for {}.", strPath);
+    // Normal probes are logged as state transitions by CMediaManager.
+    if (bStatusEx)
+      CLog::LogF(LOGERROR, "Failed to CreateFile for {}.", strPath);
     return -1;
   }
 
-  CLog::LogF(LOGDEBUG, "Requesting media status for drive {}.", strPath);
   iResult = DeviceIoControl((HANDLE) hDevice,             // handle to device
                              IOCTL_STORAGE_CHECK_VERIFY2, // dwIoControlCode
                              NULL,                        // lpInBuffer
@@ -131,14 +130,30 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
                              &dwBytesReturned ,           // number of bytes returned
                              NULL );                      // OVERLAPPED structure
 
+  // Capture before CloseHandle(), which is free to overwrite the thread's last error
+  const DWORD dwVerifyError{iResult ? static_cast<DWORD>(ERROR_SUCCESS) : GetLastError()};
+
   CloseHandle(hDevice);
 
   if(iResult == 1)
     return 2;
 
   // don't request the tray status as we often doesn't need it
-  if(!bStatusEx)
-    return 0;
+  if (!bStatusEx)
+  {
+    // ERROR_NOT_READY cannot distinguish an empty drive from a disc spinning up.
+    // Report probe failures separately; the caller retries both states at a bounded rate.
+    switch (dwVerifyError)
+    {
+      case ERROR_BUSY:
+      case ERROR_MEDIA_CHANGED:
+      case ERROR_DEVICE_NOT_CONNECTED:
+      case ERROR_IO_DEVICE:
+        return -1;
+      default:
+        return 0;
+    }
+  }
 
   hDevice = CreateFile( strPathW.c_str(),
                         GENERIC_READ | GENERIC_WRITE,
@@ -555,7 +570,7 @@ HRESULT CWIN32Util::ToggleTray(const char cDriveLetter)
   }
 
   auto strVolFormat = ToW(StringUtils::Format("\\\\.\\{}:", cDL));
-  HANDLE hDrive= CreateFile( strVolFormat.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+  HANDLE hDrive = CreateFile(strVolFormat.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   auto strRootFormat = ToW(StringUtils::Format("{}:\\", cDL));
   if( ( hDrive != INVALID_HANDLE_VALUE || GetLastError() == NO_ERROR) &&

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -53,6 +53,8 @@
 #endif
 #endif
 
+#include <cctype>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -61,6 +63,46 @@ using namespace MEDIA_DETECT;
 #endif
 
 const char MEDIA_SOURCES_XML[] = { "special://profile/mediasources.xml" };
+
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+namespace
+{
+constexpr auto DRIVE_STATUS_RETRY_INTERVAL{std::chrono::seconds(2)};
+/*! Windows does not always report a disc change made with the drive's own eject button, so even a
+    stable state is confirmed now and then. One verify IOCTL, which does not spin the disc up */
+constexpr auto DRIVE_STATUS_REFRESH_INTERVAL{std::chrono::seconds(10)};
+/*! A disc with no label yet is still mounting, so it is read again soon */
+constexpr auto MOUNTING_DISC_RETRY_INTERVAL{std::chrono::seconds(5)};
+/*! A labelled disc that did not identify itself is usually a data disc, or a Blu-ray libbluray
+    cannot open - a stable condition, and each attempt can cost seconds on the main thread */
+constexpr auto UNIDENTIFIED_DISC_RETRY_INTERVAL{std::chrono::seconds(60)};
+/*! How long a disc whose TOC could not be read is left alone before trying again - see GetCdInfo */
+constexpr auto CDINFO_RETRY_INTERVAL{std::chrono::seconds(30)};
+
+const char* DriveStateName(DriveState state)
+{
+  switch (state)
+  {
+    using enum DriveState;
+    case OPEN:
+      return "open";
+    case NOT_READY:
+      return "not ready";
+    case READY:
+      return "ready";
+    case CLOSED_NO_MEDIA:
+      return "closed, no media";
+    case CLOSED_MEDIA_PRESENT:
+      return "closed, media present";
+    case NONE:
+      return "no drive";
+    case CLOSED_MEDIA_UNDEFINED:
+      return "closed, media undefined";
+  }
+  return "unknown";
+}
+} // namespace
+#endif
 
 CMediaManager::CMediaManager()
 {
@@ -415,6 +457,13 @@ std::string CMediaManager::TranslateDevicePath(const std::string& devicePath, bo
     strDevice = StringUtils::Format("\\\\.\\{}:", strDevice[0]);
 
   URIUtils::RemoveSlashAtEnd(strDevice);
+
+  // Drive letters are case insensitive on Windows, but the translated path is used as a map key
+  // (drive state cache, cd info)
+  const size_t colon{strDevice.find(':')};
+  if (colon == 1 || (colon == 5 && StringUtils::StartsWith(strDevice, "\\\\.\\")))
+    strDevice[colon - 1] =
+        static_cast<char>(std::toupper(static_cast<unsigned char>(strDevice[colon - 1])));
 #endif
   return strDevice;
 }
@@ -423,19 +472,6 @@ bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if (!m_bOpticalDrivePresent)
-    return false;
-
-  std::string strDevice = TranslateDevicePath(devicePath, false);
-
-  // m_mapCdInfo is only populated for audio CDs
-  {
-    std::unique_lock waitLock(m_muAutoSource);
-    if (m_mapCdInfo.contains(strDevice))
-      return true;
-  }
-
-  // Check physical drive state (for video discs)
   return GetDriveStatus(devicePath) == DriveState::CLOSED_MEDIA_PRESENT;
 #else
   if(URIUtils::IsDVD(devicePath) || devicePath.empty())
@@ -448,15 +484,15 @@ bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 #endif
 }
 
-bool CMediaManager::IsAudio(const std::string& devicePath)
+bool CMediaManager::IsAudio(const std::string& devicePath, bool allowCachedFailure)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if (!m_bOpticalDrivePresent)
+  if (!IsOpticalDrivePresent())
     return false;
 
-  CCdInfo* pCdInfo = GetCdInfo(devicePath);
-  if(pCdInfo != NULL && pCdInfo->IsAudio(1))
+  CCdInfo* pCdInfo{GetCdInfo(devicePath, allowCachedFailure)};
+  if (pCdInfo != NULL && pCdInfo->IsAudio(1))
     return true;
 
   return false;
@@ -483,11 +519,50 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if (!m_bOpticalDrivePresent || !m_platformDiscDriveHander)
+  if (!IsOpticalDrivePresent() || !m_platformDiscDriveHander)
     return DriveState::NOT_READY;
 
-  std::string translatedDevicePath = TranslateDevicePath(devicePath, true);
-  return m_platformDiscDriveHander->GetDriveState(translatedDevicePath);
+  const std::string translatedDevicePath{TranslateDevicePath(devicePath, true)};
+
+  // GUI labels query this every frame. Reuse the last state until expiry or a storage/tray event.
+  uint64_t generation{0};
+  {
+    std::unique_lock lock(m_driveStatusSection);
+    const auto it{m_driveStatusCache.find(translatedDevicePath)};
+    if (it != m_driveStatusCache.end() && std::chrono::steady_clock::now() < it->second.expires)
+      return it->second.state;
+    generation = m_driveStatusGeneration;
+  }
+
+  // Deliberately queried without holding m_driveStatusSection - this can block for seconds on a
+  // drive that is spinning up, and no other caller should have to wait behind it.
+  const DriveState state{m_platformDiscDriveHander->GetDriveState(translatedDevicePath)};
+
+  {
+    std::unique_lock lock(m_driveStatusSection);
+
+    // Do not cache a probe invalidated by a storage or tray event while it was in flight.
+    if (generation == m_driveStatusGeneration)
+    {
+      // Failed probes and no-media answers may recover without an event. Throttle retries,
+      // including when an empty drive cannot be distinguished from a disc spinning up.
+      const auto expires{std::chrono::steady_clock::now() +
+                         (state == DriveState::NOT_READY || state == DriveState::CLOSED_NO_MEDIA
+                              ? DRIVE_STATUS_RETRY_INTERVAL
+                              : DRIVE_STATUS_REFRESH_INTERVAL)};
+      m_driveStatusCache.insert_or_assign(translatedDevicePath,
+                                          DriveStatusCacheEntry{state, expires});
+    }
+
+    const auto logged{m_driveStatusLogged.find(translatedDevicePath)};
+    if (logged == m_driveStatusLogged.end() || logged->second != state)
+    {
+      m_driveStatusLogged.insert_or_assign(translatedDevicePath, state);
+      CLog::LogF(LOGDEBUG, "Drive {} state is now {}", translatedDevicePath, DriveStateName(state));
+    }
+  }
+
+  return state;
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDriveState();
 #endif
@@ -496,46 +571,150 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
 #endif
 }
 
+bool CMediaManager::IsOpticalDrivePresent()
+{
+  std::unique_lock waitLock(m_muAutoSource);
+  return m_bOpticalDrivePresent;
+}
+
+void CMediaManager::ResetDriveCaches(const std::string& devicePath)
+{
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  // The drive state is keyed by the device (eg. "\\.\D:"), the disc identity by the drive ("D:")
+  const std::string translatedDevicePath{
+      devicePath.empty() ? std::string{} : TranslateDevicePath(devicePath, true)};
+  const std::string drivePath{devicePath.empty() ? std::string{}
+                                                 : TranslateDevicePath(devicePath, false)};
+
+  // Each cache has its own lock, and they are never nested
+  {
+    std::unique_lock lock(m_driveStatusSection);
+    ++m_driveStatusGeneration;
+    if (translatedDevicePath.empty())
+      m_driveStatusCache.clear();
+    else
+      m_driveStatusCache.erase(translatedDevicePath);
+  }
+
+  {
+    std::unique_lock lock(m_discInfoSection);
+    ++m_discInfoGeneration;
+    if (drivePath.empty())
+      m_mapDiscInfo.clear();
+    else
+      m_mapDiscInfo.erase(drivePath);
+  }
+
+  //! @todo m_mapCdInfo hands out raw pointers to entries it owns, so it cannot safely be cleared
+  //! here - a caller may still be reading one. It is only released through RemoveAutoSource().
+  //! Only the record of discs that yielded no CdInfo is dropped.
+  {
+    std::unique_lock waitLock(m_muAutoSource);
+    ++m_cdInfoGeneration;
+    if (drivePath.empty())
+      m_cdInfoUnavailable.clear();
+    else
+      m_cdInfoUnavailable.erase(drivePath);
+  }
+#endif
+}
+
 #ifdef HAS_OPTICAL_DRIVE
-CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
+CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath, bool allowCachedFailure)
 {
 #ifdef TARGET_WINDOWS
-  if (!m_bOpticalDrivePresent)
+  if (!IsOpticalDrivePresent())
     return NULL;
 
-  std::string strDevice = TranslateDevicePath(devicePath, false);
-  std::map<std::string,CCdInfo*>::iterator it;
-  {
-    std::unique_lock waitLock(m_muAutoSource);
-    it = m_mapCdInfo.find(strDevice);
-    if(it != m_mapCdInfo.end())
-      return it->second;
-  }
+  const std::string strDevice{TranslateDevicePath(devicePath, false)};
 
-  CCdInfo* pCdInfo=NULL;
-  CCdIoSupport cdio;
-  pCdInfo = cdio.GetCdInfo((char*)strDevice.c_str());
-  if(pCdInfo!=NULL)
+  // A read invalidated by a storage or tray event while in flight describes the previous disc,
+  // so it is discarded and the disc that is there now is read once more
+  for (int attempt = 0; attempt < 2; ++attempt)
   {
-    std::unique_lock waitLock(m_muAutoSource);
-    m_mapCdInfo.insert(std::pair<std::string,CCdInfo*>(strDevice,pCdInfo));
-  }
+    uint64_t generation{0};
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      const auto it{m_mapCdInfo.find(strDevice)};
+      if (it != m_mapCdInfo.end())
+        return it->second;
 
-  return pCdInfo;
+      // Only polling callers reuse failures; classification and playback must be able to retry.
+      const auto unavailable{m_cdInfoUnavailable.find(strDevice)};
+      if (allowCachedFailure && unavailable != m_cdInfoUnavailable.end() &&
+          std::chrono::steady_clock::now() < unavailable->second)
+        return NULL;
+      generation = m_cdInfoGeneration;
+    }
+
+    // Reading the TOC is slow, so this is done without holding m_muAutoSource
+    CCdInfo* pCdInfo{CacheCdInfo(strDevice, ReadToc(strDevice), generation)};
+    if (pCdInfo)
+      return pCdInfo;
+
+    std::unique_lock waitLock(m_muAutoSource);
+    if (generation == m_cdInfoGeneration)
+      return NULL; // The disc really could not be read
+  }
+  return NULL;
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetCdInfo();
 #endif
 }
 
+#ifdef TARGET_WINDOWS
+std::unique_ptr<CCdInfo> CMediaManager::ReadToc(const std::string& devicePath)
+{
+  if (m_readToc)
+    return m_readToc(devicePath);
+
+  CCdIoSupport cdio;
+  return std::unique_ptr<CCdInfo>{cdio.GetCdInfo(const_cast<char*>(devicePath.c_str()))};
+}
+
+CCdInfo* CMediaManager::CacheCdInfo(const std::string& devicePath,
+                                    std::unique_ptr<CCdInfo> info,
+                                    uint64_t generation)
+{
+  std::unique_lock waitLock(m_muAutoSource);
+  if (generation != m_cdInfoGeneration)
+  {
+    CLog::LogF(LOGDEBUG, "Discarding invalidated TOC read for {}", devicePath);
+    return nullptr;
+  }
+
+  const auto cached{m_mapCdInfo.find(devicePath)};
+  if (cached != m_mapCdInfo.end())
+    return cached->second;
+
+  if (info)
+  {
+    const auto [it, inserted]{m_mapCdInfo.try_emplace(devicePath, info.get())};
+    if (inserted)
+      info.release();
+    m_cdInfoUnavailable.erase(devicePath);
+    return it->second;
+  }
+
+  m_cdInfoUnavailable.insert_or_assign(devicePath,
+                                       std::chrono::steady_clock::now() + CDINFO_RETRY_INTERVAL);
+  return nullptr;
+}
+#endif
+
 bool CMediaManager::RemoveCdInfo(const std::string& devicePath)
 {
-  if (!m_bOpticalDrivePresent)
+  if (!IsOpticalDrivePresent())
     return false;
 
   std::string strDevice = TranslateDevicePath(devicePath, false);
 
   std::map<std::string,CCdInfo*>::iterator it;
   std::unique_lock waitLock(m_muAutoSource);
+#ifdef TARGET_WINDOWS
+  ++m_cdInfoGeneration;
+  m_cdInfoUnavailable.erase(strDevice);
+#endif
   it = m_mapCdInfo.find(strDevice);
   if(it != m_mapCdInfo.end())
   {
@@ -548,48 +727,86 @@ bool CMediaManager::RemoveCdInfo(const std::string& devicePath)
   return false;
 }
 
+CMediaManager::DiscInfoCacheEntry CMediaManager::GetCachedDiscInfo(const std::string& mediaPath)
+{
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  uint64_t generation{0};
+  {
+    std::unique_lock lock(m_discInfoSection);
+    const auto cached{m_mapDiscInfo.find(mediaPath)};
+    if (cached != m_mapDiscInfo.end() && std::chrono::steady_clock::now() < cached->second.expires)
+      return cached->second;
+    generation = m_discInfoGeneration;
+  }
+#endif
+
+  // Reading the disc is slow, so this is done without holding m_discInfoSection
+  DiscInfoCacheEntry entry;
+  entry.info = GetDiscInfo(mediaPath);
+  entry.label = entry.info.name;
+
+#if defined(TARGET_WINDOWS) && !defined(TARGET_WINDOWS_STORE)
+  if (entry.label.empty())
+  {
+    // Nothing identified the disc, fall back to the volume label. Deliberately kept out of
+    // entry.info, which has to stay exactly what the disc said - GetDiskUniqueId() reads an
+    // empty DiscInfo as "this disc cannot be identified"
+    std::string volumeRoot{mediaPath};
+    URIUtils::AddSlashAtEnd(volumeRoot);
+    std::wstring volumeRootW;
+    g_charsetConverter.utf8ToW(volumeRoot, volumeRootW);
+    WCHAR cVolumeName[128];
+    WCHAR cFSName[128];
+    if (GetVolumeInformationW(volumeRootW.c_str(), cVolumeName, 127, NULL, NULL, NULL, cFSName,
+                              127) != 0)
+    {
+      std::string volumeName;
+      g_charsetConverter.wToUTF8(cVolumeName, volumeName);
+      entry.label = StringUtils::TrimRight(volumeName, " ");
+    }
+  }
+#endif
+
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  CacheDiscInfo(mediaPath, entry, generation);
+#endif
+
+  return entry;
+}
+
+#ifdef TARGET_WINDOWS
+void CMediaManager::CacheDiscInfo(const std::string& mediaPath,
+                                  DiscInfoCacheEntry& entry,
+                                  uint64_t generation)
+{
+  std::unique_lock lock(m_discInfoSection);
+  if (generation == m_discInfoGeneration)
+  {
+    // A volume label does not prove that disc identification succeeded
+    if (entry.label.empty())
+      entry.expires = std::chrono::steady_clock::now() + MOUNTING_DISC_RETRY_INTERVAL;
+    else if (entry.info.empty())
+      entry.expires = std::chrono::steady_clock::now() + UNIDENTIFIED_DISC_RETRY_INTERVAL;
+    m_mapDiscInfo.insert_or_assign(mediaPath, entry);
+  }
+}
+#endif
+
 std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
 {
 #ifdef TARGET_WINDOWS_STORE
   return ""; // GetVolumeInformationW nut support in UWP app
 #elif defined(TARGET_WINDOWS)
-  if (!m_bOpticalDrivePresent)
+  if (!IsOpticalDrivePresent())
     return "";
 
-  std::string mediaPath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath);
-
-  auto cached = m_mapDiscInfo.find(mediaPath);
-  if (cached != m_mapDiscInfo.end())
-    return cached->second.name;
+  const std::string mediaPath{TranslateDevicePath(devicePath)};
 
   // try to minimize the chance of a "device not ready" dialog
-  std::string drivePath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath, true);
-  if (CServiceBroker::GetMediaManager().GetDriveStatus(drivePath) !=
-      DriveState::CLOSED_MEDIA_PRESENT)
+  if (GetDriveStatus(mediaPath) != DriveState::CLOSED_MEDIA_PRESENT)
     return "";
 
-  UTILS::DISCS::DiscInfo info;
-  info = GetDiscInfo(mediaPath);
-  if (!info.name.empty())
-  {
-    m_mapDiscInfo[mediaPath] = info;
-    return info.name;
-  }
-
-  std::string strDevice = TranslateDevicePath(devicePath);
-  WCHAR cVolumenName[128];
-  WCHAR cFSName[128];
-  URIUtils::AddSlashAtEnd(strDevice);
-  std::wstring strDeviceW;
-  g_charsetConverter.utf8ToW(strDevice, strDeviceW);
-  if(GetVolumeInformationW(strDeviceW.c_str(), cVolumenName, 127, NULL, NULL, NULL, cFSName, 127)==0)
-    return "";
-  g_charsetConverter.wToUTF8(cVolumenName, strDevice);
-  info.name = StringUtils::TrimRight(strDevice, " ");
-  if (!info.name.empty())
-    m_mapDiscInfo[mediaPath] = info;
-
-  return info.name;
+  return GetCachedDiscInfo(mediaPath).label;
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDVDLabel();
 #endif
@@ -619,7 +836,8 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
   }
 #endif
 
-  UTILS::DISCS::DiscInfo info = GetDiscInfo(mediaPath);
+  // Shares the read with GetDiskLabel(), which AddOpticalSource() calls immediately before this
+  UTILS::DISCS::DiscInfo info{GetCachedDiscInfo(mediaPath).info};
   if (info.empty())
   {
     CLog::Log(LOGDEBUG, "GetDiskUniqueId: Retrieving ID for path {} failed, ID is empty.",
@@ -650,7 +868,12 @@ bool CMediaManager::HasMediaBlurayPlaylist(const std::string& devicePath)
     return m_hasBlurayPlaylist == HasBlurayPlaylist::YES;
 
   const std::string mediaPath{TranslateDevicePath(devicePath)};
-  UTILS::DISCS::DiscInfo info{GetDiscInfo(mediaPath)};
+  UTILS::DISCS::DiscInfo info{GetCachedDiscInfo(mediaPath).info};
+#ifdef TARGET_WINDOWS
+  // Let the timed identification cache retry before remembering that no playlist exists.
+  if (info.empty())
+    return false;
+#endif
   if (!info.empty() && info.type == UTILS::DISCS::DiscType::BLURAY)
   {
     const std::string blurayPath{GetDiskUniqueId()};
@@ -703,8 +926,14 @@ std::shared_ptr<IDiscDriveHandler> CMediaManager::GetDiscDriveHandler()
 
 void CMediaManager::SetHasOpticalDrive(bool bstatus)
 {
-  std::unique_lock waitLock(m_muAutoSource);
-  m_bOpticalDrivePresent = bstatus;
+  bool changed{false};
+  {
+    std::unique_lock waitLock(m_muAutoSource);
+    changed = m_bOpticalDrivePresent != bstatus;
+    m_bOpticalDrivePresent = bstatus;
+  }
+  if (changed)
+    ResetDriveCaches();
 }
 
 bool CMediaManager::Eject(const std::string& mountpath)
@@ -713,7 +942,9 @@ bool CMediaManager::Eject(const std::string& mountpath)
 #ifdef HAVE_LIBBLURAY
   m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-  return m_platformStorage->Eject(mountpath);
+  const bool ejected{m_platformStorage->Eject(mountpath)};
+  ResetDriveCaches(mountpath);
+  return ejected;
 }
 
 void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
@@ -724,7 +955,9 @@ void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->EjectDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->EjectDriveTray(devicePath);
+    ResetDriveCaches(devicePath);
   }
 #endif
 }
@@ -737,7 +970,9 @@ void CMediaManager::CloseTray(const char cDriveLetter)
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->ToggleDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->ToggleDriveTray(devicePath);
+    ResetDriveCaches(devicePath);
   }
 #endif
 }
@@ -750,7 +985,9 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->ToggleDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->ToggleDriveTray(devicePath);
+    ResetDriveCaches(devicePath);
   }
 #endif
 }
@@ -767,13 +1004,26 @@ void CMediaManager::ProcessEvents()
     // so we have to refresh m_strFirstAvailDrive when this happens after Initialize
     // was called (e.x. the disc was inserted after the start of xbmc)
     // else TranslateDevicePath wouldn't give the correct device
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
+    {
+      const std::string firstDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstDrive;
+    }
 #elif defined(TARGET_WINDOWS)
     // On Windows, virtual drives can appear or disappear at any time.
     // Re-scan to get the current state of optical drives and update
     // m_bhasoptical and m_strFirstAvailDrive accordingly.
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
-    SetHasOpticalDrive(!m_strFirstAvailDrive.empty());
+    const std::string firstDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstDrive;
+    }
+    SetHasOpticalDrive(!firstDrive.empty());
+
+    // A device change reported only as DBT_DEVTYP_DEVICEINTERFACE gives us no drive letter, so
+    // this rescan is the sole invalidation point for it. SetHasOpticalDrive() only clears the
+    // cache when the overall presence changes
+    ResetDriveCaches();
 #endif
 #endif
 
@@ -799,7 +1049,8 @@ void CMediaManager::AddOpticalSource(const std::string& devicePath)
 
   share.strStatus = GetDiskLabel(share.strPath);
   share.strDiskUniqueId = GetDiskUniqueId(share.strPath);
-  if (IsAudio(share.strPath))
+  // The TOC was just read for the unique ID, so a failure there need not be repeated here
+  if (IsAudio(share.strPath, true))
     share.strStatus = "Audio-CD";
   else if (share.strStatus.empty())
     share.strStatus = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(446);
@@ -812,22 +1063,27 @@ void CMediaManager::AddOpticalSource(const std::string& devicePath)
 
 void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveCaches(device.path);
 #ifdef HAS_OPTICAL_DRIVE
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
 #ifdef TARGET_WINDOWS
     SetHasOpticalDrive(true); // In case drive appeared after startup (eg. virtual drive)
-    if (m_strFirstAvailDrive.empty())
-      m_strFirstAvailDrive = device.path;
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      if (m_strFirstAvailDrive.empty())
+        m_strFirstAvailDrive = device.path;
+    }
+
     AddOpticalSource(device.path);
 #endif
 
+    // Source creation clears the previous TOC; classification retries any failed read.
+    CCdInfo* pInfo{GetCdInfo(device.path)};
+    const bool isAudioDisc{pInfo && pInfo->IsAudio(1)};
+
     const std::shared_ptr<CSettings> settings{
         CServiceBroker::GetSettingsComponent()->GetSettings()};
-
-    CCdInfo* pInfo{GetCdInfo(device.path)};
-    const bool isAudioDisc{pInfo && // If it returns null, it is likely to be a protected video disc
-                           pInfo->IsAudio(1)};
 
     if (isAudioDisc)
     {
@@ -901,6 +1157,7 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
 
 void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveCaches(device.path);
 #ifdef TARGET_WINDOWS
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
@@ -918,6 +1175,7 @@ void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageD
 
 void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveCaches(device.path);
 #ifdef TARGET_WINDOWS
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
@@ -966,11 +1224,13 @@ UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
 
 void CMediaManager::RemoveDiscInfo(const std::string& devicePath)
 {
-  std::string strDevice = TranslateDevicePath(devicePath, false);
+  const std::string strDevice{TranslateDevicePath(devicePath, false)};
 
-  auto it = m_mapDiscInfo.find(strDevice);
-  if (it != m_mapDiscInfo.end())
-    m_mapDiscInfo.erase(it);
+  {
+    std::unique_lock lock(m_discInfoSection);
+    ++m_discInfoGeneration;
+    m_mapDiscInfo.erase(strDevice);
+  }
 
 #ifdef HAVE_LIBBLURAY
   CServiceBroker::GetBlurayDiscCache()->ClearDisc(strDevice);

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -15,6 +15,9 @@
 #include "threads/CriticalSection.h"
 #include "utils/DiscsUtils.h"
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <vector>
@@ -68,14 +71,27 @@ public:
 #endif
 
   bool IsDiscInDrive(const std::string& devicePath="");
-  bool IsAudio(const std::string& devicePath="");
+  /*! \brief Whether the disc in a drive is an audio CD
+   * \param allowCachedFailure Allow GUI polling to reuse a recent failed TOC read on Windows.
+   *        Explicit actions such as ripping must leave this false so they read the disc again.
+   */
+  bool IsAudio(const std::string& devicePath = "", bool allowCachedFailure = false);
   bool HasOpticalDrive();
   std::string TranslateDevicePath(const std::string& devicePath, bool bReturnAsDevice=false);
   DriveState GetDriveStatus(const std::string& devicePath = "");
+
+  /*! \brief Discard everything cached about a drive, so the next query asks the hardware again
+   * \param devicePath The optical drive path, empty for every drive
+   */
+  void ResetDriveCaches(const std::string& devicePath = "");
 #ifdef HAS_OPTICAL_DRIVE
-  MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath="");
-  bool RemoveCdInfo(const std::string& devicePath="");
-  std::string GetDiskLabel(const std::string& devicePath="");
+  /*! \brief Get the disc TOC, reusing successful reads.
+   * \param allowCachedFailure Allow GUI polling to reuse a recent failed read on Windows.
+   */
+  MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath = "",
+                                   bool allowCachedFailure = false);
+  bool RemoveCdInfo(const std::string& devicePath = "");
+  std::string GetDiskLabel(const std::string& devicePath = "");
   std::string GetDiskUniqueId(const std::string& devicePath="");
   bool HasMediaBlurayPlaylist(const std::string& devicePath = "");
 
@@ -166,7 +182,62 @@ private:
 #endif
 
   void RemoveDiscInfo(const std::string& devicePath);
-  std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
+
+  bool IsOpticalDrivePresent();
+
+  struct DiscInfoCacheEntry
+  {
+    /*! What the disc reported about itself, exactly as GetDiscInfo() returned it */
+    UTILS::DISCS::DiscInfo info;
+    /*! The name to show for the disc - info.name, or the volume label if the disc gave none */
+    std::string label;
+    /*! When the entry must be read again. max() for a disc that did identify itself */
+    std::chrono::steady_clock::time_point expires{std::chrono::steady_clock::time_point::max()};
+  };
+
+  /*! \brief Read the disc in a drive, answering from the cache whenever it can
+   * Reading a disc is slow - it can spin the drive up and, for a Blu-ray, load libaacs - so
+   * everything that needs to identify a disc shares the one read.
+   * \param mediaPath The drive holding the disc (eg. "D:")
+   * \return What the disc reported, and the name to show for it
+   */
+  DiscInfoCacheEntry GetCachedDiscInfo(const std::string& mediaPath);
+  /*! Disc identity per drive, read from the disc itself - see GetDiskLabel */
+  std::map<std::string, DiscInfoCacheEntry> m_mapDiscInfo;
+  uint64_t m_discInfoGeneration{0};
+  CCriticalSection m_discInfoSection;
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  friend class TestMediaManager;
+
+  /*! Reads the TOC of the disc in a drive. Replaceable so the cache can be tested without one */
+  std::function<std::unique_ptr<MEDIA_DETECT::CCdInfo>(const std::string& devicePath)> m_readToc;
+  std::unique_ptr<MEDIA_DETECT::CCdInfo> ReadToc(const std::string& devicePath);
+  MEDIA_DETECT::CCdInfo* CacheCdInfo(const std::string& devicePath,
+                                     std::unique_ptr<MEDIA_DETECT::CCdInfo> info,
+                                     uint64_t generation);
+  void CacheDiscInfo(const std::string& mediaPath, DiscInfoCacheEntry& entry, uint64_t generation);
+
+  struct DriveStatusCacheEntry
+  {
+    DriveState state{DriveState::NOT_READY};
+    /*! When the entry must be re-probed. Soon for a state that may recover on its own, later for
+        a stable one, in case the event that should have announced a change never arrived */
+    std::chrono::steady_clock::time_point expires{std::chrono::steady_clock::time_point::max()};
+  };
+  /*! Last known state of each optical drive, to keep the GUI off the hardware - see GetDriveStatus */
+  std::map<std::string, DriveStatusCacheEntry> m_driveStatusCache;
+  /*! Last state logged per drive. Deliberately survives ResetDriveCaches() so a re-probe that
+      lands on the same state stays quiet - only transitions are logged */
+  std::map<std::string, DriveState> m_driveStatusLogged;
+  /*! Bumped by every ResetDriveCaches() so a probe that was invalidated while it was in
+      flight can discard its now stale result instead of caching it - see GetDriveStatus */
+  uint64_t m_driveStatusGeneration{0};
+  CCriticalSection m_driveStatusSection;
+  /*! Drives whose disc yielded no CdInfo, and when to try reading it again. Guarded by
+      m_muAutoSource like m_mapCdInfo - see GetCdInfo */
+  std::map<std::string, std::chrono::steady_clock::time_point> m_cdInfoUnavailable;
+  uint64_t m_cdInfoGeneration{0};
+#endif
 #ifdef HAVE_LIBBLURAY
   HasBlurayPlaylist m_hasBlurayPlaylist{HasBlurayPlaylist::UNKNOWN};
 #endif

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestEpisodeUtils.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
+            TestMediaManager.cpp
             TestMediaSource.cpp
             TestPasswordManager.cpp
             TestPlayListPlayer.cpp

--- a/xbmc/test/TestMediaManager.cpp
+++ b/xbmc/test/TestMediaManager.cpp
@@ -1,0 +1,480 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "storage/MediaManager.h"
+
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+
+#include "storage/cdioSupport.h"
+#include "storage/discs/IDiscDriveHandler.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+class FakeDiscDriveHandler : public IDiscDriveHandler
+{
+public:
+  ~FakeDiscDriveHandler() override = default;
+
+  DriveState GetDriveState(const std::string& devicePath) override
+  {
+    ++probes;
+    if (onProbe)
+      onProbe();
+    return state;
+  }
+  TrayState GetTrayState(const std::string& devicePath) override { return TrayState::UNDEFINED; }
+  void EjectDriveTray(const std::string& devicePath) override {}
+  void CloseDriveTray(const std::string& devicePath) override {}
+  void ToggleDriveTray(const std::string& devicePath) override {}
+
+  DriveState state{DriveState::CLOSED_MEDIA_PRESENT};
+  int probes{0};
+  /*! Runs inside the probe, ie. while GetDriveStatus() holds no lock */
+  std::function<void()> onProbe;
+};
+} // namespace
+
+class TestMediaManager : public testing::Test
+{
+protected:
+  using Clock = std::chrono::steady_clock;
+  static constexpr const char* DEVICE_PATH = "?:\\kodi-test-nonexistent-optical-drive";
+  static constexpr const char* SECOND_DEVICE_PATH = "!:\\kodi-test-second-optical-drive";
+
+  void SetUp() override
+  {
+    m_manager.m_bOpticalDrivePresent = true;
+    m_manager.m_strFirstAvailDrive = DEVICE_PATH;
+    m_manager.m_platformDiscDriveHander = m_drive;
+  }
+
+  void TearDown() override
+  {
+    m_manager.RemoveCdInfo(DEVICE_PATH);
+    m_manager.RemoveCdInfo(SECOND_DEVICE_PATH);
+  }
+
+  uint64_t CdInfoGeneration() const { return m_manager.m_cdInfoGeneration; }
+  uint64_t DiscInfoGeneration() const { return m_manager.m_discInfoGeneration; }
+
+  MEDIA_DETECT::CCdInfo* StoreCdInfo(std::unique_ptr<MEDIA_DETECT::CCdInfo> info,
+                                     uint64_t generation)
+  {
+    return m_manager.CacheCdInfo(DEVICE_PATH, std::move(info), generation);
+  }
+
+  void SeedCachedFailure(const std::string& devicePath = DEVICE_PATH,
+                         Clock::time_point expires = Clock::time_point::max())
+  {
+    m_manager.m_cdInfoUnavailable[devicePath] = expires;
+  }
+
+  bool HasCachedFailure(const std::string& devicePath = DEVICE_PATH) const
+  {
+    return m_manager.m_cdInfoUnavailable.contains(devicePath);
+  }
+  bool HasCachedCdInfo() const { return m_manager.m_mapCdInfo.contains(DEVICE_PATH); }
+  auto FailureExpiry() const { return m_manager.m_cdInfoUnavailable.at(DEVICE_PATH); }
+
+  void StoreDiscInfo(const UTILS::DISCS::DiscInfo& info,
+                     const std::string& label,
+                     uint64_t generation,
+                     const std::string& mediaPath = DEVICE_PATH)
+  {
+    CMediaManager::DiscInfoCacheEntry entry;
+    entry.info = info;
+    entry.label = label;
+    m_manager.CacheDiscInfo(mediaPath, entry, generation);
+  }
+
+  void SeedDiscInfo(const std::string& label, Clock::time_point expires)
+  {
+    CMediaManager::DiscInfoCacheEntry entry;
+    entry.label = label;
+    entry.expires = expires;
+    m_manager.m_mapDiscInfo[DEVICE_PATH] = entry;
+  }
+
+  bool HasCachedDiscInfo(const std::string& mediaPath = DEVICE_PATH) const
+  {
+    return m_manager.m_mapDiscInfo.contains(mediaPath);
+  }
+  auto ReadCachedDiscInfo() { return m_manager.GetCachedDiscInfo(DEVICE_PATH); }
+#ifdef HAVE_LIBBLURAY
+  auto PlaylistStatus() const { return m_manager.m_hasBlurayPlaylist; }
+#endif
+
+  void SetFirstDrive(const std::string& devicePath) { m_manager.m_strFirstAvailDrive = devicePath; }
+
+  /*! Replace the TOC reader, so no hardware is touched and every read is counted */
+  void ReadTocWith(std::function<std::unique_ptr<MEDIA_DETECT::CCdInfo>()> reader)
+  {
+    m_manager.m_readToc = [this, reader = std::move(reader)](const std::string& devicePath)
+    {
+      ++m_tocReads;
+      return reader();
+    };
+  }
+  static std::unique_ptr<MEDIA_DETECT::CCdInfo> NoToc() { return nullptr; }
+  static std::unique_ptr<MEDIA_DETECT::CCdInfo> SomeToc()
+  {
+    return std::make_unique<MEDIA_DETECT::CCdInfo>();
+  }
+  int m_tocReads{0};
+
+  /*! The drive state cache is keyed by the device form of the path */
+  std::string DeviceKey(const std::string& devicePath)
+  {
+    return m_manager.TranslateDevicePath(devicePath, true);
+  }
+  bool HasCachedDriveStatus(const std::string& devicePath)
+  {
+    return m_manager.m_driveStatusCache.contains(DeviceKey(devicePath));
+  }
+  auto DriveStatusExpiry(const std::string& devicePath)
+  {
+    return m_manager.m_driveStatusCache.at(DeviceKey(devicePath)).expires;
+  }
+  void ExpireDriveStatus(const std::string& devicePath)
+  {
+    m_manager.m_driveStatusCache.at(DeviceKey(devicePath)).expires =
+        Clock::now() - std::chrono::seconds(1);
+  }
+
+  std::shared_ptr<FakeDiscDriveHandler> m_drive{std::make_shared<FakeDiscDriveHandler>()};
+  CMediaManager m_manager;
+};
+
+// Disc identification cache
+
+TEST_F(TestMediaManager, FailedIdentificationWithVolumeLabelExpiresSlowly)
+{
+  const auto before{Clock::now()};
+  StoreDiscInfo({}, "Volume label", DiscInfoGeneration());
+
+  const auto entry{ReadCachedDiscInfo()};
+  EXPECT_EQ(entry.label, "Volume label");
+  EXPECT_EQ(entry.info.type, UTILS::DISCS::DiscType::UNKNOWN);
+  EXPECT_TRUE(entry.info.name.empty());
+  EXPECT_GE(entry.expires, before + std::chrono::seconds(60));
+  EXPECT_LE(entry.expires, Clock::now() + std::chrono::seconds(60));
+}
+
+TEST_F(TestMediaManager, SuccessfulIdentificationRemainsCached)
+{
+  UTILS::DISCS::DiscInfo info;
+  info.type = UTILS::DISCS::DiscType::DVD;
+  info.name = "Disc title";
+  info.serial = "Disc serial";
+  StoreDiscInfo(info, info.name, DiscInfoGeneration());
+
+  const auto entry{ReadCachedDiscInfo()};
+  EXPECT_EQ(entry.info.name, info.name);
+  EXPECT_EQ(entry.info.serial, info.serial);
+  EXPECT_EQ(entry.expires, Clock::time_point::max());
+}
+
+TEST_F(TestMediaManager, UnlabelledDiscExpiresQuickly)
+{
+  const auto before{Clock::now()};
+  UTILS::DISCS::DiscInfo info;
+  info.type = UTILS::DISCS::DiscType::DVD;
+  StoreDiscInfo(info, "", DiscInfoGeneration());
+
+  const auto entry{ReadCachedDiscInfo()};
+  EXPECT_GE(entry.expires, before + std::chrono::seconds(5));
+  EXPECT_LE(entry.expires, Clock::now() + std::chrono::seconds(5));
+}
+
+TEST_F(TestMediaManager, ExpiredDiscInfoIsReadAgain)
+{
+  SeedDiscInfo("Stale label", Clock::now() - std::chrono::seconds(1));
+
+  // The device does not exist, so a fresh read yields no label at all
+  EXPECT_NE(ReadCachedDiscInfo().label, "Stale label");
+}
+
+TEST_F(TestMediaManager, ResetRejectsInFlightDiscIdentification)
+{
+  const auto generation{DiscInfoGeneration()};
+  m_manager.ResetDriveCaches(DEVICE_PATH);
+  StoreDiscInfo({}, "Old volume label", generation);
+
+  EXPECT_FALSE(HasCachedDiscInfo());
+}
+
+#ifdef HAVE_LIBBLURAY
+TEST_F(TestMediaManager, UnidentifiedDiscDoesNotCachePlaylistAbsence)
+{
+  StoreDiscInfo({}, "Volume label", DiscInfoGeneration());
+  EXPECT_FALSE(m_manager.HasMediaBlurayPlaylist(DEVICE_PATH));
+  EXPECT_EQ(PlaylistStatus(), CMediaManager::HasBlurayPlaylist::UNKNOWN);
+
+  UTILS::DISCS::DiscInfo info;
+  info.type = UTILS::DISCS::DiscType::DVD;
+  StoreDiscInfo(info, "DVD title", DiscInfoGeneration());
+  EXPECT_FALSE(m_manager.HasMediaBlurayPlaylist(DEVICE_PATH));
+  EXPECT_EQ(PlaylistStatus(), CMediaManager::HasBlurayPlaylist::NO);
+}
+#endif
+
+// TOC cache
+
+TEST_F(TestMediaManager, OnlyPollingReusesCachedTocFailure)
+{
+  ReadTocWith(NoToc);
+  SeedCachedFailure();
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH, true), nullptr);
+  EXPECT_EQ(m_manager.IsAudio(DEVICE_PATH, true), false);
+  EXPECT_EQ(m_tocReads, 0);
+  EXPECT_EQ(FailureExpiry(), Clock::time_point::max());
+
+  // Explicit actions read the disc again and refresh the failure
+  const auto before{Clock::now()};
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH), nullptr);
+  EXPECT_EQ(m_manager.IsAudio(DEVICE_PATH), false);
+  EXPECT_EQ(m_tocReads, 2);
+  EXPECT_GE(FailureExpiry(), before + std::chrono::seconds(30));
+  EXPECT_LE(FailureExpiry(), Clock::now() + std::chrono::seconds(30));
+}
+
+TEST_F(TestMediaManager, ExpiredTocFailureIsReadAgain)
+{
+  ReadTocWith(NoToc);
+  SeedCachedFailure(DEVICE_PATH, Clock::now() - std::chrono::seconds(1));
+
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH, true), nullptr);
+  EXPECT_EQ(m_tocReads, 1);
+  EXPECT_GT(FailureExpiry(), Clock::now());
+}
+
+TEST_F(TestMediaManager, GenuineTocFailureIsNotRetried)
+{
+  ReadTocWith(NoToc);
+
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH), nullptr);
+  EXPECT_EQ(m_tocReads, 1);
+  EXPECT_TRUE(HasCachedFailure());
+}
+
+TEST_F(TestMediaManager, InvalidatedTocReadIsRetriedOnce)
+{
+  // A storage event arrives during the first read only
+  ReadTocWith(
+      [this]
+      {
+        if (m_tocReads == 1)
+          m_manager.ResetDriveCaches(DEVICE_PATH);
+        return SomeToc();
+      });
+
+  auto* info{m_manager.GetCdInfo(DEVICE_PATH)};
+  EXPECT_NE(info, nullptr);
+  EXPECT_EQ(m_tocReads, 2);
+  EXPECT_TRUE(HasCachedCdInfo());
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH), info);
+  EXPECT_EQ(m_tocReads, 2);
+}
+
+TEST_F(TestMediaManager, TocRetryStopsAfterTwoAttempts)
+{
+  // Every read is invalidated while in flight
+  ReadTocWith(
+      [this]
+      {
+        m_manager.ResetDriveCaches(DEVICE_PATH);
+        return SomeToc();
+      });
+
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH), nullptr);
+  EXPECT_EQ(m_tocReads, 2);
+  EXPECT_FALSE(HasCachedCdInfo());
+  EXPECT_FALSE(HasCachedFailure());
+}
+
+TEST_F(TestMediaManager, ResetRejectsInFlightSuccessfulTocRead)
+{
+  const auto generation{CdInfoGeneration()};
+  m_manager.ResetDriveCaches(DEVICE_PATH);
+
+  EXPECT_EQ(StoreCdInfo(std::make_unique<MEDIA_DETECT::CCdInfo>(), generation), nullptr);
+  EXPECT_FALSE(HasCachedCdInfo());
+  EXPECT_FALSE(HasCachedFailure());
+}
+
+TEST_F(TestMediaManager, ResetRejectsInFlightFailedTocRead)
+{
+  const auto generation{CdInfoGeneration()};
+  m_manager.ResetDriveCaches(DEVICE_PATH);
+
+  EXPECT_EQ(StoreCdInfo(nullptr, generation), nullptr);
+  EXPECT_FALSE(HasCachedCdInfo());
+  EXPECT_FALSE(HasCachedFailure());
+}
+
+TEST_F(TestMediaManager, RemovalClearsFailureAndInvalidatesInFlightRead)
+{
+  SeedCachedFailure();
+  const auto generation{CdInfoGeneration()};
+  m_manager.RemoveCdInfo(DEVICE_PATH);
+
+  EXPECT_FALSE(HasCachedFailure());
+  EXPECT_EQ(StoreCdInfo(std::make_unique<MEDIA_DETECT::CCdInfo>(), generation), nullptr);
+  EXPECT_FALSE(HasCachedCdInfo());
+}
+
+TEST_F(TestMediaManager, SuccessfulTocReadClearsCachedFailure)
+{
+  SeedCachedFailure();
+  auto* info{StoreCdInfo(std::make_unique<MEDIA_DETECT::CCdInfo>(), CdInfoGeneration())};
+
+  ASSERT_NE(info, nullptr);
+  EXPECT_FALSE(HasCachedFailure());
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH, true), info);
+  EXPECT_EQ(m_manager.GetCdInfo(DEVICE_PATH), info);
+}
+
+TEST_F(TestMediaManager, ConcurrentTocReadsKeepPublishedSuccess)
+{
+  auto* first{StoreCdInfo(std::make_unique<MEDIA_DETECT::CCdInfo>(), CdInfoGeneration())};
+  ASSERT_NE(first, nullptr);
+
+  EXPECT_EQ(StoreCdInfo(std::make_unique<MEDIA_DETECT::CCdInfo>(), CdInfoGeneration()), first);
+  EXPECT_EQ(StoreCdInfo(nullptr, CdInfoGeneration()), first);
+  EXPECT_FALSE(HasCachedFailure());
+}
+
+// Drive state cache
+
+TEST_F(TestMediaManager, PresentDiscIsProbedOnce)
+{
+  const auto before{Clock::now()};
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_MEDIA_PRESENT);
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_MEDIA_PRESENT);
+  EXPECT_TRUE(m_manager.IsDiscInDrive(DEVICE_PATH));
+  EXPECT_EQ(m_drive->probes, 1);
+
+  // A stable state is still confirmed eventually, in case Windows skipped the removal event
+  const auto expires{DriveStatusExpiry(DEVICE_PATH)};
+  EXPECT_GE(expires, before + std::chrono::seconds(10));
+  EXPECT_LE(expires, Clock::now() + std::chrono::seconds(10));
+}
+
+TEST_F(TestMediaManager, UnreportedEjectIsNoticedAfterRefresh)
+{
+  EXPECT_TRUE(m_manager.IsDiscInDrive(DEVICE_PATH));
+
+  // The user presses the drive's eject button and no storage event arrives
+  m_drive->state = DriveState::CLOSED_NO_MEDIA;
+  EXPECT_TRUE(m_manager.IsDiscInDrive(DEVICE_PATH));
+  EXPECT_EQ(m_drive->probes, 1);
+
+  ExpireDriveStatus(DEVICE_PATH);
+  EXPECT_FALSE(m_manager.IsDiscInDrive(DEVICE_PATH));
+  EXPECT_EQ(m_drive->probes, 2);
+}
+
+TEST_F(TestMediaManager, EmptyDriveIsReprobedOnlyAfterExpiry)
+{
+  m_drive->state = DriveState::CLOSED_NO_MEDIA;
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_NO_MEDIA);
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_NO_MEDIA);
+  EXPECT_EQ(m_drive->probes, 1);
+
+  ExpireDriveStatus(DEVICE_PATH);
+  m_drive->state = DriveState::CLOSED_MEDIA_PRESENT;
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_MEDIA_PRESENT);
+  EXPECT_EQ(m_drive->probes, 2);
+}
+
+TEST_F(TestMediaManager, FailedProbeIsReprobedOnlyAfterExpiry)
+{
+  m_drive->state = DriveState::NOT_READY;
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::NOT_READY);
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::NOT_READY);
+  EXPECT_EQ(m_drive->probes, 1);
+
+  ExpireDriveStatus(DEVICE_PATH);
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::NOT_READY);
+  EXPECT_EQ(m_drive->probes, 2);
+}
+
+TEST_F(TestMediaManager, ResetInvalidatesOnlyThatDrive)
+{
+  m_manager.GetDriveStatus(DEVICE_PATH);
+  m_manager.GetDriveStatus(SECOND_DEVICE_PATH);
+  EXPECT_EQ(m_drive->probes, 2);
+
+  m_manager.ResetDriveCaches(DEVICE_PATH);
+  EXPECT_FALSE(HasCachedDriveStatus(DEVICE_PATH));
+  EXPECT_TRUE(HasCachedDriveStatus(SECOND_DEVICE_PATH));
+
+  m_manager.GetDriveStatus(DEVICE_PATH);
+  m_manager.GetDriveStatus(SECOND_DEVICE_PATH);
+  EXPECT_EQ(m_drive->probes, 3);
+}
+
+TEST_F(TestMediaManager, ResetWithoutPathClearsEveryCache)
+{
+  m_manager.GetDriveStatus(DEVICE_PATH);
+  m_manager.GetDriveStatus(SECOND_DEVICE_PATH);
+  StoreDiscInfo({}, "Label", DiscInfoGeneration(), DEVICE_PATH);
+  StoreDiscInfo({}, "Label", DiscInfoGeneration(), SECOND_DEVICE_PATH);
+  SeedCachedFailure(DEVICE_PATH);
+  SeedCachedFailure(SECOND_DEVICE_PATH);
+
+  m_manager.ResetDriveCaches();
+
+  EXPECT_FALSE(HasCachedDriveStatus(DEVICE_PATH));
+  EXPECT_FALSE(HasCachedDriveStatus(SECOND_DEVICE_PATH));
+  EXPECT_FALSE(HasCachedDiscInfo(DEVICE_PATH));
+  EXPECT_FALSE(HasCachedDiscInfo(SECOND_DEVICE_PATH));
+  EXPECT_FALSE(HasCachedFailure(DEVICE_PATH));
+  EXPECT_FALSE(HasCachedFailure(SECOND_DEVICE_PATH));
+}
+
+TEST_F(TestMediaManager, ProbeInvalidatedInFlightIsNotStored)
+{
+  // A storage event arrives while the hardware is being asked
+  m_drive->onProbe = [this] { m_manager.ResetDriveCaches(DEVICE_PATH); };
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_MEDIA_PRESENT);
+  EXPECT_FALSE(HasCachedDriveStatus(DEVICE_PATH));
+
+  m_drive->onProbe = nullptr;
+  EXPECT_EQ(m_manager.GetDriveStatus(DEVICE_PATH), DriveState::CLOSED_MEDIA_PRESENT);
+  EXPECT_EQ(m_drive->probes, 2);
+  EXPECT_TRUE(HasCachedDriveStatus(DEVICE_PATH));
+}
+
+// Path normalisation
+
+TEST_F(TestMediaManager, DrivePathsAreNormalised)
+{
+  SetFirstDrive("\\\\.\\e:");
+
+  EXPECT_EQ(m_manager.TranslateDevicePath("d:"), "D:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("d:\\"), "D:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("d:", true), "\\\\.\\D:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("\\\\.\\d:"), "D:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("\\\\.\\d:", true), "\\\\.\\D:");
+
+  // The first drive stands in for an empty path and for the local audio CD
+  EXPECT_EQ(m_manager.TranslateDevicePath(""), "E:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("", true), "\\\\.\\E:");
+  EXPECT_EQ(m_manager.TranslateDevicePath("cdda://local/"), "E:");
+}
+
+#endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This caches the last answer per drive and refreshes it only when a storage event or tray operation says it may have changed,.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #29274 

Since #28191 every GUI frame that evaluates a disc info label or IsDiscInDrive sends an IOCTL to the optical drive and logs it twice, which floods the debug log and keeps drives from spinning down. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
