### PR TITLE
[VideoRenderers] Judge HQ scaler use by the per-eye source rect

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -788,7 +788,8 @@ void CLinuxRendererGL::UpdateVideoFilter()
 
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
       viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width() &&
-      !nonLinStretchChanged && !cmsChanged)
+      srcRect.Height() == m_lastSourceRect.Height() &&
+      srcRect.Width() == m_lastSourceRect.Width() && !nonLinStretchChanged && !cmsChanged)
     return;
 
   // Reload shader when the scaling method, non-linear stretch state, or CMS
@@ -816,9 +817,11 @@ void CLinuxRendererGL::UpdateVideoFilter()
     }
   }
 
+  const ESCALINGMETHOD previousMethod = m_scalingMethod;
   m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
   m_lastViewRect = viewRect;
+  m_lastSourceRect = srcRect;
 
   if (!Supports(m_scalingMethod))
   {
@@ -849,6 +852,9 @@ void CLinuxRendererGL::UpdateVideoFilter()
     else
       m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   }
+
+  if (m_scalingMethod != previousMethod)
+    m_reloadShaders = true;
 
   switch (m_scalingMethod)
   {
@@ -2640,8 +2646,11 @@ bool CLinuxRendererGL::Supports(ESCALINGMETHOD method) const
       method == VS_SCALINGMETHOD_LANCZOS3)
   {
     // if scaling is below level, avoid hq scaling
-    float scaleX = fabs(((float)m_sourceWidth - m_destRect.Width())/m_sourceWidth)*100;
-    float scaleY = fabs(((float)m_sourceHeight - m_destRect.Height())/m_sourceHeight)*100;
+    // Empty until ManageRenderArea has run, then the per-eye crop of a stereo source
+    CRect source =
+        m_sourceRect.IsEmpty() ? CRect(0, 0, m_sourceWidth, m_sourceHeight) : m_sourceRect;
+    float scaleX = fabs((source.Width() - m_destRect.Width()) / source.Width()) * 100;
+    float scaleY = fabs((source.Height() - m_destRect.Height()) / source.Height()) * 100;
     int minScale = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_HQSCALERS);
     if (scaleX < minScale && scaleY < minScale)
       return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -227,6 +227,7 @@ protected:
   bool m_nonLinStretchGui = false;
   float m_pixelRatio = 0.0f;
   CRect m_lastViewRect;
+  CRect m_lastSourceRect;
 
   // color management
   std::unique_ptr<CColorManager> m_ColorManager;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -703,7 +703,8 @@ void CLinuxRendererGLES::UpdateVideoFilter()
   // TODO: GL also checks nonLinStretchChanged and cmsChanged in the early exit
   // and the reload check below. Add when non-linear stretch and CMS are ported to GLES.
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
-      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width())
+      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width() &&
+      srcRect.Height() == m_lastSourceRect.Height() && srcRect.Width() == m_lastSourceRect.Width())
   {
     return;
   }
@@ -712,9 +713,11 @@ void CLinuxRendererGLES::UpdateVideoFilter()
   if (m_scalingMethod != m_videoSettings.m_ScalingMethod)
     m_reloadShaders = true;
 
+  const ESCALINGMETHOD previousMethod = m_scalingMethod;
   m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
   m_lastViewRect = viewRect;
+  m_lastSourceRect = srcRect;
 
   if(!Supports(m_scalingMethod))
   {
@@ -750,6 +753,9 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     else
       m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   }
+
+  if (m_scalingMethod != previousMethod)
+    m_reloadShaders = true;
 
   switch (m_scalingMethod)
   {
@@ -2136,8 +2142,10 @@ bool CLinuxRendererGLES::SupportsMultiPassRendering()
 
 float CLinuxRendererGLES::ScalingAboveThreshold() const
 {
-  float scaleX = m_destRect.Width() / static_cast<float>(m_sourceWidth);
-  float scaleY = m_destRect.Height() / static_cast<float>(m_sourceHeight);
+  // Empty until ManageRenderArea has run, then the per-eye crop of a stereo source
+  CRect source = m_sourceRect.IsEmpty() ? CRect(0, 0, m_sourceWidth, m_sourceHeight) : m_sourceRect;
+  float scaleX = m_destRect.Width() / source.Width();
+  float scaleY = m_destRect.Height() / source.Height();
   float scaleFactor = (scaleX + scaleY) / 2.0f;
   float scalePercent = fabs(1.0f - scaleFactor) * 100;
   int minScale = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -226,6 +226,7 @@ protected:
   size_t m_planeBufferSize = 0;
 
   CRect m_lastViewRect;
+  CRect m_lastSourceRect;
 
   // HDR FBO compositing: when active, IsGuiLayer() returns false so
   // video renders separately from GUI via RenderUpdateVideo()


### PR DESCRIPTION
## Description

The "Enable HQ scalers for scaling above" check in the GL and GLES renderers measures the whole frame against the destination rect. For a side-by-side or top-and-bottom source, `CBaseRenderer::ManageRenderArea()` crops `m_sourceRect` to one eye, so the frame size is the wrong quantity:

- half-SBS 1920x1080 into a 1920x1080 eye viewport (frame packing, anaglyph, interlaced, checkerboard) reads as 0 % scaling while each eye is stretched 2x. Lanczos3 and spline36 are refused with `chosen scaling method 9, is not supported by renderer` and the video is drawn bilinear, whatever the user selected.
- the same frame into a 960x1080 eye viewport (SBS output on a 1920-wide screen) reads as 50 % and runs the HQ shader on what is a 1:1 blit.

This PR uses `m_sourceRect` in both checks. It is empty until `ManageRenderArea()` has run and `Supports()` can be called before that (settings dialogs), so the frame size stays as the fallback.

`RendererHQ.cpp` on Windows has the same shape of check against the view size; it has its own rect handling and is not touched here.

## Motivation and context

Found while measuring why half-resolution 3D looked softer on an AMD box than on a Raspberry Pi. On an RX 7600 in frame-packed 1080p24, a half-SBS resolution pattern captured with AUTO, Lanczos3, spline36 and bilinear selected gave four byte-identical images; with the threshold forced to 0 % Lanczos3 engaged and the finest surviving line block went from 47 to 67 of 255 modulation (a reference Lanczos upscale gives 68). Full-resolution content is unaffected: it is 1:1 in either formula.

## How has this been tested?

- Headless GL (Xvfb + llvmpipe), half-SBS resolution pattern, anaglyph output so each eye fills 1920x1080, `scalingmethod` 9 (Lanczos3). Before: `kodi.log` logs `chosen scaling method 9, is not supported by renderer` at the 1920-wide eye viewport and `using scaling method: lanczos3` at the 960-wide one; the finest surviving line block of the capture has 47/255 modulation, the bilinear figure. After: the two decisions swap and the block reads 66/255 (a PIL Lanczos upscale of the same eye gives 68). AUTO is unchanged at 46/255, as it only picks a HQ scaler for SD sources.
- Same clip on an RX 7600 (LibreELEC, GLES, unpatched) in frame-packed 1080p24: AUTO, Lanczos3, spline36 and bilinear produce four byte-identical captures at the default 20 % threshold; forcing the threshold to 0 % engages Lanczos3 and gives 67/255.
- The GLES hunk is the same change; it has not been run with the patch applied.
- `kodi-test` passes; clang-format clean per commit.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation, either Doxygen or wiki: no
- [x] I have read the Contributing document
- [x] I have added tests to cover my change: no unit test covers the renderer scale decision
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
