### PR TITLE
[Python] Fix 'none' in containers, et al

### DIFF
--- a/xbmc/interfaces/python/test/TestPythonBindings.cpp
+++ b/xbmc/interfaces/python/test/TestPythonBindings.cpp
@@ -111,6 +111,29 @@ assert a.getId() == -1, a.getId()
 )py"));
 }
 
+TEST_F(TestPythonBindings, NoneInsideContainers)
+{
+  if (!s_pythonUp)
+    GTEST_SKIP() << "python runtime not initialized";
+  ASSERT_TRUE(s_mainImportOk);
+  EXPECT_TRUE(RunPy(R"py(
+import xbmcgui
+li = xbmcgui.ListItem('none-in-containers', '', '', True)
+
+li.setArt({'thumb': 'a.png', 'poster': None})
+assert li.getArt('thumb') == 'a.png', li.getArt('thumb')
+assert li.getArt('poster') == '', repr(li.getArt('poster'))
+
+li.setProperties({'alpha': '1', 'beta': None})
+assert li.getProperty('beta') == '', repr(li.getProperty('beta'))
+
+li.setCast([{'name': 'A', 'role': 'B', 'thumbnail': None}])
+li.setInfo('video', {'title': 'x', 'plot': None})
+
+li.getVideoInfoTag().setStudios(['a', None])
+)py"));
+}
+
 // an xbmc type passed through an xbmcgui-obtained object crosses the shared type table
 TEST_F(TestPythonBindings, CrossModule)
 {

--- a/xbmc/interfaces/python/test/TestPythonBindings.cpp
+++ b/xbmc/interfaces/python/test/TestPythonBindings.cpp
@@ -134,6 +134,22 @@ li.getVideoInfoTag().setStudios(['a', None])
 )py"));
 }
 
