### PR TITLE
[cmake] Retry dependency downloads ExternalProject gives up on

### DIFF
--- a/cmake/scripts/common/DownloadWithRetry.cmake
+++ b/cmake/scripts/common/DownloadWithRetry.cmake
@@ -1,0 +1,51 @@
+# Downloads ARCHIVE_URL to ARCHIVE_DEST, retrying failures that ExternalProject's own
+# download step gives up on: it retries only connection-level curl errors (6 7 8 15 28
+# 35), so a response dropped or refused mid-transfer fails the dependency build.
+#
+# BUILD_DEP_TARGET runs this as a step ahead of the download step, which then finds the
+# file with a matching hash and skips the network.
+#
+# -DARCHIVE_URL=<url> -DARCHIVE_DEST=<path> -DARCHIVE_HASH=<ALGO>=<hex>
+# CMAKE_TLS_* and CMAKE_NETRC* apply as they do to file(DOWNLOAD) when passed with -D.
+
+if(NOT ARCHIVE_URL OR NOT ARCHIVE_DEST OR NOT ARCHIVE_HASH)
+  message(FATAL_ERROR "DownloadWithRetry.cmake needs ARCHIVE_URL, ARCHIVE_DEST and ARCHIVE_HASH")
+endif()
+if(NOT ARCHIVE_HASH MATCHES "^([A-Za-z0-9_]+)=([0-9A-Fa-f]+)$")
+  message(FATAL_ERROR "DownloadWithRetry.cmake: ARCHIVE_HASH must be <ALGO>=<hex>, got '${ARCHIVE_HASH}'")
+endif()
+set(_algo ${CMAKE_MATCH_1})
+string(TOLOWER "${CMAKE_MATCH_2}" _expected)
+
+if(EXISTS "${ARCHIVE_DEST}")
+  file(${_algo} "${ARCHIVE_DEST}" _actual)
+  if(_actual STREQUAL _expected)
+    return()
+  endif()
+  file(REMOVE "${ARCHIVE_DEST}")
+endif()
+
+set(_attempts 5)
+foreach(_attempt RANGE 1 ${_attempts})
+  file(DOWNLOAD "${ARCHIVE_URL}" "${ARCHIVE_DEST}" INACTIVITY_TIMEOUT 60 STATUS _status)
+  list(GET _status 0 _code)
+  list(GET _status 1 _error)
+
+  if(_code EQUAL 0)
+    file(${_algo} "${ARCHIVE_DEST}" _actual)
+    if(_actual STREQUAL _expected)
+      return()
+    endif()
+    # A complete transfer with the wrong hash is a wrong pin, not a network fault
+    file(REMOVE "${ARCHIVE_DEST}")
+    message(FATAL_ERROR "${ARCHIVE_URL}: ${_algo} mismatch, expected ${_expected}, got ${_actual}")
+  endif()
+
+  file(REMOVE "${ARCHIVE_DEST}")
+  if(_attempt EQUAL _attempts)
+    message(FATAL_ERROR "Failed to download ${ARCHIVE_URL} after ${_attempts} attempts: ${_error}")
+  endif()
+  math(EXPR _delay "${_attempt} * 10")
+  message(STATUS "Download of ${ARCHIVE_URL} failed (${_error}), attempt ${_attempt}/${_attempts}, retrying in ${_delay}s")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E sleep ${_delay})
+endforeach()

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -537,6 +537,33 @@ macro(BUILD_DEP_TARGET)
                       ${BUILD_BYPRODUCTS}
                       ${BUILD_IN_SOURCE})
 
