### PR TITLE
[cmake] Add ENABLE_INTERNAL_SWIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ dependent_option(ENABLE_INTERNAL_NFS "Enable internal libnfs?")
 dependent_option(ENABLE_INTERNAL_PCRE2 "Enable internal pcre2?")
 dependent_option(ENABLE_INTERNAL_MARIADBCLIENT "Enable internal mariadb-c-connector?")
 dependent_option(ENABLE_INTERNAL_NLOHMANNJSON "Enable internal nlohmannjson?")
+dependent_option(ENABLE_INTERNAL_SWIG "Enable internal swig?")
 dependent_option(ENABLE_INTERNAL_UDFREAD "Enable internal libudfread?")
 dependent_option(ENABLE_INTERNAL_XSLT "Enable internal libxslt?")
 

--- a/cmake/modules/buildtools/FindSWIG.cmake
+++ b/cmake/modules/buildtools/FindSWIG.cmake
@@ -1,13 +1,16 @@
 #.rst:
 # FindSWIG
 # --------
-# Finds the SWIG executable
+# Finds the SWIG executable. With ENABLE_INTERNAL_SWIG, the version pinned in
+# tools/depends/native/swig is built instead when the one found does not match it.
 #
 # This will define the following TARGET:
 #
 # SWIG::SWIG - the SWIG executable
 
 if(NOT TARGET SWIG::SWIG)
+  include(${CMAKE_SOURCE_DIR}/cmake/scripts/common/ModuleHelpers.cmake)
+
   if(NATIVEPREFIX)
     set(_swig_hints HINTS ${NATIVEPREFIX}/bin)
   endif()
@@ -19,26 +22,62 @@ if(NOT TARGET SWIG::SWIG)
                                ${_swig_hints})
   unset(_swig_hints)
 
