### PR TITLE
[Language] Resolve ISO 639 codes and names without the subtag registry.

### DIFF
--- a/xbmc/test/TestUtils.h
+++ b/xbmc/test/TestUtils.h
@@ -8,13 +8,36 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
+
+#include "ServiceManager.h"
+#include "application/Application.h"
 
 namespace XFILE
 {
   class CFile;
 }
+
+/*!
+ * \brief Takes the service manager away for as long as it is in scope, for tests covering the
+ *        work Kodi does before one exists - such as the disc probe the storage provider runs
+ *        while the manager is still being built.
+ */
+class CServiceManagerSwap
+{
+public:
+  CServiceManagerSwap() : m_saved(std::move(g_application.m_ServiceManager)) {}
+  ~CServiceManagerSwap() { g_application.m_ServiceManager = std::move(m_saved); }
+
+  CServiceManagerSwap(const CServiceManagerSwap&) = delete;
+  CServiceManagerSwap& operator=(const CServiceManagerSwap&) = delete;
+
+private:
+  std::unique_ptr<CServiceManager> m_saved;
+};
 
 class CXBMCTestUtils
 {

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -21,10 +21,64 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <array>
+#include <optional>
+#include <string_view>
 
 using namespace KODI::UTILS::I18N;
 
 constexpr std::size_t MAX_BCP47_ENGLISH_NAME_LENGTH = 30;
+
+namespace
+{
+//! Kodi's own codes for Brazilian Portuguese. No standard assigns them, so BCP 47 has no subtag
+//! for them and only an addon can say what they mean.
+constexpr std::array<std::string_view, 2> UNREGISTERED_CODES{"pb", "pob"};
+
+/*!
+ * \brief The BCP 47 language subtag for a bare ISO 639 code, taken from the ISO 639 tables.
+ *
+ * RFC 5646 draws its primary language subtags from ISO 639, and a bare code carries no script,
+ * region or variant for the subtag registry to arbitrate, so the static tables settle it.
+ *
+ * \param[in] code A trimmed, lower-cased ISO 639-1 or ISO 639-2 code.
+ * \return The subtag, or nullopt where the tables do not hold the language, in which case the
+ *         registry is the only thing that can recognize it.
+ */
+std::optional<std::string> Bcp47SubTagFromIso639(const std::string& code)
+{
+  if (std::ranges::find(UNREGISTERED_CODES, code) != UNREGISTERED_CODES.end())
+    return std::nullopt;
+
+  // BCP 47 registers the alpha-2 code for every language that has one, so an alpha-2 is already
+  // the subtag - except for the five ISO 639-1 withdrew, whose current spelling is reached by
+  // going out to the alpha-3 the language kept and back
+  if (code.length() == 2)
+  {
+    if (std::string alpha3; CLangCodeExpander::ConvertISO6391ToISO6392B(code, alpha3))
+    {
+      if (std::string alpha2; CLangCodeExpander::ConvertISO6392ToISO6391(alpha3, alpha2))
+        return alpha2;
+    }
+
+    return std::nullopt;
+  }
+
+  if (code.length() != 3)
+    return std::nullopt;
+
+  if (std::string alpha2; CLangCodeExpander::ConvertISO6392ToISO6391(code, alpha2))
+    return alpha2;
+
+  // A language with no alpha-2 is registered under its ISO 639-2/T code. Only languages that do
+  // have an alpha-2 spell their bibliographic and terminology codes apart, so a code reaching
+  // here is already the /T form
+  if (CIso639_2::LookupByCode(code).has_value())
+    return code;
+
+  return std::nullopt;
+}
+} // namespace
 
 CLangCodeExpander::STRINGLOOKUPTABLE& CLangCodeExpander::GetUserCodes()
 {
@@ -269,7 +323,7 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
   return false;
 }
 
-bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code)
+bool CLangCodeExpander::ReverseLookupInTables(const std::string& desc, std::string& code)
 {
   if (desc.empty())
     return false;
@@ -297,6 +351,20 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
     code = *ret;
     return true;
   }