+  # Fetch ahead of the download step with broader retries, see DownloadWithRetry.cmake.
+  # Pointless for local tarballs, and without a hash the download step re-downloads
+  # regardless. INDEPENDENT like the download step itself, which CMP0114 requires of
+  # anything that step depends on.
+  if(NOT ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_DIR
+     AND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_HASH
+     AND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_URL MATCHES "^[A-Za-z][A-Za-z0-9+.-]*://")
+    # ExternalProject bakes these into its download script; a cmake -P process would
+    # not see them otherwise
+    set(_download_retry_settings)
+    foreach(_var CMAKE_TLS_VERIFY CMAKE_TLS_CAINFO CMAKE_TLS_VERSION CMAKE_NETRC CMAKE_NETRC_FILE)
+      if(DEFINED ${_var})
+        list(APPEND _download_retry_settings "-D${_var}=${${_var}}")
+      endif()
+    endforeach()
+    externalproject_add_step(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} download-retry
+                             COMMAND ${CMAKE_COMMAND} ${_download_retry_settings}
+                                     -DARCHIVE_URL=${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_URL}
+                                     -DARCHIVE_DEST=${TARBALL_DIR}/${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_ARCHIVE}
+                                     -DARCHIVE_HASH=${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_HASH}
+                                     -P ${PROJECTSOURCE}/cmake/scripts/common/DownloadWithRetry.cmake
+                             DEPENDERS download
+                             INDEPENDENT TRUE
+                             COMMENT "Fetching ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_ARCHIVE}")
+    unset(_download_retry_settings)
+  endif()
+
   set_target_properties(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} PROPERTIES FOLDER "External Projects")
 
   CLEAR_BUILD_VARS()


### PR DESCRIPTION
## Description

ExternalProject's download step retries only connection-level curl errors (codes 6, 7, 8, 15, 28, 35 in `ExternalProject/download.cmake.in`). A response that is refused or dropped mid-transfer, such as a transient 5xx (curl 22) or an aborted HTTP/2 stream (curl 56), fails the whole dependency build with no retry. The Windows E2E run on #28802 hit exactly that against mirrors.kodi.tv while fetching `json-3.12.0.tar.xz`.

`BUILD_DEP_TARGET` now adds a `download-retry` step ahead of the download step of every ExternalProject dependency. `cmake/scripts/common/DownloadWithRetry.cmake` fetches the archive into the same `TARBALL_DIR` location, retrying any failure up to five times with a growing delay and a 60 second inactivity timeout. CMake's own download step then finds the file with a matching hash and skips the network, so URL, hash, verify and extract stay ExternalProject's responsibility.

Details:

- A complete transfer whose hash does not match fails immediately: that is a wrong pin in the VERSION file, not a network fault, and retrying would only delay the message.
- The step is not added for in-tree sources, for the offline local-tarball override (URL without a scheme), or when the VERSION file has no hash, since without one the download step re-downloads anyway.
- The hash argument is validated as `ALGO=hex`, the format the VERSION files already provide to `URL_HASH`.
- The step is `INDEPENDENT`, like the predefined download step that depends on it; CMP0114 (NEW since the 3.20 minimum) requires that.
- `CMAKE_TLS_VERIFY`, `CMAKE_TLS_CAINFO`, `CMAKE_TLS_VERSION`, `CMAKE_NETRC` and `CMAKE_NETRC_FILE` are forwarded to the helper when defined, since a `cmake -P` child does not see the configuring project's variables. ExternalProject bakes the same five into its own download script, and `file(DOWNLOAD)` in script mode falls back to exactly these variables, so private mirrors and custom CAs behave the same in both steps.

## How has this been tested?

Ubuntu 24.04 container, standalone CMake project using the flatc internal build, against a local HTTP server scripted to fail its first requests:

- 503 then an empty reply: both retried, third attempt succeeded, CMake's download step logged "File already exists and hash match (skip download)". Three requests total, no double download.
- Healthy server: one request, then the skip.
- Archive with the wrong content: fails on the first attempt with the mismatch message, no retries.
- `-D<MODULE>_URL=/local/path.tar.gz`: no `download-retry` step in the build graph, ExternalProject copies the file, zero requests.

The E2E branch #28802 carries this commit, so its Linux and Windows dependency builds run through the new step as well.

## Types of change

- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
