### PR TITLE
[windowing][X11] Don't read EGL handles off a GLX context

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -92,24 +92,30 @@ void* CWinSystemX11GLContext::GetGlxContext() const
   return GLXGetContext(m_pGLContext);
 }
 
+// X11 creates an EGL context by default, but --gl-interface=glx and the VDPAU
+// fallback both leave a GLX context here instead, which holds no EGL handles.
 EGLDisplay CWinSystemX11GLContext::GetEGLDisplay() const
 {
-  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay;
+  auto* context = dynamic_cast<CGLContextEGL*>(m_pGLContext);
+  return context != nullptr ? context->m_eglDisplay : EGL_NO_DISPLAY;
 }
 
 EGLSurface CWinSystemX11GLContext::GetEGLSurface() const
 {
-  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglSurface;
+  auto* context = dynamic_cast<CGLContextEGL*>(m_pGLContext);
+  return context != nullptr ? context->m_eglSurface : EGL_NO_SURFACE;
 }
 
 EGLContext CWinSystemX11GLContext::GetEGLContext() const
 {
-  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglContext;
+  auto* context = dynamic_cast<CGLContextEGL*>(m_pGLContext);
+  return context != nullptr ? context->m_eglContext : EGL_NO_CONTEXT;
 }
 
 EGLConfig CWinSystemX11GLContext::GetEGLConfig() const
 {
-  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglConfig;
+  auto* context = dynamic_cast<CGLContextEGL*>(m_pGLContext);
+  return context != nullptr ? context->m_eglConfig : nullptr;
 }
 
 bool CWinSystemX11GLContext::BindTextureUploadContext()


### PR DESCRIPTION
### Description

`CWinSystemX11GLContext::GetEGLDisplay()`, `GetEGLSurface()`, `GetEGLContext()` and `GetEGLConfig()` cast `m_pGLContext` to `CGLContextEGL` with an unchecked `static_cast`:

```cpp
EGLDisplay CWinSystemX11GLContext::GetEGLDisplay() const
{
  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay;
}
```

`m_pGLContext` is not always an EGL context. `CWinSystemX11GLContext::RefreshGLContext()` creates a `CGLContextEGL` only when the GL interface is not `glx`, and after an EGL refresh failure it deletes that context and replaces it with `GLXContextCreate()` for the VDPAU path. In both cases the object is a `CGLContextGLX`, which holds no EGL handles, and reading `m_eglDisplay` off it is undefined behaviour.

This changes the four accessors to `dynamic_cast` and return a null handle (`EGL_NO_DISPLAY` / `EGL_NO_SURFACE` / `EGL_NO_CONTEXT` / `nullptr`) when there is no EGL context, so a caller can test the result and decline.

### Reachability

No caller reaches these accessors on master. `CWinSystemX11GLContext` does not derive from `CWinSystemEGL`, so the `dynamic_cast<CWinSystemEGL*>` in `CRenderBufferDMA` and `CRendererDRMPRIMEGLES` never resolves to it. The casts are wrong regardless of who calls them, and any future change that exposes X11 through that interface would inherit the bug silently — a GLX session would read a garbage `EGLDisplay` rather than getting a null it could reject.

### Testing

Builds clean on an X11 / desktop GL configuration. Behaviour on the EGL path is unchanged: `dynamic_cast` succeeds and returns the same handles as before.

### Type of change

- [x] Bugfix
