### PR TITLE
[Disc][Win32] Enumerating optical drives for their letters no longer reads each volume label.

### DIFF
--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -226,8 +226,11 @@ void CWin32StorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDriv
         wchar_t cVolumeName[100] = {};
         int nResult = 0;
         // don't use GetVolumeInformation on fdd's as the floppy controller may be enabled in Bios but
-        // no floppy HW is attached which causes huge delays.
-        if (uDriveType != DRIVE_REMOTE && !letter.empty() && letter != L"A:" && letter != L"B:")
+        // no floppy HW is attached which causes huge delays. Nor on optical drives when only the
+        // drive letters are wanted, as it waits on a drive that is spinning up.
+        const bool wantVolumeInfo{eDriveType != DVD_DRIVES || bonlywithmedia};
+        if (wantVolumeInfo && uDriveType != DRIVE_REMOTE && !letter.empty() && letter != L"A:" &&
+            letter != L"B:")
         {
           DWORD len = sizeof(cVolumeName) / sizeof(wchar_t);
           nResult = GetVolumeInformationW(strWdrive.c_str(), cVolumeName, len, 0, 0, 0, nullptr, 0);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Enumerating optical drives for their letters no longer reads each volume label, which can blocked the GUI when drives are loading.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As above.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
