### PR TITLE
DVDDemuxFFmpeg: drop the redundant __STDC_CONSTANT_MACROS/__STDC_LIMIT_MACROS guard

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -45,12 +45,6 @@
 #include <utility>
 #include <vector>
 
-#ifndef __STDC_CONSTANT_MACROS
-#define __STDC_CONSTANT_MACROS
-#endif
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #ifdef TARGET_POSIX
 #include <stdint.h>
 #endif


### PR DESCRIPTION
## Summary
- Removes the file-local `__STDC_CONSTANT_MACROS`/`__STDC_LIMIT_MACROS` `#ifndef`/`#define` guard from `DVDDemuxFFmpeg.cpp`.
- Every platform's `ArchSetup.cmake` already defines `__STDC_CONSTANT_MACROS` globally, so this local guard never fires.
- `__STDC_LIMIT_MACROS` isn't required anywhere in the codebase or by any vendored header — nothing checks for it.

Note: this intentionally does *not* touch the platform-global `-D__STDC_CONSTANT_MACROS` defines. Kodi's own vendored/patched FFmpeg (`002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch`, the fix proposed on the ffmpeg-devel mailing list: https://ffmpeg.org/pipermail/ffmpeg-devel/2020-November/273181.html) makes the guard in `libavutil/common.h` a no-op under C++11+, but that patch was never merged upstream in FFmpeg itself — so a build against a system/external FFmpeg still needs the platform-global define. Only the file-local, always-redundant guard is removed here.

## Test plan
- [x] Confirmed `DVDDemuxFFmpeg.cpp` matched between this branch and `master` before the change (no unrelated diff).
- [x] Built the wasm platform target end to end with the guard removed and confirmed no build errors.