### PR TITLE
[cmake] Fix FindSWIG to prefer the newest SWIG found on PATH

### DIFF
--- a/cmake/modules/buildtools/FindSWIG.cmake
+++ b/cmake/modules/buildtools/FindSWIG.cmake
@@ -8,10 +8,16 @@
 # SWIG::SWIG - the SWIG executable
 
 if(NOT TARGET SWIG::SWIG)
-  find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig
+  if(NATIVEPREFIX)
+    set(_swig_hints HINTS ${NATIVEPREFIX}/bin)
+  endif()
+
+  find_program(SWIG_EXECUTABLE NAMES swig swig4.0 swig3.0 swig2.0
                                NO_CACHE
+                               NAMES_PER_DIR
                                PATH_SUFFIXES swig
-                               HINTS ${NATIVEPREFIX}/bin)
+                               ${_swig_hints})
+  unset(_swig_hints)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(SWIG


### PR DESCRIPTION
## Summary
- `find_program()` in `FindSWIG.cmake` was missing `NAMES_PER_DIR`, so it searched every PATH directory for `swig4.0` before ever trying plain `swig`. This makes a distro-packaged `swig4.0` always win over a newer SWIG installed elsewhere on PATH as just `swig` (e.g. a SWIG 4.5.0+ built from source, now required by `xbmc/interfaces/swig/CMakeLists.txt`).
- Also guards the `NATIVEPREFIX` `HINTS`: when unset (native, non-cross builds) it silently became `/bin`, which on merged-usr systems resolves to `/usr/bin` and gets searched ahead of the rest of PATH regardless of `NAMES_PER_DIR`.
- Matches the behavior of upstream CMake's own `FindSWIG.cmake` module, which already uses `NAMES_PER_DIR` for this reason.

## Test plan
- [x] Verified locally with a minimal CMake project reproducing the bug: without `NAMES_PER_DIR`, a `swig4.0` later on PATH is found ahead of an earlier plain `swig`; with the fix, PATH order is respected.
- [x] Verified the module still parses and resolves `SWIG::SWIG`/`SWIG_VERSION` correctly against a real SWIG install.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)