+
+  return false;
+}
+
+bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code)
+{
+  if (desc.empty())
+    return false;
+
+  if (ReverseLookupInTables(desc, code))
+    return true;
+
+  std::string descTmp(desc);
+  StringUtils::Trim(descTmp);
 
   const CSubTagRegistryManager& registry{CServiceBroker::GetSubTagRegistry()};
   if (const auto ret = registry.GetLanguageSubTags().LookupByDescription(descTmp); ret.has_value())
@@ -445,6 +513,13 @@ std::string CLangCodeExpander::AsISO6392B(const std::string& lang)
   if (std::string userCode; LookupUserCode(lang, userCode))
     return userCode;
 
+  // A bare code is already its own primary language subtag, so a tag parse has nothing to strip
+  if (lang.length() == 2 || lang.length() == 3)
+  {
+    if (std::string code; ConvertToISO6392B(lang, code))
+      return code;
+  }
+
   // Region, script and variant subtags have no ISO 639 equivalent, so a tag is represented by its
   // primary language subtag. Anything a tag cannot be made of - an English name, most obviously -
   // is converted as it stands.
@@ -466,6 +541,23 @@ bool CLangCodeExpander::ConvertToBcp47(const std::string& text, std::string& bcp
   // Search in the user defined map. Bypasses all other validations.
   if (LookupUserCode(code, bcp47Lang))
     return true;
+
+  if (const auto subTag = Bcp47SubTagFromIso639(code); subTag.has_value())
+  {
+    bcp47Lang = *subTag;
+    return true;
+  }
+
+  // Tried after the code, so that a name spelled like another language's code - "Ga" names gaa,
+  // but ga is Irish - resolves as the code
+  if (std::string iso639; ReverseLookupInTables(code, iso639))
+  {
+    if (const auto subTag = Bcp47SubTagFromIso639(iso639); subTag.has_value())
+    {
+      bcp47Lang = *subTag;
+      return true;
+    }
+  }
 
   auto tag = CBcp47::ParseTag(code);
 

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -162,6 +162,17 @@ protected:
   */
   static bool ReverseLookup(const std::string& desc, std::string& code);
 
+  /*!
+   * \brief The part of ReverseLookup that the user mappings and the static tables can answer,
+   *        and so the part that does not need the subtag registry.
+   * \note Searched in the same order as ReverseLookup, so that a name resolves to the same code
+   *       whichever of the two is called.
+   * \param[in] desc The english language name for which a code is looked for.
+   * \param[out] code The user defined, ISO 639-1 or ISO 639-2/T code of the given language desc.
+   * \return true if a code was found, false otherwise.
+   */
+  static bool ReverseLookupInTables(const std::string& desc, std::string& code);
+
   /** \brief Looks up the user defined code of the given code or language name.
   *   \param[in] desc The language code or name that should be converted.
   *   \param[out] userCode The user defined language code of the given language desc.

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -260,6 +260,21 @@ const TestBcp47Conversion Bcp47ConversionTests[] = {
     {"bol", true, "bol"},
     {" en ", true, "en"},
     {"EN", true, "en"},
+    // The five alpha-2 codes ISO 639-1 withdrew. BCP 47 names the current spelling, which the
+    // ISO 639 tables reach through the alpha-3 the language kept
+    {"iw", true, "he"},
+    {"in", true, "id"},
+    {"ji", true, "yi"},
+    {"jw", true, "jv"},
+    {"mo", true, "ro"},
+    // A name spelled like another language's code is read as the code: "Ga" names gaa, but ga is
+    // Irish, and a code is what media is tagged with
+    {"Ga", true, "ga"},
+    {"gaa", true, "gaa"},
+    // Kodi's own codes for Brazilian Portuguese have no BCP 47 subtag, so without an addon that
+    // answers for them there is no tag to give
+    {"pb", false, ""},
+    {"pob", false, ""},
 };
 // clang-format on
 

--- a/xbmc/utils/test/TestLanguageTag.cpp
+++ b/xbmc/utils/test/TestLanguageTag.cpp
@@ -8,6 +8,8 @@
 
 #include "utils/LanguageTag.h"
 
+#include "test/TestUtils.h"
+
 #include <gtest/gtest.h>
 
 using namespace KODI::UTILS;
@@ -286,4 +288,37 @@ TEST(TestLanguageTag, NarrowingDropsTheRegionFromTheEnglishName)
 
   // A tag with nothing to drop names the same language either way
   EXPECT_EQ(CLanguageTag::Parse("eng").GetEnglishLanguageName(), "English");
+}
+
+TEST(TestLanguageTag, ResolvesADiscLanguageFromTheIso639Tables)
+{
+  // A DVD IFO states a track language as ISO 639-1 and the preferences handed to libdvdnav are
+  // ISO 639-2, and a disc is probed before the subtag registry exists
+  CLanguageTag menu;
+  CLanguageTag audio;
+  {
+    const CServiceManagerSwap noServices;
+    menu = CLanguageTag::Parse("en");
+    audio = CLanguageTag::Parse("ger");
+  }
+
+  EXPECT_EQ(menu.AsBcp47(), "en");
+  EXPECT_EQ(menu.AsIso6392B(), "eng");
+  EXPECT_EQ(audio.AsBcp47(), "de");
+  EXPECT_EQ(audio.AsIso6392B(), "ger");
+  EXPECT_EQ(audio.AsIso6391(), "de");
+}
+
+TEST(TestLanguageTag, ResolvesAnEnglishNameFromTheIso639Tables)
+{
+  // langinfo.xml may state its locale as an english name, and that value stands in for the UI
+  // language until a language addon is loaded - so a name is resolved on the same early path
+  CLanguageTag named;
+  {
+    const CServiceManagerSwap noServices;
+    named = CLanguageTag::Parse("English");
+  }
+
+  EXPECT_EQ(named.AsBcp47(), "en");
+  EXPECT_EQ(named.AsIso6392B(), "eng");
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Possible alternative fix for #29164.

Nothing about the values being resolved needs the registry. A bare ISO 639 code names a language and qualifies it with nothing - no script, region or variant for the IANA registry to arbitrate - and RFC 5646 draws its primary language subtags from ISO 639 to begin with. An english name is not a tag at all, and the ISO 639 tables carry a name for every language they hold. Both are therefore answerable from the static tables, and so answerable before a registry has been loaded.

ConvertToBcp47 and AsISO6392B now take those two cases from the tables ahead of any tag parse. ReverseLookup is split so that the part the tables and the user mappings can answer is shared with the fast path, keeping the search order identical whichever way a name is resolved - in particular a user defined name still wins over the ISO tables.

The code is tried before the name, so that the few names spelled like another language's code - "Ga" names gaa, but ga is Irish - keep resolving as codes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Kodi crashes at startup on Windows when a disc is in the drive: the storage provider probes it while the service manager is still being built, and resolving a language reached CServiceBroker::GetSubTagRegistry(), which dereferences a service manager that does not exist yet.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
