### PR TITLE
[WASM] GLES windowing backend and browser input

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18118,6 +18118,12 @@ msgctxt "#34010"
 msgid "Siri remote pan gesture vertical sensitivity"
 msgstr ""
 
+#. Help text of setting "input.usekodikeyboard" on WebAssembly
+#: system/settings/wasm.xml
+msgctxt "#34011"
+msgid "When you need to enter some text, Kodi virtual keyboard will show up instead of the browser's or TV's built-in keyboard"
+msgstr ""
+
 #empty strings from id 34011 to 34099
 
 #: system/settings/settings.xml

--- a/cmake/scripts/wasm/ArchSetup.cmake
+++ b/cmake/scripts/wasm/ArchSetup.cmake
@@ -34,6 +34,7 @@ set(APP_BINARY_SUFFIX ".js")
 # emcc --profiling keeps function names in the build so browser DevTools can
 # attribute samples; it is off by default because it inflates the binary.
 option(ENABLE_WASM_PROFILING "Enable Emscripten --profiling (CPU profiling in browser DevTools)" OFF)
+option(ENABLE_WASM_DEV_PROXY "Route cross-origin requests through tools/wasm/serve.py's /proxy" OFF)
 
 # Threading + memory (COOP/COEP headers required in HTML for pthreads).
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
@@ -53,8 +54,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-sMAX_WEBGL_VERSION=2"
     "SHELL:-sFULL_ES3=1"
+    # The WebGL context lives on the browser main thread; GL calls from the Kodi
+    # pthread are proxied to it and presented with emscripten_webgl_commit_frame().
+    "SHELL:-sOFFSCREEN_FRAMEBUFFER=1"
+    "SHELL:-sGL_SUPPORT_EXPLICIT_SWAP_CONTROL=1"
     "SHELL:-lidbfs.js"
     "SHELL:-lembind"
+    # kodi_pre.js uses Module.ccall('kodi_wasm_dispatch_paste', ...) for clipboard paste.
+    "SHELL:-sEXPORTED_RUNTIME_METHODS=ccall,cwrap"
+    "SHELL:--pre-js ${CMAKE_SOURCE_DIR}/xbmc/platform/wasm/kodi_pre.js"
+    "SHELL:--js-library ${CMAKE_SOURCE_DIR}/xbmc/windowing/wasm/webgl_commit.js"
   )
 
   # ---------------------------------------------------------------------------
@@ -91,6 +100,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     add_compile_options(--profiling)
     add_link_options(--profiling)
     message(STATUS "WASM: Emscripten --profiling enabled (ENABLE_WASM_PROFILING=ON)")
+  endif()
+
+  if(ENABLE_WASM_DEV_PROXY)
+    add_link_options("SHELL:--pre-js ${CMAKE_SOURCE_DIR}/tools/wasm/dev_proxy_pre.js")
+    message(STATUS "WASM: cross-origin requests routed through serve.py's /proxy (ENABLE_WASM_DEV_PROXY=ON)")
   endif()
 endif()
 

--- a/cmake/scripts/wasm/ExtraTargets.cmake
+++ b/cmake/scripts/wasm/ExtraTargets.cmake
@@ -1,0 +1,8 @@
+# Emscripten reads these at link time; without this a change to them does not relink.
+set_property(TARGET ${APP_NAME_LC} APPEND PROPERTY LINK_DEPENDS
+  ${CMAKE_SOURCE_DIR}/xbmc/platform/wasm/kodi_pre.js
+  ${CMAKE_SOURCE_DIR}/xbmc/windowing/wasm/webgl_commit.js)
+if(ENABLE_WASM_DEV_PROXY)
+  set_property(TARGET ${APP_NAME_LC} APPEND PROPERTY LINK_DEPENDS
+    ${CMAKE_SOURCE_DIR}/tools/wasm/dev_proxy_pre.js)
+endif()

--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -9,3 +9,4 @@ xbmc/platform/posix/utils             platform/posix/utils
 xbmc/platform/wasm                    platform/wasm
 xbmc/platform/wasm/network            platform/wasm/network
 xbmc/platform/wasm/storage            platform/wasm/storage
+xbmc/platform/wasm/utils              platform/wasm/utils

--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -10,3 +10,4 @@ xbmc/platform/wasm                    platform/wasm
 xbmc/platform/wasm/network            platform/wasm/network
 xbmc/platform/wasm/storage            platform/wasm/storage
 xbmc/platform/wasm/utils              platform/wasm/utils
+xbmc/windowing/wasm                   windowing/wasm

--- a/system/settings/wasm.xml
+++ b/system/settings/wasm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings version="1">
+  <section id="services">
+    <category id="control">
+      <group id="2">
+        <setting id="services.esenabled">
+          <default>false</default>
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esport">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esportrange">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esmaxclients">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esallinterfaces">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.esinitialdelay">
+          <visible>false</visible>
+        </setting>
+        <setting id="services.escontinuousdelay">
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/system/settings/wasm.xml
+++ b/system/settings/wasm.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings version="1">
+  <section id="system">
+    <category id="input">
+      <group id="1">
+        <setting id="input.usekodikeyboard" type="boolean" label="24162" help="34011">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+  </section>
   <section id="services">
     <category id="control">
       <group id="2">

--- a/tools/wasm/dev_proxy_pre.js
+++ b/tools/wasm/dev_proxy_pre.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 Team Kodi
+//
+// Development-only pre-js, linked when ENABLE_WASM_DEV_PROXY=ON. Rewrites every
+// cross-origin http(s) XHR/fetch issued by the module to '/proxy?u=<encoded>',
+// the same-origin proxy tools/wasm/serve.py exposes, so sources without CORS
+// headers are reachable from a page served over http(s). Runs in the main
+// thread and in every pthread worker, hence the check on the environment rather
+// than on Module settings, which workers do not see.
+
+(function installHttpProxy(scope) {
+  var servedOverHttp = scope.location && /^https?:$/.test(scope.location.protocol);
+  var onTizen = /Tizen/i.test((scope.navigator && scope.navigator.userAgent) || '');
+  if (!servedOverHttp || onTizen) {
+    return;
+  }
+  var base = '/proxy';
+
+  function rewrite(url) {
+    if (typeof url !== 'string') {
+      return url;
+    }
+    try {
+      var u = new URL(url, scope.location.href);
+      if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+        return url;
+      }
+      if (u.origin === scope.location.origin) {
+        return url;
+      }
+      return base + '?u=' + encodeURIComponent(u.href);
+    } catch (_) {
+      return url;
+    }
+  }
+
+  if (scope.XMLHttpRequest && scope.XMLHttpRequest.prototype &&
+      !scope.XMLHttpRequest.prototype.__kodiProxyPatched) {
+    var origOpen = scope.XMLHttpRequest.prototype.open;
+    scope.XMLHttpRequest.prototype.open = function (method, url) {
+      arguments[1] = rewrite(url);
+      return origOpen.apply(this, arguments);
+    };
+    scope.XMLHttpRequest.prototype.__kodiProxyPatched = true;
+  }
+
+  if (typeof scope.fetch === 'function' && !scope.fetch.__kodiProxyPatched) {
+    var origFetch = scope.fetch.bind(scope);
+    var patched = function (input, init) {
+      if (typeof input === 'string') {
+        input = rewrite(input);
+      } else if (input && typeof input.url === 'string') {
+        var rewritten = rewrite(input.url);
+        if (rewritten !== input.url) {
+          input = new Request(rewritten, input);
+        }
+      }
+      return origFetch(input, init);
+    };
+    patched.__kodiProxyPatched = true;
+    scope.fetch = patched;
+  }
+})(globalThis);

