### PR TITLE
[WASM] Application and platform foundation

### DIFF
--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -9,3 +9,4 @@ xbmc/platform/posix/utils             platform/posix/utils
 xbmc/platform/wasm                    platform/wasm
 xbmc/platform/wasm/network            platform/wasm/network
 xbmc/platform/wasm/storage            platform/wasm/storage
+xbmc/platform/wasm/utils              platform/wasm/utils

--- a/system/settings/wasm.xml
+++ b/system/settings/wasm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings version="1">
+  <section id="services">
+    <category id="control">
+      <group id="2">
+        <setting id="services.esenabled">
+          <default>false</default>
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esport">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esportrange">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esmaxclients">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esallinterfaces">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esinitialdelay">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.escontinuousdelay">
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/tools/wasm/kodi.html
+++ b/tools/wasm/kodi.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0d0720">
+  <title>Kodi — WebAssembly</title>
+  <style>
+    :root {
+      --bg: #04020b;
+      --piers-cyan: #4dd0e1;
+      --piers-magenta-hi: #e054ff;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html,
+    body {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: var(--bg);
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                   'Helvetica Neue', Arial, sans-serif;
+    }
+
+    canvas {
+      display: block;
+      width: 100vw;
+      height: 100vh;
+      background: #000;
+      outline: none;
+    }
+
+    #splash {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 5vw 8vh;
+      overflow: hidden;
+      background: var(--bg) url('media/splash.jpg') center center / cover no-repeat;
+      transition: opacity .35s ease, visibility 0s linear .35s;
+    }
+
+    #splash.hidden {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    #splash.discarded {
+      display: none;
+    }
+
+    .splash-content {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      width: min(560px, 72vw);
+      padding: 18px 20px;
+      border: 1px solid rgba(255, 255, 255, .14);
+      border-radius: 8px;
+      background: rgba(4, 2, 11, .72);
+      transform: translateY(34vh);
+    }
+
+    .progress-block {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+    }
+
+    .progress-track {
+      position: relative;
+      width: 100%;
+      height: 4px;
+      overflow: hidden;
+      border-radius: 3px;
+      background: rgba(255, 255, 255, .16);
+    }
+
+    .progress-fill {
+      width: 0%;
+      height: 100%;
+      border-radius: 3px;
+      background: linear-gradient(90deg,
+                                  var(--piers-cyan) 0%,
+                                  var(--piers-magenta-hi) 100%);
+      transition: width .3s ease;
+    }
+
+    .progress-fill.indeterminate {
+      width: 40%;
+      animation: slide 1.6s ease-in-out infinite;
+      transition: none;
+    }
+
+    @keyframes slide {
+      0% { transform: translateX(-120%); }
+      100% { transform: translateX(260%); }
+    }
+
+    .status-line {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      width: 100%;
+      color: rgba(255, 255, 255, .55);
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .status-text {
+      max-width: 70%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      letter-spacing: .4px;
+    }
+
+    .status-pct {
+      min-width: 3ch;
+      color: var(--piers-cyan);
+      font-weight: 600;
+      text-align: right;
+    }
+
+    #splash.error .progress-fill {
+      width: 100% !important;
+      animation: none;
+      background: linear-gradient(90deg, #ff5a5a 0%, #ff9b9b 100%);
+    }
+
+    #splash.error .status-text,
+    #splash.error .status-pct {
+      color: #ff9b9b;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .progress-fill.indeterminate {
+        animation: none !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="splash" role="status" aria-live="polite" aria-label="Loading Kodi">
+    <div class="splash-content">
+      <div class="progress-block">
+        <div class="progress-track">
+          <div class="progress-fill indeterminate" id="progressFill"></div>
+        </div>
+        <div class="status-line">
+          <span class="status-text" id="statusText">Starting up…</span>
+          <span class="status-pct" id="statusPct"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="0"></canvas>
+
+  <script>
+    var splashEl     = document.getElementById('splash');
+    var statusTextEl = document.getElementById('statusText');
+    var statusPctEl  = document.getElementById('statusPct');
+    var progressFill = document.getElementById('progressFill');
+    var canvas       = document.getElementById('canvas');
+
+    function setProgress(pct) {
+      if (pct == null || isNaN(pct)) {
+        progressFill.classList.add('indeterminate');
+        statusPctEl.textContent = '';
+        return;
+      }
+      pct = Math.max(0, Math.min(100, pct));
+      progressFill.classList.remove('indeterminate');
+      progressFill.style.width = pct.toFixed(1) + '%';
+      statusPctEl.textContent = Math.round(pct) + '%';
+    }
+
+    function setStatusText(text) {
+      statusTextEl.textContent = text || '';
+    }
+
+    function hideSplash() {
+      if (splashEl.classList.contains('hidden')) return;
+      splashEl.classList.add('hidden');
+      setTimeout(function () {
+        if (splashEl.classList.contains('error')) return;
+        splashEl.setAttribute('aria-hidden', 'true');
+        splashEl.classList.add('discarded');
+      }, 900);
+    }
+
+    function showError(message) {
+      splashEl.classList.remove('discarded');
+      splashEl.removeAttribute('aria-hidden');
+      splashEl.classList.add('error');
+      splashEl.classList.remove('hidden');
+      progressFill.classList.remove('indeterminate');
+      setStatusText(message || 'Failed to load Kodi');
+      statusPctEl.textContent = '!';
+    }
+    window.showError = showError;
+
+    // Parse Emscripten setStatus strings. Common forms:
+    //   "Downloading data... (1234567/9876543)"
+    //   "Preparing... (3/7)"
+    //   "Running..."
+    //   ""  (empty → runtime ready)
+    var EMSCRIPTEN_PROGRESS_RE = /\((\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\)/;
+
+    function applyEmscriptenStatus(text) {
+      if (!text) return; // empty string means "ready"
+
+      var m = text.match(EMSCRIPTEN_PROGRESS_RE);
+      var label = text.replace(EMSCRIPTEN_PROGRESS_RE, '').trim();
+      if (m) {
+        var cur = parseFloat(m[1]);
+        var tot = parseFloat(m[2]);
+        if (tot > 0) setProgress((cur / tot) * 100);
+        if (!label) label = 'Loading assets…';
+      } else {
+        setProgress(null);
+      }
+      setStatusText(label || text);
+    }
+
+    var Module = {
+      canvas: canvas,
+      print:    function (t) { console.log(t); },
+      printErr: function (t) { console.error(t); },
+
+      setStatus: function (text) {
+        if (splashEl.classList.contains('error')) return;
+        applyEmscriptenStatus(text);
+      },
+
+      monitorRunDependencies: function (remaining) {
+        if (splashEl.classList.contains('error')) return;
+        if (remaining > 0) {
+          setStatusText('Preparing runtime… (' + remaining + ' left)');
+          setProgress(null);
+        }
+      },
+
+      onAbort: function (what) {
+        showError('Kodi aborted: ' + (what || 'unknown error'));
+      },
+
+      onKodiFirstFramePresented: function () {
+        canvas.focus();
+        hideSplash();
+      },
+
+      onRuntimeInitialized: function () {
+        setStatusText('Starting Kodi…');
+        setProgress(null);
+        canvas.focus();
+      }
+    };
+
+    window.addEventListener('error', function (e) {
+      if (e && e.filename && /kodi\.(js|wasm|data)(\?|$)/i.test(e.filename)) {
+        showError('Failed to load ' + e.filename.split('/').pop());
+      }
+    });
+
+    setStatusText('Downloading Kodi…');
+    setProgress(null);
+  </script>
+
+  <script async src="kodi.js" onerror="showError('Could not load kodi.js')"></script>
+</body>
+</html>

--- a/tools/wasm/serve.py
+++ b/tools/wasm/serve.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""
+Minimal HTTP server for Kodi WASM builds.
+
+- Serves static files with the COOP/COEP headers required by SharedArrayBuffer.
+- Exposes a same-origin streaming proxy at `/proxy?u=<url-encoded>` so the
+  browser can reach http(s) servers that don't send CORS headers. Only loopback
+  clients may use it unless --allow-lan-proxy is given.
+
+Usage:
+  cd build-wasm
+  cp ../tools/wasm/kodi.html .
+  python3 ../tools/wasm/serve.py          # http://127.0.0.1:8080
+  python3 ../tools/wasm/serve.py 9000
+  python3 ../tools/wasm/serve.py 0.0.0.0:8080  # serve media to a Kodi on the LAN
+
+The launcher itself only works from 127.0.0.1 or localhost: a page loaded over
+plain http from any other address is not a secure context, so the browser
+withholds SharedArrayBuffer and the pthread runtime cannot start. Binding to
+0.0.0.0 is for exposing this directory as a media source to another Kodi.
+"""
+
+import http.server
+import ipaddress
+import socketserver
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    allow_lan_proxy = False
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+        ".js": "application/javascript",
+    }
+
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        # CORS-enabled so a Kodi running elsewhere (a TV on the LAN) can use
+        # this server's directory listings as a media source.
+        self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.send_header("Access-Control-Expose-Headers", "*")
+        self.send_header("Cache-Control", "no-cache")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path.startswith("/proxy?"):
+            self._proxy(body=True)
+        else:
+            super().do_GET()
+
+    def do_HEAD(self):
+        if self.path.startswith("/proxy?"):
+            self._proxy(body=False)
+        else:
+            super().do_HEAD()
+
+    def _client_is_loopback(self) -> bool:
+        ip = ipaddress.ip_address(self.client_address[0])
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
+        return ip.is_loopback
+
+    def _proxy(self, body: bool):
+        if not self.allow_lan_proxy and not self._client_is_loopback():
+            self.send_error(403, "proxy is loopback-only; start with --allow-lan-proxy")
+            return
+        url = urllib.parse.parse_qs(self.path.split("?", 1)[1]).get("u", [""])[0]
+        if not url.startswith(("http://", "https://")):
+            self.send_error(400, "bad ?u=")
+            return
+
+        req = urllib.request.Request(url, method=self.command)
+        # Forward a few request headers so the upstream sees a real client.
+        # Notably, download.blender.org returns 403 to the default
+        # "Python-urllib/3.x" agent.
+        for name in ("Range", "User-Agent", "Referer"):
+            value = self.headers.get(name)
+            if value is not None:
+                req.add_header(name, value)
+        req.add_header("Accept-Encoding", "identity")
+        if req.get_header("User-agent") is None:
+            req.add_header("User-Agent", "Mozilla/5.0 (Kodi-WASM proxy)")
+
+        try:
+            upstream = urllib.request.urlopen(req, timeout=15)
+        except urllib.error.HTTPError as exc:
+            upstream = exc
+        except Exception as exc:
+            self.send_error(502, f"upstream: {exc}")
+            return
+
+        with upstream:
+            self.send_response(upstream.status)
+            for name in ("Content-Type", "Content-Length", "Content-Range",
+                         "Accept-Ranges", "Last-Modified", "ETag"):
+                value = upstream.headers.get(name)
+                if value is not None:
+                    self.send_header(name, value)
+            self.end_headers()
+            if body and self.command != "HEAD":
+                try:
+                    while chunk := upstream.read(64 * 1024):
+                        self.wfile.write(chunk)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+
+class ThreadingServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "--allow-lan-proxy" in args:
+        args.remove("--allow-lan-proxy")
+        Handler.allow_lan_proxy = True
+    bind = "127.0.0.1"
+    port_arg = args[0] if args else "8080"
+    if ":" in port_arg:
+        bind, port_text = port_arg.rsplit(":", 1)
+        port = int(port_text)
+    else:
+        port = int(port_arg)
+    print(f"Serving http://{bind}:{port}/kodi.html  (Ctrl-C to stop)")
+    print(f"Proxy:   http://{bind}:{port}/proxy?u=<url-encoded>")
+    ThreadingServer((bind, port), Handler).serve_forever()

--- a/tools/wasm/serve.py
+++ b/tools/wasm/serve.py
@@ -4,9 +4,12 @@
 Minimal HTTP server for Kodi WASM builds.
 
 - Serves static files with the COOP/COEP headers required by SharedArrayBuffer.
+- Serves static files with byte-range support so a remote Kodi can seek.
 - Exposes a same-origin streaming proxy at `/proxy?u=<url-encoded>` so the
   browser can reach http(s) servers that don't send CORS headers. Only loopback
-  clients may use it unless --allow-lan-proxy is given.
+  clients may use it unless --allow-lan-proxy is given. The proxy is for single
+  files: references inside a proxied HLS/DASH playlist are not rewritten, so
+  relative ones resolve against this server and absolute ones bypass the proxy.
 
 Usage:
   cd build-wasm
@@ -23,6 +26,8 @@ withholds SharedArrayBuffer and the pthread runtime cannot start. Binding to
 
 import http.server
 import ipaddress
+import os
+import re
 import socketserver
 import sys
 import urllib.error
@@ -49,6 +54,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Headers", "*")
         self.send_header("Access-Control-Expose-Headers", "*")
         self.send_header("Cache-Control", "no-cache")
+        if not self.path.startswith("/proxy?"):
+            self.send_header("Accept-Ranges", "bytes")
         super().end_headers()
 
     def do_OPTIONS(self):
@@ -58,7 +65,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith("/proxy?"):
             self._proxy(body=True)
-        else:
+        elif not self._send_range():
             super().do_GET()
 
     def do_HEAD(self):
@@ -66,6 +73,48 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self._proxy(body=False)
         else:
             super().do_HEAD()
+
+    def _send_range(self) -> bool:
+        """Serve one `bytes=` range of a regular file; False if not applicable."""
+        match = re.fullmatch(r"bytes=(\d*)-(\d*)", self.headers.get("Range", ""))
+        path = self.translate_path(self.path)
+        if not match or not os.path.isfile(path):
+            return False
+        size = os.path.getsize(path)
+        first, last = match.groups()
+        if first:
+            start = int(first)
+            end = min(int(last), size - 1) if last else size - 1
+        elif last:
+            start = max(size - int(last), 0)
+            end = size - 1
+        else:
+            return False
+        if start > end or start >= size:
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{size}")
+            self.end_headers()
+            return True
+
+        with open(path, "rb") as f:
+            self.send_response(206)
+            self.send_header("Content-Type", self.guess_type(path))
+            self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+            self.send_header("Content-Length", str(end - start + 1))
+            self.send_header("Last-Modified", self.date_time_string(os.fstat(f.fileno()).st_mtime))
+            self.end_headers()
+            f.seek(start)
+            remaining = end - start + 1
+            try:
+                while remaining > 0:
+                    chunk = f.read(min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    remaining -= len(chunk)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+        return True
 
     def _client_is_loopback(self) -> bool:
         ip = ipaddress.ip_address(self.client_address[0])

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -37,6 +37,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
+#include "application/AppEnvironment.h"
 #include "application/AppInboundProtocol.h"
 #include "application/AppParams.h"
 #include "application/ApplicationActionListeners.h"
@@ -181,6 +182,10 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+
+#ifdef TARGET_WASM
+#include <emscripten.h>
+#endif
 
 #include <tinyxml.h>
 
@@ -1659,6 +1664,12 @@ int CApplication::Run()
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 
+#ifdef TARGET_WASM
+  // emscripten_set_main_loop() unwinds the stack instead of returning; WasmRunIteration()
+  // handles shutdown once the browser calls it back with m_bStop set.
+  emscripten_set_main_loop([]() { g_application.WasmRunIteration(); }, 0, 1);
+  return m_ExitCode; // unreachable
+#else
   while (!m_bStop)
     RunIteration();
 
@@ -1666,6 +1677,7 @@ int CApplication::Run()
 
   CLog::Log(LOGINFO, "Exiting the application...");
   return m_ExitCode;
+#endif
 }
 
 void CApplication::RunIteration()
@@ -1694,6 +1706,22 @@ void CApplication::RunIteration()
       KODI::TIME::Sleep(noRenderFrameTime - frameTime);
   }
 }
+
+#ifdef TARGET_WASM
+void CApplication::WasmRunIteration()
+{
+  if (!m_bStop)
+  {
+    RunIteration();
+    return;
+  }
+
+  emscripten_cancel_main_loop();
+  Cleanup();
+  CLog::Log(LOGINFO, "Exiting the application...");
+  CAppEnvironment::TearDown();
+}
+#endif
 
 bool CApplication::Cleanup()
 {

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1651,10 +1651,6 @@ int CApplication::Run()
 {
   CLog::Log(LOGINFO, "Running the application...");
 
-  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
-  std::chrono::milliseconds frameTime;
-  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
-
   CFileItemList& playlist = CServiceBroker::GetAppParams()->GetPlaylist();
   if (playlist.Size() > 0)
   {
@@ -1663,37 +1659,40 @@ int CApplication::Run()
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 
-  // Run the app
   while (!m_bStop)
-  {
-    // Animate and render a frame
-
-    lastFrameTime = std::chrono::steady_clock::now();
-    Process();
-
-    bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
-    if (!m_bStop)
-    {
-      FrameMove(true, renderGUI);
-    }
-
-    if (renderGUI && !m_bStop)
-    {
-      Render();
-    }
-    else if (!renderGUI)
-    {
-      auto now = std::chrono::steady_clock::now();
-      frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
-      if (frameTime.count() < noRenderFrameTime)
-        KODI::TIME::Sleep(std::chrono::milliseconds(noRenderFrameTime - frameTime.count()));
-    }
-  }
+    RunIteration();
 
   Cleanup();
 
   CLog::Log(LOGINFO, "Exiting the application...");
   return m_ExitCode;
+}
+
+void CApplication::RunIteration()
+{
+  // Animate and render a frame
+
+  const auto lastFrameTime = std::chrono::steady_clock::now();
+  Process();
+
+  bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
+  if (!m_bStop)
+  {
+    FrameMove(true, renderGUI);
+  }
+
+  if (renderGUI && !m_bStop)
+  {
+    Render();
+  }
+  else if (!renderGUI)
+  {
+    constexpr std::chrono::milliseconds noRenderFrameTime{15}; // Simulates ~66fps
+    const auto frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - lastFrameTime);
+    if (frameTime < noRenderFrameTime)
+      KODI::TIME::Sleep(noRenderFrameTime - frameTime);
+  }
 }
 
 bool CApplication::Cleanup()

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -241,6 +241,9 @@ private:
   void PrintStartupLog();
   void ResetCurrentItem();
   void RunIteration();
+#ifdef TARGET_WASM
+  void WasmRunIteration();
+#endif
 
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -240,6 +240,7 @@ public:
 private:
   void PrintStartupLog();
   void ResetCurrentItem();
+  void RunIteration();
 
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
@@ -14,7 +14,7 @@
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
-#if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN)
+#if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN) && !defined(TARGET_WASM)
 std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
 {
   return std::make_unique<CPosixInterfaceForCLog>();

--- a/xbmc/platform/wasm/main.cpp
+++ b/xbmc/platform/wasm/main.cpp
@@ -26,6 +26,9 @@ int main(int argc, char* argv[])
   appParamParser.GetAppParams()->SetLogTarget("console");
 
   CAppEnvironment::SetUp(appParamParser.GetAppParams());
+
+  // Only reached when startup fails: once the Emscripten main loop is installed the stack is
+  // unwound and CApplication tears the environment down itself.
   const int status = XBMC_Run(true);
   CAppEnvironment::TearDown();
   return status;

--- a/xbmc/platform/wasm/main.cpp
+++ b/xbmc/platform/wasm/main.cpp
@@ -27,9 +27,9 @@ int main(int argc, char* argv[])
 
   CAppEnvironment::SetUp(appParamParser.GetAppParams());
 
+  const int status = XBMC_Run(true);
   // Only reached when startup fails: once the Emscripten main loop is installed the stack is
   // unwound and CApplication tears the environment down itself.
-  const int status = XBMC_Run(true);
   CAppEnvironment::TearDown();
   return status;
 }

--- a/xbmc/platform/wasm/utils/CMakeLists.txt
+++ b/xbmc/platform/wasm/utils/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES WasmInterfaceForCLog.cpp)
+
+set(HEADERS WasmInterfaceForCLog.h)
+
+core_add_library(platform_wasm_utils)

--- a/xbmc/platform/wasm/utils/WasmInterfaceForCLog.cpp
+++ b/xbmc/platform/wasm/utils/WasmInterfaceForCLog.cpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "platform/wasm/utils/WasmInterfaceForCLog.h"
+
+#include "ServiceBroker.h"
+#include "application/AppParams.h"
+
+#include <mutex>
+
+#include <emscripten.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/dist_sink.h>
+
+namespace
+{
+// Routes log lines to the browser console, mapping spdlog levels onto console methods so
+// DevTools filtering works.
+class CBrowserConsoleSink : public spdlog::sinks::base_sink<std::mutex>
+{
+protected:
+  void sink_it_(const spdlog::details::log_msg& msg) override
+  {
+    spdlog::memory_buf_t formatted;
+    formatter_->format(msg, formatted);
+
+    // The formatter appends a newline, which the console would render as an empty line.
+    size_t length = formatted.size();
+    while (length > 0 && (formatted[length - 1] == '\n' || formatted[length - 1] == '\r'))
+      --length;
+
+    int method = 3;
+    switch (msg.level)
+    {
+      case spdlog::level::trace:
+      case spdlog::level::debug:
+        method = 0;
+        break;
+      case spdlog::level::info:
+        method = 1;
+        break;
+      case spdlog::level::warn:
+        method = 2;
+        break;
+      default:
+        break;
+    }
+
+    // clang-format off
+    EM_ASM({
+      const text = UTF8ToString($0, $1);
+      switch ($2)
+      {
+        case 0: console.debug(text); break;
+        case 1: console.info(text); break;
+        case 2: console.warn(text); break;
+        default: console.error(text); break;
+      }
+    }, formatted.data(), length, method);
+    // clang-format on
+  }
+
+  void flush_() override {}
+};
+} // namespace
+
+std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
+{
+  return std::make_unique<CWasmInterfaceForCLog>();
+}
+
+void CWasmInterfaceForCLog::AddSinks(
+    std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
+{
+  if (CServiceBroker::GetAppParams()->GetLogTarget() == "console")
+    distributionSink->add_sink(std::make_shared<CBrowserConsoleSink>());
+}

--- a/xbmc/platform/wasm/utils/WasmInterfaceForCLog.h
+++ b/xbmc/platform/wasm/utils/WasmInterfaceForCLog.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/utils/PosixInterfaceForCLog.h"
+
+class CWasmInterfaceForCLog : public CPosixInterfaceForCLog
+{
+public:
+  CWasmInterfaceForCLog() = default;
+  ~CWasmInterfaceForCLog() override = default;
+
+  void AddSinks(
+      std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const override;
+};

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -269,6 +269,9 @@ bool CSettings::InitializeDefinitions()
   if (CFile::Exists(SETTINGS_XML_FOLDER "webos.xml") &&
       !Initialize(SETTINGS_XML_FOLDER "webos.xml"))
     CLog::Log(LOGFATAL, "Unable to load webOS-specific settings definitions");
+#elif defined(TARGET_WASM)
+  if (CFile::Exists(SETTINGS_XML_FOLDER "wasm.xml") && !Initialize(SETTINGS_XML_FOLDER "wasm.xml"))
+    CLog::Log(LOGFATAL, "Unable to load wasm-specific settings definitions");
 #elif defined(TARGET_LINUX)
   if (CFile::Exists(SETTINGS_XML_FOLDER "linux.xml") && !Initialize(SETTINGS_XML_FOLDER "linux.xml"))
     CLog::Log(LOGFATAL, "Unable to load linux-specific settings definitions");


### PR DESCRIPTION
## Description
Brings up the application layer for the WebAssembly (Emscripten) platform on top of the runtime skeleton from #28226.

- `CApplication::Run()` drives frames through `emscripten_set_main_loop` on wasm. The per-frame body moves into a `RunIteration()` shared by the blocking loop every other platform uses and the browser callback, so there is a single copy of the frame logic.
- New `CWasmInterfaceForCLog` platform log, following the Android/Darwin pattern, that routes console logging to `console.debug/info/warn/error` so DevTools level filtering works.
- `system/settings/wasm.xml` hides the event server settings, which cannot work without UDP sockets in a browser.
- `tools/wasm/kodi.html` is the canvas host with a loading splash driven by `Module.setStatus`, and `tools/wasm/serve.py` is a small dev server that sets the COOP/COEP headers pthreads require and offers a same-origin proxy, loopback-only by default, for media sources without CORS headers.

## Motivation and context
Part of the series porting Kodi to WebAssembly. A browser tab cannot block its own event loop, so the main loop has to be inverted into a per-frame callback; the rest is the minimum plumbing to see log output and serve the build locally.

## How has this been tested?
Built with the Emscripten toolchain (emcc 6.0.9) against this branch: all touched targets compile, including the full recompile triggered by the `Application.h` change. The final link needs the GLES renderers that the windowing follow-up adds, so this slice does not produce a runnable `kodi.js` on its own. The complete series runs in Chrome and on a Samsung Tizen TV.

## What is the effect on users?
None for existing platforms. Non-wasm builds keep the same `Run()` behaviour, only refactored.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [x] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

