### PR TITLE
[cmake][windows] Give vcvarsall an arch under the Ninja generator

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -986,6 +986,15 @@ function(create_module_dev_env)
     string(TOLOWER "${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}" _lower_hostarch)
     string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" _lower_targetarch)
 
+    # Only the Visual Studio generator sets the two above. Under Ninja, ARCH comes
+    # from ArchSetup and the host from the machine, so vcvarsall still gets an arch.
+    if(NOT _lower_hostarch)
+      string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" _lower_hostarch)
+    endif()
+    if(NOT _lower_targetarch)
+      string(TOLOWER "${ARCH}" _lower_targetarch)
+    endif()
+
     if("${_lower_hostarch}" STREQUAL "x64")
       set(_lower_hostarch amd64)
     endif()


### PR DESCRIPTION
## Description

`create_module_dev_env` builds the vcvarsall wrapper used by the meson and autotools dependency builds on Windows (dav1d, udfread, libdvdcss, libdvdread, libdvdnav, libbluray, lcms2). It derives the architecture argument from `CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE` and `CMAKE_GENERATOR_PLATFORM`, which only the Visual Studio generator sets. Under Ninja both are empty, so every configure, build and install step of those dependencies ran

```
vcvarsall.bat 10.0.26100.0
```

and vcvarsall printed its usage error. The builds still succeeded whenever the calling shell already had the MSVC environment, which hid the problem.

When the two variables are empty, fall back to `CMAKE_HOST_SYSTEM_PROCESSOR` for the host and to the `ARCH` that `cmake/scripts/windows/ArchSetup.cmake` derives for the target. The existing x64/win32 mappings then yield `amd64`, `x86` or `arm64` as before.

## How has this been tested?

Seen on the Windows E2E workflow of #28802, which configures with `-G Ninja`: ten `[ERROR:vcvarsall.bat] Error in script usage` blocks per build, one per dev-environment step. That workflow now carries this commit and is the check that the errors are gone. Visual Studio generator builds are unaffected because the fallback only runs when the variables are empty.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