--- a/tools/wasm/kodi.html
+++ b/tools/wasm/kodi.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0d0720">
+  <title>Kodi — WebAssembly</title>
+  <style>
+    :root {
+      --bg: #04020b;
+      --piers-cyan: #4dd0e1;
+      --piers-magenta-hi: #e054ff;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html,
+    body {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: var(--bg);
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                   'Helvetica Neue', Arial, sans-serif;
+    }
+
+    canvas {
+      display: block;
+      width: 100vw;
+      height: 100vh;
+      background: #000;
+      outline: none;
+    }
+
+    #splash {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 5vw 8vh;
+      overflow: hidden;
+      background: var(--bg) url('media/splash.jpg') center center / cover no-repeat;
+      transition: opacity .35s ease, visibility 0s linear .35s;
+    }
+
+    #splash.hidden {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    #splash.discarded {
+      display: none;
+    }
+
+    .splash-content {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      width: min(560px, 72vw);
+      padding: 18px 20px;
+      border: 1px solid rgba(255, 255, 255, .14);
+      border-radius: 8px;
+      background: rgba(4, 2, 11, .72);
+      transform: translateY(34vh);
+    }
+
+    .progress-block {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+    }
+
+    .progress-track {
+      position: relative;
+      width: 100%;
+      height: 4px;
+      overflow: hidden;
+      border-radius: 3px;
+      background: rgba(255, 255, 255, .16);
+    }
+
+    .progress-fill {
+      width: 0%;
+      height: 100%;
+      border-radius: 3px;
+      background: linear-gradient(90deg,
+                                  var(--piers-cyan) 0%,
+                                  var(--piers-magenta-hi) 100%);
+      transition: width .3s ease;
+    }
+
+    .progress-fill.indeterminate {
+      width: 40%;
+      animation: slide 1.6s ease-in-out infinite;
+      transition: none;
+    }
+
+    @keyframes slide {
+      0% { transform: translateX(-120%); }
+      100% { transform: translateX(260%); }
+    }
+
+    .status-line {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      width: 100%;
+      color: rgba(255, 255, 255, .55);
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .status-text {
+      max-width: 70%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      letter-spacing: .4px;
+    }
+
+    .status-pct {
+      min-width: 3ch;
+      color: var(--piers-cyan);
+      font-weight: 600;
+      text-align: right;
+    }
+
+    #splash.error .progress-fill {
+      width: 100% !important;
+      animation: none;
+      background: linear-gradient(90deg, #ff5a5a 0%, #ff9b9b 100%);
+    }
+
+    #splash.error .status-text,
+    #splash.error .status-pct {
+      color: #ff9b9b;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .progress-fill.indeterminate {
+        animation: none !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="splash" role="status" aria-live="polite" aria-label="Loading Kodi">
+    <div class="splash-content">
+      <div class="progress-block">
+        <div class="progress-track">
+          <div class="progress-fill indeterminate" id="progressFill"></div>
+        </div>
+        <div class="status-line">
+          <span class="status-text" id="statusText">Starting up…</span>
+          <span class="status-pct" id="statusPct"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="0"></canvas>
+
+  <script>
+    var splashEl     = document.getElementById('splash');
+    var statusTextEl = document.getElementById('statusText');
+    var statusPctEl  = document.getElementById('statusPct');
+    var progressFill = document.getElementById('progressFill');
+    var canvas       = document.getElementById('canvas');
+
+    function setProgress(pct) {
+      if (pct == null || isNaN(pct)) {
+        progressFill.classList.add('indeterminate');
+        statusPctEl.textContent = '';
+        return;
+      }
+      pct = Math.max(0, Math.min(100, pct));
+      progressFill.classList.remove('indeterminate');
+      progressFill.style.width = pct.toFixed(1) + '%';
+      statusPctEl.textContent = Math.round(pct) + '%';
+    }
+
+    function setStatusText(text) {
+      statusTextEl.textContent = text || '';
+    }
+
+    function hideSplash() {
+      if (splashEl.classList.contains('hidden')) return;
+      splashEl.classList.add('hidden');
+      setTimeout(function () {
+        if (splashEl.classList.contains('error')) return;
+        splashEl.setAttribute('aria-hidden', 'true');
+        splashEl.classList.add('discarded');
+      }, 900);
+    }
+
+    function showError(message) {
+      splashEl.classList.remove('discarded');
+      splashEl.removeAttribute('aria-hidden');
+      splashEl.classList.add('error');
+      splashEl.classList.remove('hidden');
+      progressFill.classList.remove('indeterminate');
+      setStatusText(message || 'Failed to load Kodi');
+      statusPctEl.textContent = '!';
+    }
+    window.showError = showError;
+
+    // Parse Emscripten setStatus strings. Common forms:
+    //   "Downloading data... (1234567/9876543)"
+    //   "Preparing... (3/7)"
+    //   "Running..."
+    //   ""  (empty → runtime ready)
+    var EMSCRIPTEN_PROGRESS_RE = /\((\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\)/;
+
+    function applyEmscriptenStatus(text) {
+      if (!text) return; // empty string means "ready"
+
+      var m = text.match(EMSCRIPTEN_PROGRESS_RE);
+      var label = text.replace(EMSCRIPTEN_PROGRESS_RE, '').trim();
+      if (m) {
+        var cur = parseFloat(m[1]);
+        var tot = parseFloat(m[2]);
+        if (tot > 0) setProgress((cur / tot) * 100);
+        if (!label) label = 'Loading assets…';
+      } else {
+        setProgress(null);
+      }
+      setStatusText(label || text);
+    }
+
+    var Module = {
+      canvas: canvas,
+      print:    function (t) { console.log(t); },
+      printErr: function (t) { console.error(t); },
+
+      setStatus: function (text) {
+        if (splashEl.classList.contains('error')) return;
+        applyEmscriptenStatus(text);
+      },
+
+      monitorRunDependencies: function (remaining) {
+        if (splashEl.classList.contains('error')) return;
+        if (remaining > 0) {
+          setStatusText('Preparing runtime… (' + remaining + ' left)');
+          setProgress(null);
+        }
+      },
+
+      onAbort: function (what) {
+        showError('Kodi aborted: ' + (what || 'unknown error'));
+      },
+
+      onKodiFirstFramePresented: function () {
+        canvas.focus();
+        hideSplash();
+      },
+
+      onRuntimeInitialized: function () {
+        setStatusText('Starting Kodi…');
+        setProgress(null);
+        canvas.focus();
+      }
+    };
+
+    window.addEventListener('error', function (e) {
+      if (e && e.filename && /kodi\.(js|wasm|data)(\?|$)/i.test(e.filename)) {
+        showError('Failed to load ' + e.filename.split('/').pop());
+      }
+    });
+
+    setStatusText('Downloading Kodi…');
+    setProgress(null);
+  </script>
+
+  <script async src="kodi.js" onerror="showError('Could not load kodi.js')"></script>
+</body>
+</html>

--- a/tools/wasm/serve.py
+++ b/tools/wasm/serve.py
@@ -6,7 +6,9 @@ Minimal HTTP server for Kodi WASM builds.
 - Serves static files with the COOP/COEP headers required by SharedArrayBuffer.
 - Exposes a same-origin streaming proxy at `/proxy?u=<url-encoded>` so the
   browser can reach http(s) servers that don't send CORS headers. Only loopback
-  clients may use it unless --allow-lan-proxy is given.
+  clients may use it unless --allow-lan-proxy is given. Build with
+  -DENABLE_WASM_DEV_PROXY=ON so the module routes its cross-origin requests
+  through it (tools/wasm/dev_proxy_pre.js).
 
 Usage:
   cd build-wasm

--- a/tools/wasm/serve.py
+++ b/tools/wasm/serve.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""
+Minimal HTTP server for Kodi WASM builds.
+
+- Serves static files with the COOP/COEP headers required by SharedArrayBuffer.
+- Exposes a same-origin streaming proxy at `/proxy?u=<url-encoded>` so the
+  browser can reach http(s) servers that don't send CORS headers. Only loopback
+  clients may use it unless --allow-lan-proxy is given.
+
+Usage:
+  cd build-wasm
+  cp ../tools/wasm/kodi.html .
+  python3 ../tools/wasm/serve.py          # http://127.0.0.1:8080
+  python3 ../tools/wasm/serve.py 9000
+  python3 ../tools/wasm/serve.py 0.0.0.0:8080  # serve media to a Kodi on the LAN
+
+The launcher itself only works from 127.0.0.1 or localhost: a page loaded over
+plain http from any other address is not a secure context, so the browser
+withholds SharedArrayBuffer and the pthread runtime cannot start. Binding to
+0.0.0.0 is for exposing this directory as a media source to another Kodi.
+"""
+
+import http.server
+import ipaddress
+import socketserver
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    allow_lan_proxy = False
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+        ".js": "application/javascript",
+    }
+
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        # CORS-enabled so a Kodi running elsewhere (a TV on the LAN) can use
+        # this server's directory listings as a media source.
+        self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.send_header("Access-Control-Expose-Headers", "*")
+        self.send_header("Cache-Control", "no-cache")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path.startswith("/proxy?"):
+            self._proxy(body=True)
+        else:
+            super().do_GET()
+
+    def do_HEAD(self):
+        if self.path.startswith("/proxy?"):
+            self._proxy(body=False)
+        else:
+            super().do_HEAD()
+
+    def _client_is_loopback(self) -> bool:
+        ip = ipaddress.ip_address(self.client_address[0])
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
+        return ip.is_loopback
+
+    def _proxy(self, body: bool):
+        if not self.allow_lan_proxy and not self._client_is_loopback():
+            self.send_error(403, "proxy is loopback-only; start with --allow-lan-proxy")
+            return
+        url = urllib.parse.parse_qs(self.path.split("?", 1)[1]).get("u", [""])[0]
+        if not url.startswith(("http://", "https://")):
+            self.send_error(400, "bad ?u=")
+            return
+
+        req = urllib.request.Request(url, method=self.command)
+        # Forward a few request headers so the upstream sees a real client.
+        # Notably, download.blender.org returns 403 to the default
+        # "Python-urllib/3.x" agent.
+        for name in ("Range", "User-Agent", "Referer"):
+            value = self.headers.get(name)
+            if value is not None:
+                req.add_header(name, value)
+        req.add_header("Accept-Encoding", "identity")
+        if req.get_header("User-agent") is None:
+            req.add_header("User-Agent", "Mozilla/5.0 (Kodi-WASM proxy)")
+
+        try:
+            upstream = urllib.request.urlopen(req, timeout=15)
+        except urllib.error.HTTPError as exc:
+            upstream = exc
+        except Exception as exc:
+            self.send_error(502, f"upstream: {exc}")
+            return
+
+        with upstream:
+            self.send_response(upstream.status)
+            for name in ("Content-Type", "Content-Length", "Content-Range",
+                         "Accept-Ranges", "Last-Modified", "ETag"):
+                value = upstream.headers.get(name)
+                if value is not None:
+                    self.send_header(name, value)
+            self.end_headers()
+            if body and self.command != "HEAD":
+                try:
+                    while chunk := upstream.read(64 * 1024):
+                        self.wfile.write(chunk)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+
+class ThreadingServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "--allow-lan-proxy" in args:
+        args.remove("--allow-lan-proxy")
+        Handler.allow_lan_proxy = True
+    bind = "127.0.0.1"
+    port_arg = args[0] if args else "8080"
+    if ":" in port_arg:
+        bind, port_text = port_arg.rsplit(":", 1)
+        port = int(port_text)
+    else:
+        port = int(port_arg)
+    print(f"Serving http://{bind}:{port}/kodi.html  (Ctrl-C to stop)")
+    print(f"Proxy:   http://{bind}:{port}/proxy?u=<url-encoded>")
+    ThreadingServer((bind, port), Handler).serve_forever()

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -37,6 +37,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
+#include "application/AppEnvironment.h"
 #include "application/AppInboundProtocol.h"
 #include "application/AppParams.h"
 #include "application/ApplicationActionListeners.h"
@@ -181,6 +182,10 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+
+#ifdef TARGET_WASM
+#include <emscripten.h>
+#endif
 
 #include <tinyxml.h>
 
@@ -1651,10 +1656,6 @@ int CApplication::Run()
 {
   CLog::Log(LOGINFO, "Running the application...");
 
-  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
-  std::chrono::milliseconds frameTime;
-  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
-
   CFileItemList& playlist = CServiceBroker::GetAppParams()->GetPlaylist();
   if (playlist.Size() > 0)
   {
@@ -1663,38 +1664,64 @@ int CApplication::Run()
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 
-  // Run the app
+#ifdef TARGET_WASM
+  // A browser tab cannot block its own event loop: the browser calls back once per frame and
+  // emscripten_set_main_loop unwinds the stack instead of returning, so shutdown happens in
+  // WasmRunIteration().
+  emscripten_set_main_loop([]() { g_application.WasmRunIteration(); }, 0, 1);
+#else
   while (!m_bStop)
-  {
-    // Animate and render a frame
-
-    lastFrameTime = std::chrono::steady_clock::now();
-    Process();
-
-    bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
-    if (!m_bStop)
-    {
-      FrameMove(true, renderGUI);
-    }
-
-    if (renderGUI && !m_bStop)
-    {
-      Render();
-    }
-    else if (!renderGUI)
-    {
-      auto now = std::chrono::steady_clock::now();
-      frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
-      if (frameTime.count() < noRenderFrameTime)
-        KODI::TIME::Sleep(std::chrono::milliseconds(noRenderFrameTime - frameTime.count()));
-    }
-  }
+    RunIteration();
+#endif
 
   Cleanup();
 
   CLog::Log(LOGINFO, "Exiting the application...");
   return m_ExitCode;
 }
+
+void CApplication::RunIteration()
+{
+  // Animate and render a frame
+
+  const auto lastFrameTime = std::chrono::steady_clock::now();
+  Process();
+
+  bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
+  if (!m_bStop)
+  {
+    FrameMove(true, renderGUI);
+  }
+
+  if (renderGUI && !m_bStop)
+  {
+    Render();
+  }
+  else if (!renderGUI)
+  {
+    constexpr std::chrono::milliseconds noRenderFrameTime{15}; // Simulates ~66fps
+    const auto frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - lastFrameTime);
+    if (frameTime < noRenderFrameTime)
+      KODI::TIME::Sleep(noRenderFrameTime - frameTime);
+  }
+}
+
+#ifdef TARGET_WASM
+void CApplication::WasmRunIteration()
+{
+  if (!m_bStop)
+  {
+    RunIteration();
+    return;
+  }
+
+  emscripten_cancel_main_loop();
+  Cleanup();
+  CLog::Log(LOGINFO, "Exiting the application...");
+  CAppEnvironment::TearDown();
+}
+#endif
 
 bool CApplication::Cleanup()
 {

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -240,6 +240,10 @@ public:
 private:
   void PrintStartupLog();
   void ResetCurrentItem();
+  void RunIteration();
+#ifdef TARGET_WASM
+  void WasmRunIteration();
+#endif
 
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -42,7 +42,8 @@ if(TARGET ${APP_NAME_LC}::OpenGLES AND ("android" IN_LIST CORE_PLATFORM_NAME_LC 
                             "tvos" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "gbm" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "x11" IN_LIST CORE_PLATFORM_NAME_LC OR
-                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC))
+                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC OR
+                            "wasm" IN_LIST CORE_PLATFORM_NAME_LC))
   list(APPEND SOURCES LinuxRendererGLES.cpp
                       OverlayRendererGLES.cpp)
   list(APPEND HEADERS LinuxRendererGLES.h

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
@@ -35,7 +35,8 @@ if(TARGET ${APP_NAME_LC}::OpenGLES AND ("android" IN_LIST CORE_PLATFORM_NAME_LC 
                             "tvos" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "gbm" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "x11" IN_LIST CORE_PLATFORM_NAME_LC OR
-                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC))
+                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC OR
+                            "wasm" IN_LIST CORE_PLATFORM_NAME_LC))
   list(APPEND SOURCES VideoFilterShaderGLES.cpp
                       YUV2RGBShaderGLES.cpp)
   list(APPEND HEADERS VideoFilterShaderGLES.h

--- a/xbmc/dialogs/GUIDialogKeyboardTouch.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardTouch.cpp
@@ -9,6 +9,8 @@
 #include "GUIDialogKeyboardTouch.h"
 #if defined(TARGET_DARWIN_EMBEDDED)
 #include "platform/darwin/ios-common/DarwinEmbedKeyboard.h"
+#elif defined(TARGET_WASM)
+#include "windowing/wasm/WasmKeyboard.h"
 #endif
 
 CGUIDialogKeyboardTouch::CGUIDialogKeyboardTouch()
@@ -23,6 +25,8 @@ bool CGUIDialogKeyboardTouch::ShowAndGetInput(char_callback_t pCallback, const s
 {
 #if defined(TARGET_DARWIN_EMBEDDED)
   m_keyboard.reset(new CDarwinEmbedKeyboard());
+#elif defined(TARGET_WASM)
+  m_keyboard = std::make_unique<KODI::WINDOWING::WASM::CWasmKeyboard>();
 #endif
 
   if (!m_keyboard)

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -22,9 +22,10 @@
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#if defined(TARGET_DARWIN_EMBEDDED)
+#if defined(TARGET_DARWIN_EMBEDDED) || defined(TARGET_WASM)
 #include "dialogs/GUIDialogKeyboardTouch.h"
-
+#endif
+#if defined(TARGET_DARWIN_EMBEDDED)
 #include "platform/darwin/ios-common/DarwinEmbedKeyboard.h"
 #endif
 
@@ -98,16 +99,19 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString,
 #else
   useKodiKeyboard = CDarwinEmbedKeyboard::hasExternalKeyboard();
 #endif // defined(TARGET_DARWIN_TVOS)
+#elif defined(TARGET_WASM)
+  useKodiKeyboard = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      CSettings::SETTING_INPUT_USEKODIKEYBOARD);
 #endif
 
   auto& winManager = CServiceBroker::GetGUI()->GetWindowManager();
   CGUIKeyboard* kb = nullptr;
   if (useKodiKeyboard)
     kb = winManager.GetWindow<CGUIDialogKeyboardGeneric>(WINDOW_DIALOG_KEYBOARD);
-#if defined(TARGET_DARWIN_EMBEDDED)
+#if defined(TARGET_DARWIN_EMBEDDED) || defined(TARGET_WASM)
   else
     kb = winManager.GetWindow<CGUIDialogKeyboardTouch>(WINDOW_DIALOG_KEYBOARD_TOUCH);
-#endif // defined(TARGET_DARWIN_EMBEDDED)
+#endif
 
   if (kb)
   {

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
@@ -14,7 +14,7 @@
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
-#if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN)
+#if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN) && !defined(TARGET_WASM)
 std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
 {
   return std::make_unique<CPosixInterfaceForCLog>();

--- a/xbmc/platform/wasm/PlatformWasm.cpp
+++ b/xbmc/platform/wasm/PlatformWasm.cpp
@@ -8,6 +8,8 @@
 
 #include "PlatformWasm.h"
 
+#include "windowing/wasm/WinSystemWasmGLESContext.h"
+
 #include <cstdlib>
 
 CPlatform* CPlatform::CreateInstance()
@@ -20,5 +22,10 @@ bool CPlatformWasm::InitStageOne()
   if (!std::getenv("HOME"))
     setenv("HOME", "/home/web_user", 1);
 
-  return CPlatformPosix::InitStageOne();
+  if (!CPlatformPosix::InitStageOne())
+    return false;
+
+  CWinSystemWasmGLESContext::Register();
+
+  return true;
 }

--- a/xbmc/platform/wasm/kodi_pre.js
+++ b/xbmc/platform/wasm/kodi_pre.js
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 Team Kodi
+//
+// Main-thread setup for Kodi's WASM build: profile persistence, canvas focus
+// and clipboard paste. Rendering goes through a WebGL context Emscripten
+// creates on <canvas id="canvas"> and proxies to the Kodi pthread.
+
+// Persist Kodi's user profile ($HOME/.kodi) to IndexedDB via IDBFS so that
+// sources.xml, guisettings.xml, the databases, etc. survive a page refresh.
+// Mount and populate run inside Module.preRun, and addRunDependency blocks
+// main() until IDBFS has finished loading from IndexedDB.
+(function installIdbfsPersistence() {
+  var Module = globalThis.Module = globalThis.Module || {};
+  var PROFILE_PATH = '/home/web_user/.kodi';
+
+  Module.preRun = Module.preRun || [];
+  Module.preRun.push(function mountKodiProfile() {
+    try {
+      FS.mkdirTree(PROFILE_PATH);
+    } catch (e) {
+      console.warn('[kodi] mkdirTree ' + PROFILE_PATH + ':', e);
+    }
+
+    try {
+      FS.mount(IDBFS, {}, PROFILE_PATH);
+    } catch (e) {
+      console.warn('[kodi] IDBFS mount failed, profile will not persist:', e);
+      return;
+    }
+
+    // Block main() until the profile has been loaded from IndexedDB.
+    addRunDependency('kodi-idbfs-populate');
+    FS.syncfs(true, function (err) {
+      if (err) {
+        console.warn('[kodi] IDBFS populate:', err);
+      }
+      removeRunDependency('kodi-idbfs-populate');
+    });
+
+    // Debounced background flush to IndexedDB.
+    var syncing = false;
+    var pending = false;
+    function flushToIdb() {
+      if (syncing) { pending = true; return; }
+      syncing = true;
+      FS.syncfs(false, function (err) {
+        syncing = false;
+        if (err) { console.warn('[kodi] IDBFS persist:', err); }
+        if (pending) { pending = false; flushToIdb(); }
+      });
+    }
+
+    setInterval(flushToIdb, 5000);
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('pagehide', flushToIdb, { capture: true });
+      window.addEventListener('beforeunload', flushToIdb, { capture: true });
+    }
+  });
+})();
+
+(function () {
+  if (typeof document === 'undefined') {
+    return; // pthread worker
+  }
+
+  var Module = globalThis.Module = globalThis.Module || {};
+  var kodi = (Module.kodi = Module.kodi || {});
+
+  var canvas = document.getElementById('canvas');
+  if (!canvas) {
+    console.warn('[kodi] No <canvas id="canvas"> found; rendering disabled.');
+    return;
+  }
+  // tabindex=0 allows the canvas to receive focus so paste and keyboard reach Kodi.
+  if (canvas.getAttribute('tabindex') === '-1' || canvas.getAttribute('tabindex') === null) {
+    canvas.setAttribute('tabindex', '0');
+  }
+
+  // The WebGL context is created on this canvas by Emscripten (proxied from the
+  // Kodi pthread); nothing else may take a rendering context on it.
+  kodi.canvas = canvas;
+
+  var prevOnRuntime = Module.onRuntimeInitialized;
+  Module.onRuntimeInitialized = function () {
+    // Must run on the browser main thread (document is undefined on pthread workers).
+    document.addEventListener(
+        'paste',
+        function (e) {
+          // A paste into a DOM field (the native keyboard's input) is the browser's.
+          var t = e.target;
+          if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) {
+            return;
+          }
+          try {
+            var text = (e.clipboardData && e.clipboardData.getData)
+                ? e.clipboardData.getData('text/plain')
+                : String();
+            if (text === undefined || text === null) {
+              text = String();
+            }
+            e.preventDefault();
+            if (typeof Module.ccall === 'function') {
+              Module.ccall('kodi_wasm_dispatch_paste', null, ['string'], [text]);
+            }
+          } catch (err) {
+            console.error('[kodi] paste handler:', err);
+          }
+        },
+        true);
+    try { canvas.focus(); } catch (_) {}
+    if (typeof prevOnRuntime === 'function') {
+      try { prevOnRuntime(); } catch (e) { console.error(e); }
+    }
+  };
+})();

--- a/xbmc/platform/wasm/main.cpp
+++ b/xbmc/platform/wasm/main.cpp
@@ -26,6 +26,9 @@ int main(int argc, char* argv[])
   appParamParser.GetAppParams()->SetLogTarget("console");
 
   CAppEnvironment::SetUp(appParamParser.GetAppParams());
+
+  // Only reached when startup fails: once the Emscripten main loop is installed the stack is
+  // unwound and CApplication tears the environment down itself.
   const int status = XBMC_Run(true);
   CAppEnvironment::TearDown();
   return status;

--- a/xbmc/platform/wasm/utils/CMakeLists.txt
+++ b/xbmc/platform/wasm/utils/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES WasmInterfaceForCLog.cpp)
+
+set(HEADERS WasmInterfaceForCLog.h)
+
+core_add_library(platform_wasm_utils)

--- a/xbmc/platform/wasm/utils/WasmInterfaceForCLog.cpp
+++ b/xbmc/platform/wasm/utils/WasmInterfaceForCLog.cpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "platform/wasm/utils/WasmInterfaceForCLog.h"
+
+#include "ServiceBroker.h"
+#include "application/AppParams.h"
+
+#include <mutex>
+
+#include <emscripten.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/dist_sink.h>
+
+namespace
+{
+// Routes log lines to the browser console, mapping spdlog levels onto console methods so
+// DevTools filtering works.
+class CBrowserConsoleSink : public spdlog::sinks::base_sink<std::mutex>
+{
+protected:
+  void sink_it_(const spdlog::details::log_msg& msg) override
+  {
+    spdlog::memory_buf_t formatted;
+    formatter_->format(msg, formatted);
+
+    // The formatter appends a newline, which the console would render as an empty line.
+    size_t length = formatted.size();
+    while (length > 0 && (formatted[length - 1] == '\n' || formatted[length - 1] == '\r'))
+      --length;
+
+    int method = 3;
+    switch (msg.level)
+    {
+      case spdlog::level::trace:
+      case spdlog::level::debug:
+        method = 0;
+        break;
+      case spdlog::level::info:
+        method = 1;
+        break;
+      case spdlog::level::warn:
+        method = 2;
+        break;
+      default:
+        break;
+    }
+
+    // clang-format off
+    EM_ASM({
+      const text = UTF8ToString($0, $1);
+      switch ($2)
+      {
+        case 0: console.debug(text); break;
+        case 1: console.info(text); break;
+        case 2: console.warn(text); break;
+        default: console.error(text); break;
+      }
+    }, formatted.data(), length, method);
+    // clang-format on
+  }
+
+  void flush_() override {}
+};
+} // namespace
+
+std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
+{
+  return std::make_unique<CWasmInterfaceForCLog>();
+}
+
+void CWasmInterfaceForCLog::AddSinks(
+    std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
+{
+  if (CServiceBroker::GetAppParams()->GetLogTarget() == "console")
+    distributionSink->add_sink(std::make_shared<CBrowserConsoleSink>());
+}

--- a/xbmc/platform/wasm/utils/WasmInterfaceForCLog.h
+++ b/xbmc/platform/wasm/utils/WasmInterfaceForCLog.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/utils/PosixInterfaceForCLog.h"
+
+class CWasmInterfaceForCLog : public CPosixInterfaceForCLog
+{
+public:
+  CWasmInterfaceForCLog() = default;
+  ~CWasmInterfaceForCLog() override = default;
+
+  void AddSinks(
+      std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const override;
+};

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -269,6 +269,9 @@ bool CSettings::InitializeDefinitions()
   if (CFile::Exists(SETTINGS_XML_FOLDER "webos.xml") &&
       !Initialize(SETTINGS_XML_FOLDER "webos.xml"))
     CLog::Log(LOGFATAL, "Unable to load webOS-specific settings definitions");
+#elif defined(TARGET_WASM)
+  if (CFile::Exists(SETTINGS_XML_FOLDER "wasm.xml") && !Initialize(SETTINGS_XML_FOLDER "wasm.xml"))
+    CLog::Log(LOGFATAL, "Unable to load wasm-specific settings definitions");
 #elif defined(TARGET_LINUX)
   if (CFile::Exists(SETTINGS_XML_FOLDER "linux.xml") && !Initialize(SETTINGS_XML_FOLDER "linux.xml"))
     CLog::Log(LOGFATAL, "Unable to load linux-specific settings definitions");

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -438,6 +438,7 @@ public:
   static constexpr auto SETTING_INPUT_SIRIREMOTEVERTICALSENSITIVITY =
       "input.siriremoteverticalsensitivity";
   static constexpr auto SETTING_INPUT_TVOSUSEKODIKEYBOARD = "input.tvosusekodikeyboard";
+  static constexpr auto SETTING_INPUT_USEKODIKEYBOARD = "input.usekodikeyboard";
   static constexpr auto SETTING_NETWORK_USEHTTPPROXY = "network.usehttpproxy";
   static constexpr auto SETTING_NETWORK_HTTPPROXYTYPE = "network.httpproxytype";
   static constexpr auto SETTING_NETWORK_HTTPPROXYSERVER = "network.httpproxyserver";

--- a/xbmc/windowing/wasm/CMakeLists.txt
+++ b/xbmc/windowing/wasm/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SOURCES OSScreenSaverWasm.cpp
+            VideoSyncWasm.cpp
+            WinEventsWasm.cpp
+            WasmClipboard.cpp
+            WasmKeyboard.cpp
+            WasmVsync.cpp)
+
+set(HEADERS OSScreenSaverWasm.h
+            VideoSyncWasm.h
+            WinEventsWasm.h
+            WasmClipboard.h
+            WasmKeyboard.h
+            WasmVsync.h
+            WebGLCommit.h)
+
+if(TARGET ${APP_NAME_LC}::OpenGLES)
+  list(APPEND SOURCES WinSystemWasmGLESContext.cpp)
+  list(APPEND HEADERS WinSystemWasmGLESContext.h)
+endif()
+
+core_add_library(windowing_wasm)

--- a/xbmc/windowing/wasm/OSScreenSaverWasm.cpp
+++ b/xbmc/windowing/wasm/OSScreenSaverWasm.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "OSScreenSaverWasm.h"
+
+#include <emscripten.h>
+#include <emscripten/em_asm.h>
+
+using namespace KODI::WINDOWING::WASM;
+
+namespace
+{
+// The browser releases a wake lock whenever the page is hidden, so the lock is
+// re-requested on the next visibility change for as long as it is wanted.
+void SetWakeLockWanted(bool wanted)
+{
+  // clang-format off
+  MAIN_THREAD_EM_ASM(({
+    if (!('wakeLock' in navigator))
+      return;
+    const kodi = (Module.kodi = Module.kodi || {});
+    if (!kodi.wakeLock) {
+      const wl = (kodi.wakeLock = { wanted: false, pending: false, sentinel: null, warned: false });
+      wl.acquire = () => {
+        if (!wl.wanted || wl.pending || wl.sentinel || document.visibilityState !== 'visible')
+          return;
+        wl.pending = true;
+        navigator.wakeLock.request('screen').then((sentinel) => {
+          wl.pending = false;
+          if (!wl.wanted) {
+            sentinel.release();
+            return;
+          }
+          wl.sentinel = sentinel;
+          sentinel.addEventListener('release', () => {
+            if (wl.sentinel === sentinel)
+              wl.sentinel = null;
+          });
+        }).catch((e) => {
+          wl.pending = false;
+          if (!wl.warned) {
+            wl.warned = true;
+            console.warn('[kodi] screen wake lock:', e);
+          }
+        });
+      };
+      document.addEventListener('visibilitychange', wl.acquire);
+    }
+    const wl = kodi.wakeLock;
+    wl.wanted = !!$0;
+    if (wl.wanted) {
+      wl.acquire();
+    } else if (wl.sentinel) {
+      wl.sentinel.release();
+      wl.sentinel = null;
+    }
+  }), wanted ? 1 : 0);
+  // clang-format on
+}
+} // namespace
+
+void COSScreenSaverWasm::Inhibit()
+{
+  SetWakeLockWanted(true);
+}
+
+void COSScreenSaverWasm::Uninhibit()
+{
+  SetWakeLockWanted(false);
+}

--- a/xbmc/windowing/wasm/OSScreenSaverWasm.h
+++ b/xbmc/windowing/wasm/OSScreenSaverWasm.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "windowing/OSScreenSaver.h"
+
+namespace KODI::WINDOWING::WASM
+{
+
+/*!
+ * \brief Keeps the display awake through the browser's Screen Wake Lock API.
+ */
+class COSScreenSaverWasm : public IOSScreenSaver
+{
+public:
+  void Inhibit() override;
+  void Uninhibit() override;
+};
+
+} // namespace KODI::WINDOWING::WASM

--- a/xbmc/windowing/wasm/VideoSyncWasm.cpp
+++ b/xbmc/windowing/wasm/VideoSyncWasm.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "VideoSyncWasm.h"
+
+#include "ServiceBroker.h"
+#include "WasmVsync.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
+#include "utils/MathUtils.h"
+#include "utils/TimeUtils.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
+
+using namespace KODI::WINDOWING::WASM;
+
+namespace
+{
+// Bounds how long a stop request waits while a hidden tab produces no ticks.
+constexpr double TICK_WAIT_TIMEOUT_MS = 100.0;
+} // namespace
+
+bool CVideoSyncWasm::Setup()
+{
+  const int64_t lastTick = VSYNC::LastTickHostTime();
+  m_lastVBlankTime = lastTick != 0 ? lastTick : CurrentHostCounter();
+  return true;
+}
+
+// The browser skips requestAnimationFrame callbacks while its main thread is
+// busy, so vblanks are counted from the tick timestamps rather than the ticks.
+void CVideoSyncWasm::Run(CEvent& stop)
+{
+  uint32_t seen = VSYNC::Tick();
+  while (!stop.Signaled())
+  {
+    const uint32_t tick = VSYNC::WaitForTick(seen, TICK_WAIT_TIMEOUT_MS);
+    if (tick == seen)
+      continue;
+    seen = tick;
+
+    const int64_t tickTime = VSYNC::LastTickHostTime();
+    const double elapsed = static_cast<double>(tickTime - m_lastVBlankTime) /
+                           static_cast<double>(CurrentHostFrequency());
+    m_lastVBlankTime = tickTime;
+    m_refClock->UpdateClock(MathUtils::round_int(elapsed * static_cast<double>(m_fps)), tickTime);
+  }
+}
+
+float CVideoSyncWasm::GetFps()
+{
+  m_fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
+  return m_fps;
+}

--- a/xbmc/windowing/wasm/VideoSyncWasm.h
+++ b/xbmc/windowing/wasm/VideoSyncWasm.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "windowing/VideoSync.h"
+
+#include <cstdint>
+
+namespace KODI::WINDOWING::WASM
+{
+class CVideoSyncWasm : public CVideoSync
+{
+public:
+  explicit CVideoSyncWasm(CVideoReferenceClock* clock) : CVideoSync(clock) {}
+
+  bool Setup() override;
+  void Run(CEvent& stop) override;
+  void Cleanup() override {}
+  float GetFps() override;
+
+private:
+  int64_t m_lastVBlankTime{0};
+};
+} // namespace KODI::WINDOWING::WASM

--- a/xbmc/windowing/wasm/WasmClipboard.cpp
+++ b/xbmc/windowing/wasm/WasmClipboard.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "WasmClipboard.h"
+
+#include "ServiceBroker.h"
+#include "guilib/WindowIDs.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
+#include "messaging/ApplicationMessenger.h"
+
+#include <mutex>
+#include <string>
+
+#include <emscripten.h>
+
+namespace
+{
+std::mutex g_mutex;
+std::string g_pending;
+} // namespace
+
+// Browser paste listener is registered in kodi_pre.js (main thread only). Pthreads have no document.
+
+extern "C" EMSCRIPTEN_KEEPALIVE void kodi_wasm_dispatch_paste(const char* utf8)
+{
+  std::string text = utf8 ? utf8 : "";
+  {
+    std::lock_guard lock(g_mutex);
+    g_pending = std::move(text);
+  }
+  auto* action = new CAction(ACTION_PASTE);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, action);
+}
+
+std::string WASM_CLIPBOARD::ConsumePendingPasteText()
+{
+  std::lock_guard lock(g_mutex);
+  return std::move(g_pending);
+}

--- a/xbmc/windowing/wasm/WasmClipboard.h
+++ b/xbmc/windowing/wasm/WasmClipboard.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <string>
+
+namespace WASM_CLIPBOARD
+{
+/*!
+ * Take any UTF-8 text pending from the last browser paste event and clear the buffer.
+ * Used by CWinSystemWasmGLESContext::GetClipboardText for CGUIEditControl::OnPasteClipboard.
+ *
+ * The paste listener lives in platform/wasm/kodi_pre.js (main thread); it calls
+ * kodi_wasm_dispatch_paste(), which must remain exported (EMSCRIPTEN_KEEPALIVE).
+ */
+[[nodiscard]] std::string ConsumePendingPasteText();
+} // namespace WASM_CLIPBOARD

--- a/xbmc/windowing/wasm/WasmKeyboard.cpp
+++ b/xbmc/windowing/wasm/WasmKeyboard.cpp
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "WasmKeyboard.h"
+
+#include "utils/log.h"
+
+#include <atomic>
+#include <cstddef>
+
+#include <emscripten.h>
+#include <emscripten/em_asm.h>
+#include <emscripten/threading.h>
+
+namespace KODI::WINDOWING::WASM
+{
+namespace
+{
+std::atomic<int> g_activeKeyboards{0};
+bool g_jsInstalled = false;
+constexpr double WAIT_MS = 100.0;
+
+int32_t Load(const int32_t& field)
+{
+  return __atomic_load_n(&field, __ATOMIC_ACQUIRE);
+}
+} // namespace
+
+static_assert(offsetof(CWasmKeyboard::Shared, signal) == 0, "signal offset");
+static_assert(offsetof(CWasmKeyboard::Shared, state) == 4, "state offset");
+static_assert(offsetof(CWasmKeyboard::Shared, textLength) == 8, "textLength offset");
+static_assert(offsetof(CWasmKeyboard::Shared, text) == 12, "text offset");
+
+// Main-thread side. Field offsets and state values mirror struct Shared.
+void CWasmKeyboard::InstallJs()
+{
+  if (g_jsInstalled)
+    return;
+  g_jsInstalled = true;
+
+  MAIN_THREAD_EM_ASM(({
+    const SIG = 0, STATE = 1, LEN = 2, TEXT = 12, TEXT_MAX = 4095;
+    const SHOWN = 1, CONFIRMED = 2, CANCELLED = 3;
+    // Samsung TV IME soft keys.
+    const KEY_IME_DONE = 65376, KEY_IME_CANCEL = 65385;
+    const kodi = (Module.kodi = Module.kodi || {});
+    const kb = (kodi.keyboard = {});
+    let root = null;
+    let input = null;
+    let ptr = 0;
+
+    const publish = (state) => {
+      if (!ptr) return;
+      const base = ptr >> 2;
+      if (state !== undefined) Atomics.store(HEAP32, base + STATE, state);
+      Atomics.add(HEAP32, base + SIG, 1);
+      Atomics.notify(HEAP32, base + SIG);
+    };
+    const publishText = () => {
+      if (!ptr || !input) return;
+      const bytes = new TextEncoder().encode(input.value);
+      const n = Math.min(bytes.length, TEXT_MAX);
+      HEAPU8.set(bytes.subarray(0, n), ptr + TEXT);
+      HEAPU8[ptr + TEXT + n] = 0;
+      Atomics.store(HEAP32, (ptr >> 2) + LEN, n);
+      publish();
+    };
+    const finish = (state) => {
+      if (!ptr) return;
+      if (Atomics.load(HEAP32, (ptr >> 2) + STATE) !== SHOWN) return;
+      publishText();
+      publish(state);
+    };
+
+    kb.show = (sharedPtr, initialPtr, headingPtr, hidden) => {
+      kb.hide();
+      ptr = sharedPtr;
+      root = document.createElement('div');
+      root.style.cssText = 'position:fixed;left:50%;top:12%;transform:translateX(-50%);'
+        + 'z-index:10;min-width:40vw;max-width:80vw;padding:1.2em 1.5em;border-radius:0.6em;'
+        + 'background:rgba(20,20,20,0.92);color:#fff;font:1.6em sans-serif;box-shadow:0 0.5em 2em rgba(0,0,0,0.6)';
+      const heading = UTF8ToString(headingPtr);
+      if (heading) {
+        const label = document.createElement('div');
+        label.textContent = heading;
+        label.style.cssText = 'margin-bottom:0.6em;opacity:0.85';
+        root.appendChild(label);
+      }
+      input = document.createElement('input');
+      input.type = hidden ? 'password' : 'text';
+      input.value = UTF8ToString(initialPtr);
+      input.autocomplete = 'off';
+      input.autocapitalize = 'off';
+      input.spellcheck = false;
+      input.style.cssText = 'width:100%;box-sizing:border-box;font:inherit;padding:0.4em 0.6em;'
+        + 'border:2px solid #17b2e7;border-radius:0.3em;background:#000;color:#fff;outline:none';
+      input.addEventListener('input', publishText);
+      input.addEventListener('keydown', (e) => {
+        if (e.keyCode === 13 || e.keyCode === KEY_IME_DONE) { e.preventDefault(); finish(CONFIRMED); }
+        else if (e.keyCode === 27 || e.keyCode === KEY_IME_CANCEL) { e.preventDefault(); finish(CANCELLED); }
+        e.stopPropagation();
+      });
+      input.addEventListener('keyup', (e) => e.stopPropagation());
+      input.addEventListener('blur', () => finish(CANCELLED));
+      root.appendChild(input);
+      document.body.appendChild(root);
+      publish(SHOWN);
+      input.focus();
+      input.setSelectionRange(input.value.length, input.value.length);
+    };
+    kb.setText = (textPtr, close) => {
+      if (!input) return;
+      input.value = UTF8ToString(textPtr);
+      publishText();
+      if (close) finish(CONFIRMED);
+    };
+    kb.hide = () => {
+      if (root) { root.remove(); root = null; input = null; }
+      ptr = 0;
+      const canvas = document.getElementById('canvas');
+      if (canvas) canvas.focus();
+    };
+  }));
+}
+
+CWasmKeyboard::~CWasmKeyboard()
+{
+  Hide();
+}
+
+bool CWasmKeyboard::IsActive()
+{
+  return g_activeKeyboards.load(std::memory_order_acquire) > 0;
+}
+
+bool CWasmKeyboard::ShowAndGetInput(char_callback_t pCallback,
+                                    const std::string& initialString,
+                                    std::string& typedString,
+                                    const std::string& heading,
+                                    bool bHiddenInput)
+{
+  InstallJs();
+
+  m_shared = {};
+  __atomic_store_n(&m_shared.state, SHOWN, __ATOMIC_RELEASE);
+  m_shown = true;
+  g_activeKeyboards.fetch_add(1, std::memory_order_acq_rel);
+
+  MAIN_THREAD_EM_ASM(({ Module.kodi.keyboard.show($0, $1, $2, $3); }), &m_shared,
+                     initialString.c_str(), heading.c_str(), bHiddenInput ? 1 : 0);
+
+  std::string lastReported = initialString;
+  int32_t state = SHOWN;
+  while (true)
+  {
+    const auto seen = static_cast<uint32_t>(Load(m_shared.signal));
+    state = Load(m_shared.state);
+    const int32_t length = Load(m_shared.textLength);
+    const std::string text(m_shared.text, static_cast<size_t>(length));
+    if (text != lastReported)
+    {
+      lastReported = text;
+      if (pCallback)
+        pCallback(this, text);
+    }
+    if (state != SHOWN)
+      break;
+    emscripten_futex_wait(&m_shared.signal, seen, WAIT_MS);
+  }
+
+  Hide();
+  if (state != CONFIRMED)
+    return false;
+
+  typedString = lastReported;
+  return true;
+}
+
+void CWasmKeyboard::Cancel()
+{
+  if (Load(m_shared.state) != SHOWN)
+    return;
+  __atomic_store_n(&m_shared.state, static_cast<int32_t>(CANCELLED), __ATOMIC_RELEASE);
+  __atomic_add_fetch(&m_shared.signal, 1, __ATOMIC_ACQ_REL);
+  emscripten_futex_wake(&m_shared.signal, 1);
+}
+
+bool CWasmKeyboard::SetTextToKeyboard(const std::string& text, bool closeKeyboard)
+{
+  if (!m_shown)
+    return false;
+  MAIN_THREAD_EM_ASM(({ Module.kodi.keyboard.setText($0, $1); }), text.c_str(),
+                     closeKeyboard ? 1 : 0);
+  return true;
+}
+
+void CWasmKeyboard::Hide()
+{
+  if (!m_shown)
+    return;
+  m_shown = false;
+  MAIN_THREAD_EM_ASM(({ Module.kodi.keyboard.hide(); }));
+  g_activeKeyboards.fetch_sub(1, std::memory_order_acq_rel);
+}
+} // namespace KODI::WINDOWING::WASM

--- a/xbmc/windowing/wasm/WasmKeyboard.h
+++ b/xbmc/windowing/wasm/WasmKeyboard.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "guilib/GUIKeyboard.h"
+
+#include <cstdint>
+#include <string>
+
+namespace KODI::WINDOWING::WASM
+{
+// Text entry through a DOM <input> on the browser main thread, which is what
+// brings up the browser's or the TV's own on-screen keyboard.
+class CWasmKeyboard : public CGUIKeyboard
+{
+public:
+  CWasmKeyboard() = default;
+  ~CWasmKeyboard() override;
+
+  bool ShowAndGetInput(char_callback_t pCallback,
+                       const std::string& initialString,
+                       std::string& typedString,
+                       const std::string& heading,
+                       bool bHiddenInput) override;
+  void Cancel() override;
+  bool SetTextToKeyboard(const std::string& text, bool closeKeyboard) override;
+
+  // True while a native keyboard owns key events; CWinEventsWasm drops them then.
+  static bool IsActive();
+
+  // Written by the main thread with Atomics; `signal` is bumped and notified
+  // on every change so ShowAndGetInput can futex-wait on it.
+  struct Shared
+  {
+    int32_t signal;
+    int32_t state;
+    int32_t textLength;
+    char text[4096];
+  };
+
+private:
+  enum State : int32_t
+  {
+    IDLE = 0,
+    SHOWN = 1,
+    CONFIRMED = 2,
+    CANCELLED = 3,
+  };
+
+  static void InstallJs();
+  void Hide();
+
+  Shared m_shared{};
+  bool m_shown{false};
+};
+} // namespace KODI::WINDOWING::WASM

--- a/xbmc/windowing/wasm/WasmVsync.cpp
+++ b/xbmc/windowing/wasm/WasmVsync.cpp
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "WasmVsync.h"
+
+#include <emscripten/em_asm.h>
+#include <emscripten/threading.h>
+
+namespace
+{
+volatile uint32_t g_tick = 0;
+alignas(8) volatile int64_t g_tickTimeNs = 0;
+volatile int32_t g_refreshRateMilliHz = 0;
+bool g_pumpInstalled = false;
+constexpr double DEFAULT_REFRESH_RATE = 60.0;
+} // namespace
+
+namespace KODI::WINDOWING::WASM::VSYNC
+{
+// CurrentHostCounter() is emscripten_get_now() in nanoseconds, which under
+// pthreads is performance.timeOrigin + performance.now(); the rAF timestamp is
+// relative to that same origin. Microseconds still fit a double exactly, so the
+// conversion happens there and the last scaling step in BigInt.
+void InstallPump()
+{
+  if (g_pumpInstalled)
+    return;
+  g_pumpInstalled = true;
+
+  MAIN_THREAD_EM_ASM(
+      {
+        const tickIdx = $0 >> 2;
+        const timeIdx = $1 >> 3;
+        const rateIdx = $2 >> 2;
+        let lastTimestamp = 0.0;
+        let measuredRefreshRate = 0.0;
+        const tick = (timestamp) =>
+        {
+          if (lastTimestamp > 0.0)
+          {
+            const intervalMs = timestamp - lastTimestamp;
+            if (intervalMs > 0.0)
+            {
+              const hz = 1000.0 / intervalMs;
+              if (hz >= 20.0 && hz <= 240.0)
+              {
+                measuredRefreshRate =
+                    measuredRefreshRate > 0.0 ? measuredRefreshRate * 0.9 + hz * 0.1 : hz;
+                Atomics.store(HEAP32, rateIdx, Math.round(measuredRefreshRate * 1000.0));
+              }
+            }
+          }
+          lastTimestamp = timestamp;
+          Atomics.store(HEAP64, timeIdx,
+                        BigInt(Math.round((performance.timeOrigin + timestamp) * 1000.0)) * 1000n);
+          Atomics.add(HEAP32, tickIdx, 1);
+          Atomics.notify(HEAP32, tickIdx);
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      },
+      &g_tick, &g_tickTimeNs, &g_refreshRateMilliHz);
+}
+
+uint32_t Tick()
+{
+  return __atomic_load_n(&g_tick, __ATOMIC_ACQUIRE);
+}
+
+uint32_t WaitForTick(uint32_t seen, double timeoutMs)
+{
+  if (Tick() == seen)
+    emscripten_futex_wait(&g_tick, seen, timeoutMs);
+  return Tick();
+}
+
+int64_t LastTickHostTime()
+{
+  return __atomic_load_n(&g_tickTimeNs, __ATOMIC_ACQUIRE);
+}
+
+double RefreshRate()
+{
+  const int32_t milliHz = __atomic_load_n(&g_refreshRateMilliHz, __ATOMIC_RELAXED);
+  return milliHz > 0 ? milliHz / 1000.0 : DEFAULT_REFRESH_RATE;
+}
+} // namespace KODI::WINDOWING::WASM::VSYNC

--- a/xbmc/windowing/wasm/WasmVsync.h
+++ b/xbmc/windowing/wasm/WasmVsync.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// Display refresh ticks from the browser main thread's requestAnimationFrame
+// loop, shared with every Kodi thread that paces itself to the display.
+namespace KODI::WINDOWING::WASM::VSYNC
+{
+// Installs the requestAnimationFrame pump on the browser main thread. Idempotent.
+void InstallPump();
+
+// Number of display frames the pump has seen.
+uint32_t Tick();
+
+// Blocks until the tick count differs from `seen` or `timeoutMs` elapses, and
+// returns the current count.
+uint32_t WaitForTick(uint32_t seen, double timeoutMs);
+
+// Time of the most recent tick in CurrentHostCounter() units, 0 before the first.
+int64_t LastTickHostTime();
+
+// Refresh rate measured by the pump; 60 until enough frames have been seen.
+double RefreshRate();
+} // namespace KODI::WINDOWING::WASM::VSYNC

--- a/xbmc/windowing/wasm/WebGLCommit.h
+++ b/xbmc/windowing/wasm/WebGLCommit.h
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+extern "C"
+{
+  // Blits Emscripten's offscreen framebuffer to the canvas on the browser main
+  // thread, after every GL call queued before it. Implemented in webgl_commit.js.
+  // Returns 1 on success, 0 when no proxied context is current.
+  int wasm_webgl_commit_frame(void);
+}

--- a/xbmc/windowing/wasm/WinEventsWasm.cpp
+++ b/xbmc/windowing/wasm/WinEventsWasm.cpp
@@ -1,0 +1,393 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "WinEventsWasm.h"
+
+#include "ServiceBroker.h"
+#include "WasmKeyboard.h"
+#include "application/AppInboundProtocol.h"
+#include "guilib/GUIWindowManager.h"
+#include "input/keyboard/XBMC_keyboard.h"
+#include "utils/CharsetConverter.h"
+
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_set>
+
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <emscripten/key_codes.h>
+#include <emscripten/threading.h>
+
+namespace
+{
+CWinEventsWasm* g_events = nullptr;
+
+constexpr const char* CANVAS_TARGET = "#canvas";
+
+XBMCMod TranslateModifiers(const EmscriptenKeyboardEvent* e)
+{
+  XBMCMod mod = XBMCKMOD_NONE;
+
+  if (e->shiftKey)
+    mod = static_cast<XBMCMod>(mod | XBMCKMOD_LSHIFT);
+  if (e->ctrlKey)
+    mod = static_cast<XBMCMod>(mod | XBMCKMOD_LCTRL);
+  if (e->altKey)
+    mod = static_cast<XBMCMod>(mod | XBMCKMOD_LALT);
+  if (e->metaKey)
+    mod = static_cast<XBMCMod>(mod | XBMCKMOD_LMETA);
+
+  return mod;
+}
+
+XBMCKey TranslatePrintableKey(const char c)
+{
+  if (c >= 'a' && c <= 'z')
+    return static_cast<XBMCKey>(XBMCK_a + (c - 'a'));
+  if (c >= 'A' && c <= 'Z')
+    return static_cast<XBMCKey>(XBMCK_a + (c - 'A'));
+  if (c >= '0' && c <= '9')
+    return static_cast<XBMCKey>(XBMCK_0 + (c - '0'));
+
+  switch (c)
+  {
+    case ' ':
+      return XBMCK_SPACE;
+    case '!':
+      return XBMCK_EXCLAIM;
+    case '"':
+      return XBMCK_QUOTEDBL;
+    case '#':
+      return XBMCK_HASH;
+    case '$':
+      return XBMCK_DOLLAR;
+    case '%':
+      return XBMCK_PERCENT;
+    case '&':
+      return XBMCK_AMPERSAND;
+    case '\'':
+      return XBMCK_QUOTE;
+    case '(':
+      return XBMCK_LEFTPAREN;
+    case ')':
+      return XBMCK_RIGHTPAREN;
+    case '*':
+      return XBMCK_ASTERISK;
+    case '+':
+      return XBMCK_PLUS;
+    case ',':
+      return XBMCK_COMMA;
+    case '-':
+      return XBMCK_MINUS;
+    case '.':
+      return XBMCK_PERIOD;
+    case '/':
+      return XBMCK_SLASH;
+    case ':':
+      return XBMCK_COLON;
+    case ';':
+      return XBMCK_SEMICOLON;
+    case '<':
+      return XBMCK_LESS;
+    case '=':
+      return XBMCK_EQUALS;
+    case '>':
+      return XBMCK_GREATER;
+    case '?':
+      return XBMCK_QUESTION;
+    case '@':
+      return XBMCK_AT;
+    case '[':
+      return XBMCK_LEFTBRACKET;
+    case '\\':
+      return XBMCK_BACKSLASH;
+    case ']':
+      return XBMCK_RIGHTBRACKET;
+    case '^':
+      return XBMCK_CARET;
+    case '_':
+      return XBMCK_UNDERSCORE;
+    case '`':
+      return XBMCK_BACKQUOTE;
+    case '{':
+      return XBMCK_LEFTBRACE;
+    case '|':
+      return XBMCK_PIPE;
+    case '}':
+      return XBMCK_RIGHTBRACE;
+    case '~':
+      return XBMCK_TILDE;
+    default:
+      return XBMCK_UNKNOWN;
+  }
+}
+
+uint16_t TranslateUnicode(const EmscriptenKeyboardEvent* e)
+{
+  // KeyboardEvent.key holds either one printable character or a named key such as
+  // "Enter", so a single code point is what distinguishes text from the rest.
+  // Anything above the BMP has no room in the uint16_t keysym.
+  const std::u32string codePoints = CCharsetConverter::utf8ToUtf32(e->key);
+  if (codePoints.size() != 1 || codePoints[0] > UINT16_MAX)
+    return 0;
+
+  return static_cast<uint16_t>(codePoints[0]);
+}
+
+XBMCKey TranslateDomKey(const EmscriptenKeyboardEvent* e)
+{
+  if (std::strcmp(e->key, "Back") == 0)
+    return XBMCK_ESCAPE;
+
+  if (e->location == DOM_KEY_LOCATION_NUMPAD)
+  {
+    if (e->keyCode >= DOM_VK_NUMPAD0 && e->keyCode <= DOM_VK_NUMPAD9)
+      return static_cast<XBMCKey>(XBMCK_KP0 + (e->keyCode - DOM_VK_NUMPAD0));
+
+    switch (e->keyCode)
+    {
+      case DOM_VK_ADD:
+        return XBMCK_KP_PLUS;
+      case DOM_VK_SUBTRACT:
+        return XBMCK_KP_MINUS;
+      case DOM_VK_MULTIPLY:
+        return XBMCK_KP_MULTIPLY;
+      case DOM_VK_DIVIDE:
+        return XBMCK_KP_DIVIDE;
+      case DOM_VK_DECIMAL:
+      case DOM_VK_DELETE:
+        return XBMCK_KP_PERIOD;
+      case DOM_VK_RETURN:
+      case DOM_VK_ENTER:
+        return XBMCK_KP_ENTER;
+      default:
+        break;
+    }
+  }
+
+  if (const XBMCKey printable = TranslatePrintableKey(e->key[0]);
+      e->key[0] != '\0' && e->key[1] == '\0' && printable != XBMCK_UNKNOWN)
+  {
+    return printable;
+  }
+
+  if (e->keyCode >= DOM_VK_F1 && e->keyCode <= DOM_VK_F15)
+    return static_cast<XBMCKey>(XBMCK_F1 + (e->keyCode - DOM_VK_F1));
+
+  switch (e->keyCode)
+  {
+    case 10009: // Tizen TV hardware Back key
+      return XBMCK_ESCAPE;
+    case DOM_VK_BACK_SPACE:
+      return XBMCK_BACKSPACE;
+    case DOM_VK_TAB:
+      return XBMCK_TAB;
+    case DOM_VK_RETURN:
+    case DOM_VK_ENTER:
+      return XBMCK_RETURN;
+    case DOM_VK_ESCAPE:
+      return XBMCK_ESCAPE;
+    case DOM_VK_SPACE:
+      return XBMCK_SPACE;
+    case DOM_VK_PAGE_UP:
+      return XBMCK_PAGEUP;
+    case DOM_VK_PAGE_DOWN:
+      return XBMCK_PAGEDOWN;
+    case DOM_VK_END:
+      return XBMCK_END;
+    case DOM_VK_HOME:
+      return XBMCK_HOME;
+    case DOM_VK_LEFT:
+      return XBMCK_LEFT;
+    case DOM_VK_UP:
+      return XBMCK_UP;
+    case DOM_VK_RIGHT:
+      return XBMCK_RIGHT;
+    case DOM_VK_DOWN:
+      return XBMCK_DOWN;
+    case DOM_VK_INSERT:
+      return XBMCK_INSERT;
+    case DOM_VK_DELETE:
+      return XBMCK_DELETE;
+    case DOM_VK_SHIFT:
+      return e->location == DOM_KEY_LOCATION_RIGHT ? XBMCK_RSHIFT : XBMCK_LSHIFT;
+    case DOM_VK_CONTROL:
+      return e->location == DOM_KEY_LOCATION_RIGHT ? XBMCK_RCTRL : XBMCK_LCTRL;
+    case DOM_VK_ALT:
+      return e->location == DOM_KEY_LOCATION_RIGHT ? XBMCK_RALT : XBMCK_LALT;
+    case DOM_VK_WIN:
+      return e->location == DOM_KEY_LOCATION_RIGHT ? XBMCK_RSUPER : XBMCK_LSUPER;
+    case DOM_VK_CONTEXT_MENU:
+      return XBMCK_MENU;
+    case DOM_VK_CAPS_LOCK:
+      return XBMCK_CAPSLOCK;
+    case DOM_VK_NUM_LOCK:
+      return XBMCK_NUMLOCK;
+    case DOM_VK_SCROLL_LOCK:
+      return XBMCK_SCROLLOCK;
+    default:
+      return XBMCK_UNKNOWN;
+  }
+}
+
+XBMC_Event TranslateKeyEvent(const EmscriptenKeyboardEvent* e, uint8_t type)
+{
+  XBMC_Event ev{};
+  ev.type = type;
+  ev.key.keysym.scancode = e->keyCode;
+  ev.key.keysym.sym = TranslateDomKey(e);
+  ev.key.keysym.mod = TranslateModifiers(e);
+  ev.key.keysym.unicode = TranslateUnicode(e);
+  return ev;
+}
+
+// Identity mapping: render resolution == canvas CSS size.
+void TranslateMousePosition(const EmscriptenMouseEvent* e, uint16_t& x, uint16_t& y)
+{
+  const int rawX = std::max(0, e->targetX);
+  const int rawY = std::max(0, e->targetY);
+  x = static_cast<uint16_t>(std::min(rawX, static_cast<int>(UINT16_MAX)));
+  y = static_cast<uint16_t>(std::min(rawY, static_cast<int>(UINT16_MAX)));
+}
+
+// Keys pressed while the native keyboard owned input. Their release arrives
+// after the keyboard has closed and must be dropped too, or Kodi's long-press
+// handling acts on a release it never saw the press for.
+std::unordered_set<unsigned long> g_swallowedKeys;
+
+EM_BOOL OnKeyDown(int /*eventType*/, const EmscriptenKeyboardEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  if (KODI::WINDOWING::WASM::CWasmKeyboard::IsActive())
+  {
+    g_swallowedKeys.insert(e->keyCode);
+    return EM_FALSE;
+  }
+  g_events->MessagePush(TranslateKeyEvent(e, XBMC_KEYDOWN));
+  // Cancelling the paste shortcut would suppress the DOM "paste" event that
+  // supplies the clipboard text (see WasmClipboard.cpp).
+  const bool isPaste = (e->ctrlKey || e->metaKey) && e->keyCode == DOM_VK_V;
+  return isPaste ? EM_FALSE : EM_TRUE;
+}
+
+EM_BOOL OnKeyUp(int /*eventType*/, const EmscriptenKeyboardEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  if (KODI::WINDOWING::WASM::CWasmKeyboard::IsActive() || g_swallowedKeys.erase(e->keyCode) > 0)
+    return EM_FALSE;
+  g_events->MessagePush(TranslateKeyEvent(e, XBMC_KEYUP));
+  return EM_TRUE;
+}
+
+EM_BOOL OnMouseMove(int /*eventType*/, const EmscriptenMouseEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  XBMC_Event ev{};
+  ev.type = XBMC_MOUSEMOTION;
+  TranslateMousePosition(e, ev.motion.x, ev.motion.y);
+  g_events->MessagePush(ev);
+  return EM_FALSE;
+}
+
+EM_BOOL OnMouseButtonDown(int /*eventType*/, const EmscriptenMouseEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  XBMC_Event ev{};
+  ev.type = XBMC_MOUSEBUTTONDOWN;
+  TranslateMousePosition(e, ev.button.x, ev.button.y);
+  ev.button.button = static_cast<unsigned char>(e->button + 1);
+  g_events->MessagePush(ev);
+  return EM_TRUE;
+}
+
+EM_BOOL OnMouseButtonUp(int /*eventType*/, const EmscriptenMouseEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  XBMC_Event ev{};
+  ev.type = XBMC_MOUSEBUTTONUP;
+  TranslateMousePosition(e, ev.button.x, ev.button.y);
+  ev.button.button = static_cast<unsigned char>(e->button + 1);
+  g_events->MessagePush(ev);
+  return EM_TRUE;
+}
+
+EM_BOOL OnResize(int /*eventType*/, const EmscriptenUiEvent* e, void* /*userData*/)
+{
+  if (!g_events)
+    return EM_FALSE;
+  XBMC_Event ev{};
+  ev.type = XBMC_VIDEORESIZE;
+  ev.resize.width = e->windowInnerWidth;
+  ev.resize.height = e->windowInnerHeight;
+  ev.resize.scale = 1.0;
+  g_events->MessagePush(ev);
+  return EM_FALSE;
+}
+} // namespace
+
+CWinEventsWasm::CWinEventsWasm()
+{
+  g_events = this;
+  emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, nullptr, EM_TRUE, OnKeyDown);
+  emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, nullptr, EM_TRUE, OnKeyUp);
+  emscripten_set_mousemove_callback(CANVAS_TARGET, nullptr, EM_TRUE, OnMouseMove);
+  emscripten_set_mousedown_callback(CANVAS_TARGET, nullptr, EM_TRUE, OnMouseButtonDown);
+  emscripten_set_mouseup_callback(CANVAS_TARGET, nullptr, EM_TRUE, OnMouseButtonUp);
+  emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, nullptr, EM_TRUE, OnResize);
+}
+
+CWinEventsWasm::~CWinEventsWasm()
+{
+  g_events = nullptr;
+}
+
+void CWinEventsWasm::MessagePush(const XBMC_Event& newEvent)
+{
+  std::unique_lock lock(m_mutex);
+  m_events.push_back(newEvent);
+}
+
+void CWinEventsWasm::ProcessProxyCallbacks()
+{
+  // Modal dialogs spin a nested Kodi render loop on the worker thread.
+  // Process proxied browser callbacks here so keyboard/mouse events can still
+  // reach this thread while that nested loop is active.
+  emscripten_current_thread_process_queued_calls();
+}
+
+bool CWinEventsWasm::DispatchQueuedEvents()
+{
+  bool handledEvent = false;
+  for (;;)
+  {
+    XBMC_Event pumpEvent{};
+    {
+      std::unique_lock lock(m_mutex);
+      if (m_events.empty())
+        break;
+      pumpEvent = m_events.front();
+      m_events.pop_front();
+    }
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      handledEvent |= appPort->OnEvent(pumpEvent);
+  }
+  return handledEvent;
+}
+
+bool CWinEventsWasm::MessagePump()
+{
+  ProcessProxyCallbacks();
+  return DispatchQueuedEvents();
+}

--- a/xbmc/windowing/wasm/WinEventsWasm.h
+++ b/xbmc/windowing/wasm/WinEventsWasm.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "windowing/WinEvents.h"
+#include "windowing/XBMC_events.h"
+
+#include <deque>
+#include <mutex>
+
+class CWinEventsWasm : public IWinEvents
+{
+public:
+  CWinEventsWasm();
+  ~CWinEventsWasm() override;
+
+  bool MessagePump() override;
+
+  void MessagePush(const XBMC_Event& newEvent);
+
+private:
+  void ProcessProxyCallbacks();
+  bool DispatchQueuedEvents();
+
+  std::mutex m_mutex;
+  std::deque<XBMC_Event> m_events;
+};

--- a/xbmc/windowing/wasm/WinSystemWasmGLESContext.cpp
+++ b/xbmc/windowing/wasm/WinSystemWasmGLESContext.cpp
@@ -1,0 +1,285 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WinSystemWasmGLESContext.h"
+
+#include "OSScreenSaverWasm.h"
+#include "VideoSyncWasm.h"
+#include "WasmClipboard.h"
+#include "WasmVsync.h"
+#include "WebGLCommit.h"
+#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
+#include "settings/DisplaySettings.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/WindowSystemFactory.h"
+
+#include <cstdint>
+#include <string>
+
+#include <emscripten/em_asm.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+#include <emscripten/html5_webgl.h>
+
+using namespace KODI::WINDOWING::WASM;
+
+namespace
+{
+constexpr double VSYNC_WAIT_TIMEOUT_MS = 100.0;
+// Kodi commits within the display frame the tick started, the compositor picks
+// the canvas up at the next frame boundary and the panel shows it one interval
+// after that.
+constexpr float DISPLAY_LATENCY_FRAMES = 2.0f;
+
+// The context is created on the browser main thread and proxied to this pthread:
+// a thread that never returns to its event loop (Kodi's modal dialog loops) must
+// not own per-frame browser resources.
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE CreateProxiedGLContext()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.alpha = EM_FALSE;
+  attrs.depth = EM_TRUE;
+  attrs.stencil = EM_TRUE;
+  attrs.antialias = EM_FALSE;
+  attrs.premultipliedAlpha = EM_TRUE;
+  attrs.preserveDrawingBuffer = EM_FALSE;
+  attrs.powerPreference = EM_WEBGL_POWER_PREFERENCE_HIGH_PERFORMANCE;
+  attrs.failIfMajorPerformanceCaveat = EM_FALSE;
+  attrs.majorVersion = 2;
+  attrs.minorVersion = 0;
+  attrs.enableExtensionsByDefault = EM_TRUE;
+  attrs.explicitSwapControl = EM_TRUE;
+  attrs.renderViaOffscreenBackBuffer = EM_TRUE;
+  attrs.proxyContextToMainThread = EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS;
+  return emscripten_webgl_create_context("#canvas", &attrs);
+}
+
+void NotifyFirstFramePresented()
+{
+  MAIN_THREAD_ASYNC_EM_ASM({
+    if (typeof Module.onKodiFirstFramePresented === 'function')
+      Module.onKodiFirstFramePresented();
+  });
+}
+
+void GetCanvasSize(int* width, int* height)
+{
+  double w = 0;
+  double h = 0;
+  emscripten_get_element_css_size("#canvas", &w, &h);
+  *width = static_cast<int>(w);
+  *height = static_cast<int>(h);
+  if (*width <= 0)
+    *width = 1280;
+  if (*height <= 0)
+    *height = 720;
+}
+} // namespace
+
+void CWinSystemWasmGLESContext::Register()
+{
+  KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
+}
+
+std::unique_ptr<CWinSystemBase> CWinSystemWasmGLESContext::CreateWinSystem()
+{
+  return std::make_unique<CWinSystemWasmGLESContext>();
+}
+
+CWinSystemWasmGLESContext::CWinSystemWasmGLESContext()
+{
+  m_winEvents = std::make_unique<CWinEventsWasm>();
+}
+
+CWinSystemWasmGLESContext::~CWinSystemWasmGLESContext()
+{
+  if (m_webglContext > 0)
+    emscripten_webgl_destroy_context(m_webglContext);
+}
+
+bool CWinSystemWasmGLESContext::InitWindowSystem()
+{
+  VIDEOPLAYER::CRendererFactory::ClearRenderer();
+  CLinuxRendererGLES::Register();
+  CScreenshotSurfaceGLES::Register();
+
+  int initW = 0;
+  int initH = 0;
+  GetCanvasSize(&initW, &initH);
+  emscripten_set_canvas_element_size("#canvas", initW, initH);
+
+  m_webglContext = CreateProxiedGLContext();
+  if (m_webglContext <= 0)
+  {
+    CLog::Log(LOGERROR, "WASM: failed to create proxied WebGL2 context ({})", m_webglContext);
+    return false;
+  }
+
+  const EMSCRIPTEN_RESULT r = emscripten_webgl_make_context_current(m_webglContext);
+  if (r != EMSCRIPTEN_RESULT_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "WASM: emscripten_webgl_make_context_current failed ({})", r);
+    return false;
+  }
+
+  VSYNC::InstallPump();
+
+  CLog::Log(LOGINFO, "WASM: using main-thread WebGL2 context proxied to the Kodi thread ({}x{})",
+            initW, initH);
+  return CWinSystemBase::InitWindowSystem();
+}
+
+bool CWinSystemWasmGLESContext::DestroyWindowSystem()
+{
+  if (m_webglContext > 0)
+  {
+    emscripten_webgl_destroy_context(m_webglContext);
+    m_webglContext = 0;
+  }
+  return CWinSystemBase::DestroyWindowSystem();
+}
+
+bool CWinSystemWasmGLESContext::CreateNewWindow(const std::string& name,
+                                                bool fullScreen,
+                                                RESOLUTION_INFO& res)
+{
+  // Render at the viewport's CSS pixel size so mouse coordinates map 1:1.
+  int w = 0;
+  int h = 0;
+  GetCanvasSize(&w, &h);
+
+  UpdateDesktopResolution(res, "Browser", w, h, static_cast<float>(VSYNC::RefreshRate()), 0);
+  res.bFullScreen = fullScreen;
+
+  emscripten_set_canvas_element_size("#canvas", w, h);
+
+  if (emscripten_webgl_get_current_context() != m_webglContext)
+    emscripten_webgl_make_context_current(m_webglContext);
+
+  m_nWidth = static_cast<unsigned int>(w);
+  m_nHeight = static_cast<unsigned int>(h);
+  m_bWindowCreated = true;
+
+  CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = res;
+  SetWindowResolution(w, h);
+  CRenderSystemGLES::ResetRenderSystem(w, h);
+
+  CLog::Log(LOGINFO, "WASM: created GLES window {}x{} ({})", w, h, name);
+  return true;
+}
+
+bool CWinSystemWasmGLESContext::DestroyWindow()
+{
+  m_bWindowCreated = false;
+  return true;
+}
+
+bool CWinSystemWasmGLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
+{
+  emscripten_set_canvas_element_size("#canvas", newWidth, newHeight);
+  SetWindowResolution(newWidth, newHeight);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
+  m_nWidth = static_cast<unsigned int>(newWidth);
+  m_nHeight = static_cast<unsigned int>(newHeight);
+  return true;
+}
+
+bool CWinSystemWasmGLESContext::SetFullScreen(bool fullScreen,
+                                              RESOLUTION_INFO& res,
+                                              bool blankOtherDisplays)
+{
+  return CreateNewWindow("", fullScreen, res);
+}
+
+void CWinSystemWasmGLESContext::ForceFullScreen(const RESOLUTION_INFO& resInfo)
+{
+  // AppInboundProtocol calls us with the cached RES_DESKTOP on browser resize,
+  // so resInfo is stale.  Re-query the live canvas CSS size and update
+  // RES_DESKTOP + the cached mouse resolution so mouse events (which arrive in
+  // CSS pixels) stay identity-mapped to Kodi's GUI coordinate space.
+  int w = 0;
+  int h = 0;
+  GetCanvasSize(&w, &h);
+  if (w <= 0 || h <= 0)
+    return;
+
+  RESOLUTION_INFO& desktop = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+  const std::string output = desktop.strOutput.empty() ? "Browser" : desktop.strOutput;
+  const uint32_t flags = desktop.dwFlags;
+  UpdateDesktopResolution(desktop, output, w, h, static_cast<float>(VSYNC::RefreshRate()), flags);
+  GetGfxContext().ResetOverscan(desktop);
+
+  ResizeWindow(w, h, 0, 0);
+
+  GetGfxContext().ApplyModeChange(RES_DESKTOP);
+}
+
+bool CWinSystemWasmGLESContext::MessagePump()
+{
+  if (m_winEvents)
+    return m_winEvents->MessagePump();
+  return false;
+}
+
+void CWinSystemWasmGLESContext::SetVSyncImpl(bool enable)
+{
+}
+
+void CWinSystemWasmGLESContext::PresentRenderImpl(bool rendered)
+{
+  if (!rendered || m_webglContext <= 0)
+    return;
+
+  // The timeout keeps Kodi running when rAF is throttled (hidden tab).
+  const uint32_t next = VSYNC::WaitForTick(m_lastVsyncSeen, VSYNC_WAIT_TIMEOUT_MS);
+  if (next == m_lastVsyncSeen)
+    return;
+  m_lastVsyncSeen = next;
+
+  // Synchronous: the main thread runs every queued GL call, then blits the
+  // offscreen framebuffer to the canvas.
+  if (wasm_webgl_commit_frame() == 0)
+  {
+    CLog::Log(LOGWARNING, "WASM: no WebGL context to commit the frame to");
+    return;
+  }
+  if (!m_firstFramePresented)
+  {
+    m_firstFramePresented = true;
+    NotifyFirstFramePresented();
+  }
+}
+
+int CWinSystemWasmGLESContext::GetBufferAge()
+{
+  return 1;
+}
+
+float CWinSystemWasmGLESContext::GetDisplayLatency()
+{
+  return DISPLAY_LATENCY_FRAMES * 1000.0f / static_cast<float>(VSYNC::RefreshRate());
+}
+
+std::unique_ptr<CVideoSync> CWinSystemWasmGLESContext::GetVideoSync(CVideoReferenceClock* clock)
+{
+  return std::make_unique<CVideoSyncWasm>(clock);
+}
+
+std::string CWinSystemWasmGLESContext::GetClipboardText()
+{
+  return WASM_CLIPBOARD::ConsumePendingPasteText();
+}
+
+std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> CWinSystemWasmGLESContext::GetOSScreenSaverImpl()
+{
+  return std::make_unique<COSScreenSaverWasm>();
+}

--- a/xbmc/windowing/wasm/WinSystemWasmGLESContext.h
+++ b/xbmc/windowing/wasm/WinSystemWasmGLESContext.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "WinEventsWasm.h"
+#include "rendering/gles/RenderSystemGLES.h"
+#include "windowing/WinSystem.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <emscripten/html5.h>
+
+class CWinSystemWasmGLESContext : public CWinSystemBase, public CRenderSystemGLES
+{
+public:
+  CWinSystemWasmGLESContext();
+  ~CWinSystemWasmGLESContext() override;
+
+  static void Register();
+  static std::unique_ptr<CWinSystemBase> CreateWinSystem();
+
+  CRenderSystemBase* GetRenderSystem() override { return this; }
+
+  bool InitWindowSystem() override;
+  bool DestroyWindowSystem() override;
+
+  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool DestroyWindow() override;
+
+  bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
+  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  void ForceFullScreen(const RESOLUTION_INFO& resInfo) override;
+
+  bool MessagePump() override;
+  bool HasCursor() override { return false; }
+
+  void Register(IDispResource* resource) override {}
+  void Unregister(IDispResource* resource) override {}
+
+  /*!
+   * \brief WebGL cannot report a buffer age, but the offscreen framebuffer Kodi
+   * renders into survives emscripten_webgl_commit_frame(), which only blits it to
+   * the canvas. The previous frame is therefore always intact and the GUI needs
+   * to redraw dirty regions only.
+   */
+  int GetBufferAge() override;
+
+  float GetDisplayLatency() override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
+
+  std::string GetClipboardText() override;
+
+protected:
+  std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
+  void SetVSyncImpl(bool enable) override;
+  void PresentRenderImpl(bool rendered) override;
+
+private:
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE m_webglContext{0};
+  uint32_t m_lastVsyncSeen{0};
+  bool m_firstFramePresented{false};
+};

--- a/xbmc/windowing/wasm/webgl_commit.js
+++ b/xbmc/windowing/wasm/webgl_commit.js
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+// Presents Emscripten's offscreen framebuffer without the synchronous GL state
+// queries emscripten_webgl_commit_frame() makes. Scissor test is re-enabled
+// unconditionally: CRenderSystemGLES keeps it enabled between frames.
+mergeInto(LibraryManager.library, {
+  wasm_webgl_commit_frame__deps: ['$GL'],
+  wasm_webgl_commit_frame__proxy: 'sync',
+  wasm_webgl_commit_frame__sig: 'i',
+  wasm_webgl_commit_frame: function() {
+    const context = GL.currentContext;
+    if (!context || !context.GLctx || !context.defaultFbo) return 0;
+    const gl = context.GLctx;
+    gl.disable(gl.SCISSOR_TEST);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, context.defaultFbo);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.blitFramebuffer(0, 0, gl.canvas.width, gl.canvas.height,
+                       0, 0, gl.canvas.width, gl.canvas.height,
+                       gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, context.defaultFbo);
+    gl.enable(gl.SCISSOR_TEST);
+    return 1;
+  },
+});


### PR DESCRIPTION
## Description
Stacked on #29258: the first two commits are that PR, only the last commit belongs here.

Adds the windowing backend and browser input for the WebAssembly (Emscripten) platform.

- `CWinSystemWasmGLESContext` creates a WebGL2 context on the canvas and proxies it to the Kodi pthread, the same way every GL call is proxied under `PROXY_TO_PTHREAD`. Frames are presented by blitting Emscripten's offscreen framebuffer to the canvas (`webgl_commit.js`) once the browser's `requestAnimationFrame` pump on the main thread ticks, so presentation follows real vsync rather than the pthread's emulated timing. `CVideoSyncWasm` feeds the reference clock from the same ticks and `COSScreenSaverWasm` uses the Screen Wake Lock API.
- `CWinEventsWasm` translates DOM keyboard, mouse and resize events into `XBMC_Event`s, including the Tizen TV remote keys.
- `CWasmKeyboard` brings up the browser's or the TV's own on-screen keyboard through a DOM `<input>`, behind a new `input.usekodikeyboard` setting (default off, mirroring the tvOS setting). `CWasmClipboard` supplies paste text from the DOM `paste` event, since a browser cannot read the clipboard synchronously.
- `kodi_pre.js` persists the profile to IndexedDB via IDBFS and wires canvas focus and paste on the main thread. The cross-origin request rewrite that pairs with `tools/wasm/serve.py` lives in a separate pre-js linked only with `-DENABLE_WASM_DEV_PROXY=ON`.
- The GLES video renderers and shaders are enabled for the wasm platform.

## Motivation and context
Part of the series porting Kodi to WebAssembly. This is the piece that puts pixels on screen and gets input back in.

## How has this been tested?
Full wasm build with emcc 6.0.9 on this branch: compiles and links to `kodi.js`. The windowing code has been exercised as part of the complete series in Chrome and on a Samsung Tizen TV. Two small changes made during review have not yet been re-run: Ctrl/Cmd+V is no longer cancelled on keydown so the DOM paste event can fire, and a redundant extra message pump in the modal dialog loop was removed since `FrameMove` already drives `MessagePump()` there.

## What is the effect on users?
None for existing platforms. The only shared-code changes are the wasm entries in two CMake lists and the wasm branch of the touch-keyboard factory.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [x] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
