### PR TITLE
[VideoPlayer,Android] MediaCodec EGL renderer: report SHADER_RGB

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -107,6 +107,11 @@ bool CRendererMediaCodec::LoadShadersHook()
   return true;
 }
 
+EShaderFormat CRendererMediaCodec::GetShaderFormat()
+{
+  return SHADER_RGB;
+}
+
 bool CRendererMediaCodec::RenderHook(int index)
 {
   CYuvPlane &plane = m_buffers[index].fields[0][0];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
@@ -36,6 +36,7 @@ protected:
   // hooks for hw dec renderer
   bool LoadShadersHook() override;
   bool RenderHook(int index) override;
+  EShaderFormat GetShaderFormat() override;
 
 private:
   float m_textureMatrix[16];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
@@ -29,6 +29,7 @@ enum EShaderFormat
   SHADER_AYUV, // packed 4:4:4 in GL_RGBA8  (AYUV / XYUV)
   SHADER_Y410, // packed 4:4:4 in GL_RGB10_A2 (Y410)
   SHADER_Y412, // packed 4:4:4 in GL_RGBA16 (Y412 / Y416)
+  SHADER_RGB, // already RGB, no conversion
   SHADER_MAX,
 };
 
@@ -68,6 +69,7 @@ private:
       {SHADER_AYUV, "AYUV packed 4:4:4"},
       {SHADER_Y410, "Y410 packed 4:4:4 10-bit"},
       {SHADER_Y412, "Y412 packed 4:4:4 12/16-bit"},
+      {SHADER_RGB, "RGB"},
   });
 
   static_assert(SHADER_MAX == shaderFormatMap.size(),


### PR DESCRIPTION
## Description

LinuxRendererGLES is two things at once. Registered as "default", it is the concrete CPU-upload renderer for software-decoded frames. It is also the base class of the GLES hardware renderers, which inherit its Configure. A hardware renderer whose buffer carries no pixel format has to answer GetShaderFormat itself, as RendererVAAPIGLES does from its VA fourcc. RendererMediaCodec inherited Configure but left GetShaderFormat to the base table.

Since 82ee4367 from #28123, that inherited Configure refuses any buffer whose GetShaderFormat() is SHADER_NONE, so a hardware buffer with no host planes cannot reach the CPU-upload path. The MediaCodec buffer never sets a pixel format, so the base table answered SHADER_NONE for it too. With "Media Codec Surface" disabled, Configure failed, the renderer stayed unconfigured and the player aborted output: black screen.

RendererMediaCodec draws its own external texture in RenderHook and never builds a YUV shader, so the format it reports is read by nothing but that guard. Give it a SHADER_RGB answer, which names what the texture holds and lets Configure proceed. The guard keeps refusing buffers that really have no planes.

Fixes #29147


<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
#29147 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
untested as yet on Android

## What is the effect on users?
GLES video rendering on Android works again

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