+  if(SWIG_EXECUTABLE)
+    execute_process(COMMAND ${SWIG_EXECUTABLE} -version
+                    OUTPUT_VARIABLE SWIG_version_output
+                    ERROR_VARIABLE SWIG_version_output)
+    string(REGEX REPLACE ".*SWIG Version[^0-9.]*\([0-9.]+\).*" "\\1"
+           SWIG_VERSION "${SWIG_version_output}")
+    unset(SWIG_version_output)
+  endif()
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC swig)
+  set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}_LIB_TYPE native)
+
+  SETUP_BUILD_VARS()
+
+  if(ENABLE_INTERNAL_SWIG AND NOT "${SWIG_VERSION}" VERSION_EQUAL "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER}")
+    # Host tool, so always a release build
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_TYPE Release)
+
+    if(NATIVEPREFIX)
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INSTALL_PREFIX ${NATIVEPREFIX})
+    else()
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+    endif()
+
+    # A non-empty CMAKE_ARGS is what makes BUILD_DEP_TARGET drive this as a CMake project
+    set(CMAKE_ARGS -DWITH_PCRE=ON)
+
+    if(EXISTS "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_TOOLCHAIN_FILE "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+    endif()
+
+    if(WIN32 OR WINDOWS_STORE)
+      # Generate for the host arch, not the target
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_GENERATOR_PLATFORM CMAKE_GENERATOR_PLATFORM ${HOSTTOOLSET})
+    endif()
+
+    set(SWIG_EXECUTABLE ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INSTALL_PREFIX}/bin/swig${CMAKE_HOST_EXECUTABLE_SUFFIX})
+    set(SWIG_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+    set(BUILD_BYPRODUCTS ${SWIG_EXECUTABLE})
+
+    BUILD_DEP_TARGET()
+  endif()
+
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(SWIG
                                     REQUIRED_VARS SWIG_EXECUTABLE
                                     VERSION_VAR SWIG_VERSION)
 
   if(SWIG_FOUND)
-    execute_process(COMMAND ${SWIG_EXECUTABLE} -version
-      OUTPUT_VARIABLE SWIG_version_output
-      ERROR_VARIABLE SWIG_version_output
-      RESULT_VARIABLE SWIG_version_result)
-      string(REGEX REPLACE ".*SWIG Version[^0-9.]*\([0-9.]+\).*" "\\1"
-             SWIG_VERSION "${SWIG_version_output}")
-
     add_executable(SWIG::SWIG IMPORTED GLOBAL)
     set_target_properties(SWIG::SWIG PROPERTIES
                                      IMPORTED_LOCATION "${SWIG_EXECUTABLE}"
                                      VERSION "${SWIG_VERSION}")
-  else()
-    if(SWIG_FIND_REQUIRED)
-      message(FATAL_ERROR "Swig executable was not found.")
+
+    if(TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_dependencies(SWIG::SWIG ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
   endif()
 endif()

--- a/docs/README.Fedora.md
+++ b/docs/README.Fedora.md
@@ -77,6 +77,9 @@ sudo dnf install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel a
 > [!WARNING]  
 > Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
+> [!NOTE]  
+> The Python bindings need SWIG 4.5.0 or newer. If your release ships an older `swig`, install `bison` and configure Kodi with `-DENABLE_INTERNAL_SWIG=ON` to build the pinned version as part of the Kodi build.
+
 Building for Wayland requires some extra packages:
 ```
 sudo dnf install mesa-libGLES-devel wayland-devel waylandpp-devel wayland-protocols-devel

--- a/docs/README.FreeBSD.md
+++ b/docs/README.FreeBSD.md
@@ -89,6 +89,9 @@ sudo pkg install autoconf automake avahi-app binutils cmake curl dbus doxygen e2
 > Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
 > [!NOTE]  
+> The Python bindings need SWIG 4.5.0 or newer. If your release ships an older `swig`, install `bison` and configure Kodi with `-DENABLE_INTERNAL_SWIG=ON` to build the pinned version as part of the Kodi build.
+
+> [!NOTE]  
 > For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
 
 You can install it with:

--- a/docs/README.Linux.md
+++ b/docs/README.Linux.md
@@ -129,11 +129,14 @@ sudo make -C tools/depends/target/waylandpp PREFIX=/usr/local
 > Complete list of dependencies is available **[here](https://github.com/xbmc/xbmc/tree/master/tools/depends/target)**.
 
 ### 3.2. Enable internal dependencies
-Some dependencies can be configured to build before Kodi. That's the case with `flatbuffers`, `crossguid`, `fmt`, `spdlog`, `fstrcmp`, `nlohmann-json` and `dav1d`. To enable the internal build of a dependency, append `-DENABLE_INTERNAL_<DEPENDENCY_NAME>=ON` to the configure command below. For example, configuring an X11 build with internal `fmt` would become `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_INTERNAL_FMT=ON` instead of `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local`.
+Some dependencies can be configured to build before Kodi. That's the case with `flatbuffers`, `crossguid`, `fmt`, `spdlog`, `fstrcmp`, `nlohmann-json`, `dav1d` and `swig`. To enable the internal build of a dependency, append `-DENABLE_INTERNAL_<DEPENDENCY_NAME>=ON` to the configure command below. For example, configuring an X11 build with internal `fmt` would become `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_INTERNAL_FMT=ON` instead of `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local`.
 Internal dependencies that are based on cmake upstream (currently crossguid, ffmpeg, fmt, spdlog) can have their build type overridden by defining `-D<DEPENDENCY_NAME>_BUILD_TYPE=<buildtype>`. Build Type can be one of `Release, RelWithDebInfo, Debug, MinSizeRel`. eg `-DFFMPEG_BUILD_TYPE=RelWithDebInfo`. If not provided, the build type will be the same as the core Kodi project.
 
 > [!NOTE]  
 > fstrcmp requires libtool
+
+> [!NOTE]  
+> The Python bindings need SWIG 4.5.0 or newer, which most distributions do not package yet. `-DENABLE_INTERNAL_SWIG=ON` builds the pinned version during the Kodi build; it needs `bison` and the PCRE2 development package.
 
 ### 3.3. External Dependencies
 

--- a/docs/README.Ubuntu.md
+++ b/docs/README.Ubuntu.md
@@ -181,6 +181,9 @@ Similarly, building for GBM also requires some extra packages:
 sudo apt install libgbm-dev libinput-dev libxkbcommon-dev
 ```
 
+> [!NOTE]  
+> The Python bindings need SWIG 4.5.0 or newer, which no Ubuntu release up to 26.04 (Resolute) packages. Install `bison` and configure Kodi with `-DENABLE_INTERNAL_SWIG=ON` to build the pinned version as part of the Kodi build.
+
 Optional packages that you might want to install for extra functionality (generating doxygen documentation, for instance):
 ```
 sudo apt install doxygen libcap-dev libsndio-dev libmariadbd-dev

--- a/docs/README.openSUSE.md
+++ b/docs/README.openSUSE.md
@@ -89,6 +89,9 @@ sudo zypper install alsa-devel autoconf automake bluez-devel boost-devel capi4li
 > [!WARNING]  
 > Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
+> [!NOTE]  
+> The Python bindings need SWIG 4.5.0 or newer. If your release ships an older `swig`, install `bison` and configure Kodi with `-DENABLE_INTERNAL_SWIG=ON` to build the pinned version as part of the Kodi build.
+
 Building for Wayland requires some extra packages:
 ```
 sudo zypper install wayland-devel libwayland-egl1 libwayland-egl-devel libxkbcommon-devel scons wayland-protocols-devel

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -6,11 +6,12 @@ find_package(SWIG REQUIRED ${SEARCH_QUIET})
 get_target_property(_swig_version SWIG::SWIG VERSION)
 if(_swig_version VERSION_LESS 4.5.0)
   message(FATAL_ERROR "The python bindings require SWIG 4.5.0 or newer "
-                      "(found ${_swig_version})")
+                      "(found ${_swig_version}). -DENABLE_INTERNAL_SWIG=ON builds a suitable one.")
 endif()
 
 function(generate_file file)
   set(CPP_FILE ${file}.cpp)
+  set(DEP_FILE ${CMAKE_CURRENT_BINARY_DIR}/${CPP_FILE}.d)
 
   # AddonModuleXbmcgui.i -> low-level module/init name "xbmcgui"
   get_filename_component(module_name ${file} NAME_WE)
@@ -24,29 +25,13 @@ function(generate_file file)
   # 302: kodi_generics.i declares Tuple/Alternative/Dictionary to carry their typemaps, so
   # SWIG ignores the header definitions it later sees. That is the intent, not a collision.
   # -pyi: PEP 484 stub files for addon authors, a build artifact beside the wrappers
+  # -MMD/-MF/-MT: header dependencies as a depfile, so swig is not needed at configure
+  # time (ENABLE_INTERNAL_SWIG builds it during the build)
   set(SWIG_ARGS -python -c++ -builtin -interface ${module_name} -pyi
                 -w401,389,514,362,302 -o ${CPP_FILE}
+                -MMD -MF ${DEP_FILE} -MT ${CMAKE_CURRENT_BINARY_DIR}/${CPP_FILE}
                 -I${CMAKE_SOURCE_DIR}/xbmc
-                ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file})
-
-  # This generates a file that has the dependencies the swig input finds
-  # execute_process needs explicit use of explicit swig executable location. it is not TARGET aware
-  # retrieve location property from TARGET
-  get_target_property(_swig_exe SWIG::SWIG IMPORTED_LOCATION)
-  execute_process(COMMAND ${_swig_exe} -MM -MF ${CMAKE_BINARY_DIR}/build/swig/${file}.dep ${SWIG_ARGS})
-  file(READ ${CMAKE_BINARY_DIR}/build/swig/${file}.dep swig_deps)
-
-  # Match all lines except the first one until " \"
-  string(REGEX MATCHALL "\n  [^ ]+" temp ${swig_deps})
-  set(swig_deps)
-  foreach(t ${temp})
-    string(STRIP "${t}" t)
-    set(swig_deps ${swig_deps} "${t}")
-  endforeach()
-
-  # We set this to allow cmake to detect if changes in the headers are made
-  # and to force a cmake reconfigure to detect new dependencies that may have been added.
-  set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${swig_deps})
+                ${CMAKE_CURRENT_SOURCE_DIR}/${file})
 
   add_custom_command(OUTPUT ${CPP_FILE}
                      COMMAND SWIG::SWIG
@@ -55,8 +40,9 @@ function(generate_file file)
                              -DFILE=${CMAKE_CURRENT_BINARY_DIR}/${CPP_FILE}
                              -DSWIG_VERSION=${_swig_version}
                              -P ${CMAKE_CURRENT_SOURCE_DIR}/fix-swig-3535.cmake
-                     DEPENDS SWIG::SWIG ${swig_deps}
-                             ${CMAKE_CURRENT_SOURCE_DIR}/fix-swig-3535.cmake)
+                     DEPENDS SWIG::SWIG ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+                             ${CMAKE_CURRENT_SOURCE_DIR}/fix-swig-3535.cmake
+                     DEPFILE ${DEP_FILE})
 
   set(SOURCES ${SOURCES} "${CPP_FILE}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Description

The Python bindings require SWIG 4.5.0 since #28958 (`-pyi` stubs, pytyping annotations, and the `fix-swig-3535.cmake` rewrite verified against 4.5.0/4.5.1). No Ubuntu release up to 26.04 nor Debian stable packages that version (Ubuntu 22.04: 4.0.2, 24.04: 4.2.0, 26.04: 4.4.0, Debian trixie: 4.3.0), so a plain system build on Linux currently fails at configure and the build guides, which list the distro `swig` package, are out of date.

This adds `ENABLE_INTERNAL_SWIG`, following the FlatC pattern: when the option is on and the SWIG found on the host is not the version pinned in `tools/depends/native/swig`, that tarball is built through `BUILD_DEP_TARGET` into the native prefix. It is a `dependent_option`, so it defaults on for depends and Windows builds, where the pinned version is already present and nothing happens, and off for Linux/FreeBSD system builds.

Two commits:

1. **Track SWIG header dependencies with a depfile.** `xbmc/interfaces/swig/CMakeLists.txt` used to run `swig -MM` at configure time to list the headers each `.i` pulls in and register them as `CMAKE_CONFIGURE_DEPENDS`. That needs the swig binary at configure time, which an internally built one is not, and forces a full reconfigure on every header edit. Generation now passes `-MMD -MF -MT` and the custom command uses `DEPFILE`, so header edits regenerate just the wrapper.
2. **Add ENABLE_INTERNAL_SWIG.** FindSWIG gains the internal build path and reports the version before `find_package_handle_standard_args` (previously `VERSION_VAR` was set after the call). The version error now points at the option. The Linux, Ubuntu, Fedora, openSUSE and FreeBSD guides get a note about the 4.5.0 requirement and how to satisfy it (`bison` is needed for SWIG's own build; the PCRE2 dev package is already in every list).

## Motivation and context

Unblocks Linux system builds on every current distro release, replaces the hand-rolled SWIG install in `sonarqube.yml` (follow-up), and is what the Linux E2E workflows in #28802 need.

## How has this been tested?

- Ubuntu 24.04 container, standalone CMake project loading the real `FindSWIG.cmake` and the real interface files, with both Ninja and Unix Makefiles: option off with a 4.2.0 swig fails at configure with the expected message; option on downloads and builds 4.5.0, `swig -swiglib` resolves inside the prefix, `AddonModuleXbmcaddon.i.cpp`, the `.pyi` stub and `swigpyrun.h` generate, the fix-3535 rewrite applies, a no-op rebuild does nothing, and touching a header listed in the depfile regenerates the wrapper.
- `find_package(SWIG)` from a nested directory, matching where Kodi calls it (the first version of the module used a relative include that only resolved from the top level).
- Full Kodi builds: Linux GBM/Wayland/X11 and Windows via the E2E workflows on #28802 (in progress at the time of writing); macOS/iOS/Android through depends, where the pinned SWIG is already in the native prefix and the internal path stays inactive.

## Notes

- `DEPFILE` needs CMake 3.20 for Makefile generators, which is the project minimum since c5ff226f79, and 3.21 for Xcode and Visual Studio; depends pins 3.31 and Windows requires 3.30.6.
- Cross builds without tools/depends (Yocto, Buildroot, distro cross toolchains) must keep the option off and provide a host SWIG >= 4.5.0, as they already do for flatc: there is no native toolchain file for the sub-build to use.
- #27209 (Groovy 5) is unrelated to this change: #28958 removed Groovy entirely, so that issue can be closed against it.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