+TEST_F(TestPythonBindings, FileContextManager)
+{
+  if (!s_pythonUp)
+    GTEST_SKIP() << "python runtime not initialized";
+  ASSERT_TRUE(s_mainImportOk);
+  EXPECT_TRUE(RunPy(R"py(
+import xbmcvfs
+p = 'special://temp/swig-ctx.txt'
+with xbmcvfs.File(p, 'w') as f:
+    f.write('hello')
+with xbmcvfs.File(p) as f:
+    assert f.read() == 'hello', repr(f.read())
+xbmcvfs.delete(p)
+)py"));
+}
+
 // an xbmc type passed through an xbmcgui-obtained object crosses the shared type table
 TEST_F(TestPythonBindings, CrossModule)
 {

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -51,6 +51,16 @@ KODI_CONSTRUCT(XBMCAddon::xbmcvfs, Stat)
     SWIG_fail;
 }
 
+/* Python calls __exit__ with the exception triple, which File.h does not take. */
+%ignore XBMCAddon::xbmcvfs::File::__exit__();
+%extend XBMCAddon::xbmcvfs::File {
+  void __exit__(PyObject* exc_type = nullptr, PyObject* exc_value = nullptr,
+                PyObject* traceback = nullptr)
+  {
+    $self->close();
+  }
+}
+
 %include "interfaces/legacy/File.h"
 
 %rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;

--- a/xbmc/interfaces/swig/kodi_common.i
+++ b/xbmc/interfaces/swig/kodi_common.i
@@ -25,8 +25,7 @@
       include, because SWIG fragments are first-definition-wins. */
 %include "kodi_list.i"
 
-/* 2. stock library */
-%include <std_string.i>
+/* 2. stock library, included by kodi_string.i around its own definitions */
 %include "kodi_string.i"
 
 /* 3. Kodi's generic vocabulary types: Tuple, Alternative, Dictionary */

--- a/xbmc/interfaces/swig/kodi_common.i
+++ b/xbmc/interfaces/swig/kodi_common.i
@@ -26,6 +26,7 @@
 %include "kodi_list.i"
 
 /* 2. stock library, included by kodi_string.i around its own definitions */
+%include <stdint.i>
 %include "kodi_string.i"
 
 /* 3. Kodi's generic vocabulary types: Tuple, Alternative, Dictionary */

--- a/xbmc/interfaces/swig/kodi_string.i
+++ b/xbmc/interfaces/swig/kodi_string.i
@@ -6,6 +6,47 @@
  *  See LICENSES/README.md for more information.
  */
 
+%{
+#include "utils/log.h"
+%}
+
+/* 'None' is accepted as the empty string, including as a dict value or list element. */
+//! @todo Drop the 'None' acceptance after v22; kodi_typing.i annotates these as str.
+%fragment(SWIG_AsVal_frag(std::string), "header", fragment=SWIG_AsPtr_frag(std::string)) {
+SWIGINTERN int
+SWIG_AsVal_dec(std::string)(SWIG_Object obj, std::string* val)
+{
+  if (obj == Py_None)
+  {
+    CLog::Log(LOGWARNING, "Passing None where a string is expected is deprecated and might be "
+                          "removed in future Kodi versions. Please pass an empty string instead.");
+    if (val)
+      val->clear();
+    return SWIG_OK;
+  }
+
+  std::string* v = 0;
+  int res = SWIG_AsPtr(std::string)(obj, &v);
+  if (!SWIG_IsOK(res))
+    return res;
+  if (v)
+  {
+    if (val)
+      *val = *v;
+    if (SWIG_IsNewObj(res))
+    {
+      delete v;
+      res = SWIG_DelNewMask(res);
+    }
+    return res;
+  }
+  return SWIG_ERROR;
+}
+}
+
+/* Fragments are first-definition-wins, typemaps last-declaration-wins. */
+%include <std_string.i>
+
 /* Kodi declares optional string parameters as `const String& x = emptyString`.
    Stock std_string.i routes `const std::string&` through %typemaps_asptrfromn
    (typemaps/ptrtypes.swg), whose in-typemap heap-allocates and whose freearg is
@@ -13,21 +54,13 @@
    Because the defaulted parameter starts out pointing at the emptyString global,
    the compiler cannot prove that delete is never reached with the global, and
    warns. The combination is in fact unreachable, but the build must be
-   warning-free, so the argument is converted into a stack temporary instead:
-   nothing is allocated, nothing is freed, and the freearg goes away.
-   SWIG_AsVal_std_string is stock, supplied by std_string.i. */
+   warning-free, so the argument is converted into a stack temporary instead. */
 %typemap(in, fragment=SWIG_AsVal_frag(std::string)) const std::string & (std::string swig_temp)
 {
-  /* The shipped bindings coerce None to the empty string (PyXBMCGetUnicodeString
-     returns XBMCAddon::emptyString for Py_None). Scrapers rely on it: they pass
-     dict.get(...) straight into setters, and a missing key is None. */
-  if ($input != Py_None)
-  {
-    int swig_res = SWIG_AsVal_std_string($input, &swig_temp);
-    if (!SWIG_IsOK(swig_res))
-      SWIG_exception_fail(SWIG_ArgError(swig_res),
-        "in method '$symname', argument $argnum of type '$type'");
-  }
+  int swig_res = SWIG_AsVal_std_string($input, &swig_temp);
+  if (!SWIG_IsOK(swig_res))
+    SWIG_exception_fail(SWIG_ArgError(swig_res),
+      "in method '$symname', argument $argnum of type '$type'");
   $1 = &swig_temp;
 }
 %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) const std::string & {


### PR DESCRIPTION
## Description
Small cleanups after the switch to native SWIG.

Fixes #29254
Fixes #29263


## Motivation and context
fixes

## How has this been tested?
updated both local swig addon test harnesses:
```
2026-09-09 23:23:35.866 T:37775   debug <general>: ------ Window Init (Home.xml) ------
2026-09-09 23:23:35.907 T:37775   debug <general>: ------ Window Init (/home/xbmc/.kodi/addons/script.swigharness/resources/skins/default/1080i/harness.xml) ------
2026-09-09 23:23:35.907 T:37775    info <general>: Loading skin file: /home/xbmc/.kodi/addons/script.swigharness/resources/skins/default/1080i/harness.xml, load type: LOAD_ON_GUI_INIT
2026-09-09 23:23:35.949 T:37775   debug <general>: ------ Window Deinit (/home/xbmc/.kodi/addons/script.swigharness/resources/skins/default/1080i/harness.xml) ------
2026-09-09 23:23:35.957 T:37819   debug <CSettingsManager>: requested setting (a_setting_that_does_not_exist) was not found.
2026-09-09 23:23:35.957 T:37819   error <general>: EXCEPTION: Invalid setting type
2026-09-09 23:23:35.957 T:37819   debug <CSettingsManager>: requested setting (a_setting_that_does_not_exist) was not found.
2026-09-09 23:23:35.957 T:37819   error <general>: EXCEPTION: Invalid setting type
2026-09-09 23:23:35.957 T:37819   debug <CSettingsManager>: requested setting (a_setting_that_does_not_exist) was not found.
2026-09-09 23:23:35.957 T:37819   error <general>: EXCEPTION: Invalid setting type
2026-09-09 23:23:35.957 T:37819   debug <CSettingsManager>: requested setting (a_setting_that_does_not_exist) was not found.
2026-09-09 23:23:35.957 T:37819   error <general>: EXCEPTION: Invalid setting type
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 1      PASS     vector<String> out is a mutable list
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 1      PASS     vector<String> in from list
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 1      PASS     vector<String> in from tuple and generator
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 2      PASS     vector<int> out from Control::getPosition
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 3+4    PASS     vector<bool>, vector<int>, vector<double> via Settings
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 5      PASS     vector<const Actor*> in, wrapped elements
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 6      PASS     vector<const ListItem*> in via ControlList
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 7      PASS     vector<Control*> out keeps wrapped types
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 8      PASS     map<String,String> in via setArt
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 9      PASS     map<String,String,less<>> in via setUniqueIDs
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 10     PASS     Dictionary<String> in via setProperties
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 11     PASS     Tuple<String,String> out is a 2-tuple
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 12     PASS     listdir returns a tuple of two mutable lists
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 13     PASS     map<String,Tuple<float,int>> in via setRatings
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 13     PASS     setRatings accepts a None default, as scrapers pass
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 14     PASS     vector<Tuple<String,String>> in via addContextMenuItems
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 15     PASS     vector<Tuple<int,String,String>> in via addSeasons
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 16     PASS     addDirectoryItems: list of (str, ListItem, bool)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 16     PASS     addDirectoryItems rejects a tuple with no ListItem
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 22     PASS     Dictionary coerces numeric values, as addons pass them
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 22     PASS     setInfo: depth-5 dict of (str | list of (str | 2-tuple)) (legacy)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 17     PASS     vector<Dictionary<String>> in via setAvailableFanart
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 18     PASS     Alternative<String,vector<String>> out from Dialog.browse
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 19     PASS     Alternative<String,ListItem*> in via ControlList.addItem
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 20     PASS     vector<Alternative<String,ListItem*>> in
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 21     PASS     PlayParameter accepts both alternatives
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 22     PASS     setFileTitle, setCount, setSize, setOverlay
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 23     PASS     vector<Tuple<String,String>> in via WsgiResponse
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 24     PASS     unique_ptr<vector<int>> out from Dialog.multiselect
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 25     PASS     Buffer in and out, bytes round trip
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 25     PASS     Buffer in accepts str, bytes and bytearray
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] 26     PASS     ControlList.setStaticContent takes a list of ListItem
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: xbmc.log(msg=, level=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: ListItem(label, offscreen=True)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: addDirectoryItem(handle=, url=, listitem=, isFolder=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: setResolvedUrl(handle=, succeeded=, listitem=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: setUniqueID(value, type=, isdefault=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: setRating(rating, votes=, type=, isdefault=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     kwargs: addAvailableArtwork(url, arttype=, preview=, season=)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     defaulted arguments may be omitted
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     None accepted where String is expected
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     None accepted by a setter, as scrapers pass it
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     None accepted as a dict value
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     None accepted as a list element
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     None accepted inside setCast and setInfo
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     getVideoInfoTag mutations stick and are visible again
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     borrowed tag survives its python handle being dropped
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a Window can be created and dropped repeatedly
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     getControl returns the concrete Control subclass
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     ControlList.getSelectedItem returns a ListItem
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     xbmcgui ListItem is accepted by xbmcplugin
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     InfoTag types cross from xbmcgui into xbmc
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     an Actor built in xbmc is accepted by xbmcgui
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     PlayList supports len() and indexing
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Action equals itself
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Action compares equal to its own id (backward compat)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     InfoTagVideo exposes readable properties
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     module constants are present and typed
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Addon and its typed getters
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Addon() with no id resolves through the language hook
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     unicode survives the round trip
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     wrong argument type raises TypeError
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     wrong element type in a container raises TypeError
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a non-sequence where a sequence is expected raises TypeError
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a C++ exception surfaces as RuntimeError
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a class with no public constructor cannot be built
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     vfs exists/mkdir/delete round trip
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     File works as a context manager, as addons write files
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Monitor.onNotification fires in a python subclass
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     director callback arguments arrive as str
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     an exception in a director callback does not kill Kodi
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a director subclass that never calls super().__init__()
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     director subclass keeps its own constructor arguments
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     constructor arguments come from the outer call
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Window subclass receives onInit
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     WindowDialog subclass receives onInit
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Window subclass receives onAction with a wrapped Action
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      SKIP     Window subclass receives onClick for a control no click was delivered; needs an interactive front end
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     WindowXML subclass loads and receives onInit
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     WindowXMLDialog subclass loads and receives onInit
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     WindowXMLDialog subclass with its own keyword arguments
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Window subclass with its own keyword arguments
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     a director object survives being dropped and recreated
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     movie scraper: search result to ListItem
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     movie scraper: full get_details sequence
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     tv scraper: add_main_show_info sequence
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     tv scraper: add_episode_info sequence
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     music scraper: addDirectoryItems with (url, item, bool)
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     scraper settings access through Addon
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     Dialog.notification with keyword arguments
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] -      PASS     suite source never chains a borrowed getter off a constructor
2026-09-09 23:23:35.958 T:37819    info <general>: [SWIGHARNESS] RESULT: PASS (90 passed, 0 failed, 1 skipped)
2026-09-09 23:23:35.991 T:37775   debug <general>: ------ Window Init (DialogConfirm.xml) ------
2026-09-09 23:23:35.991 T:37775    info <general>: Loading skin file: DialogConfirm.xml, load type: KEEP_IN_MEMORY
2026-09-09 23:23:36.000 T:37775   debug <general>: ------ Window Init (DialogNotification.xml) ------
2026-09-09 23:23:37.873 T:37775   debug <general>: ------ Window Deinit (DialogNotification.xml) ------
2026-09-09 23:23:52.606 T:37793   debug <general>: Thread Timer 124148074215104 terminating
2026-09-09 23:23:52.611 T:37833   debug <general>: IMAGE_FILES::CleanerResult IMAGE_FILES::CImageCacheCleaner::ScanOldestCache(unsigned int): begin process to clean image cache
2026-09-09 23:23:52.654 T:37833   debug <general>: IMAGE_FILES::CleanerResult IMAGE_FILES::CImageCacheCleaner::ScanOldestCache(unsigned int): found no old cached images to process
2026-09-09 23:23:52.654 T:37833   debug <general>: std::chrono::milliseconds CTextureCache::ScanOldestCache(): scheduling the next image cache cleaning in 48 hours
2026-09-09 23:23:52.655 T:37856   debug <general>: Thread Timer start, auto delete: false
2026-09-09 23:24:22.607 T:37829   debug <general>: Thread JobWorker 124147556406976 terminating (autodelete)
2026-09-09 23:24:22.607 T:37828   debug <general>: Thread JobWorker 124147153753792 terminating (autodelete)
2026-09-09 23:24:22.607 T:37824   debug <general>: Thread JobWorker 124146834994880 terminating (autodelete)
2026-09-09 23:24:22.655 T:37833   debug <general>: Thread JobWorker 124146801424064 terminating (autodelete)
2026-09-09 23:25:00.441 T:37775    info <general>: Samba is idle. Closing the remaining connections
```

## What is the effect on users?
addons work


## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
