### PR TITLE
Fix watched mode in Videos browsing

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -401,6 +401,24 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
   if (bResult)
   {
+    const bool isVideoDb = VIDEO::IsVideoDb(items);
+    // The content is already set for videodb paths, set content for the other paths.
+    if (!isVideoDb)
+    {
+      if (URIUtils::PathEquals(items.GetPath(), "special://videoplaylists/"))
+        items.SetContent("playlists");
+      else if (!items.IsVirtualDirectoryRoot())
+      { // load info from the database
+        std::string label;
+        if (items.GetLabel().empty() &&
+            m_rootDir.IsSource(items.GetPath(),
+                               CMediaSourceSettings::GetInstance().GetSources("video"), &label))
+          items.SetLabel(label);
+        if (!items.IsSourcesPath() && !items.IsLibraryFolder())
+          LoadVideoInfo(items, m_database);
+      }
+    }
+
     m_persistWatchedMode = true;
     if (const CVariant prop = items.GetProperty(PROPERTY_WATCHED_MODE); prop.isInteger())
     {
@@ -414,7 +432,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
     if (m_persistWatchedMode)
       m_watchedMode = CMediaSettings::GetInstance().GetWatchedMode(items.GetContent());
 
-    if (VIDEO::IsVideoDb(items))
+    if (isVideoDb)
     {
       XFILE::CVideoDatabaseDirectory dir;
       CQueryParams params;
@@ -534,16 +552,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
           }
         }
       }
-    }
-    else if (URIUtils::PathEquals(items.GetPath(), "special://videoplaylists/"))
-      items.SetContent("playlists");
-    else if (!items.IsVirtualDirectoryRoot())
-    { // load info from the database
-      std::string label;
-      if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("video"), &label))
-        items.SetLabel(label);
-      if (!items.IsSourcesPath() && !items.IsLibraryFolder())
-        LoadVideoInfo(items, m_database);
     }
 
     CVideoDbUrl videoUrl;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Follow up fix of PR #28780 

`CGUIWindowVideoBase::GetDirectory()` returns an items list with a valid content type for library paths, but not for other paths.
As a result, the content type was not available by the time the watched mode was set in `CGUIWindowVideoNav::GetDirectory()`.
The watched mode is needed in turn in the tv show flattening for videodb paths.

The fix is to move the code executed for non-videodb paths, which sets the content type, earlier.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix #29185

Watched mode while browsing Videos not restored/persisted/synced with watched mode of Movies and TV Shows.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Opened smartplaylist with watched mode attribute, browsed movies or tv shows => unchanged
Browsing Videos sets the watched mode according to the content displayed (movies or shows) and watched mode changes are persisted.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Restore sync of watched mode while browsing Videos with the watched mode of Movies/TV Shows that was broken by #28780.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
