### PR TITLE
[Android] Move gradle cache out of the build folder but keep it separate based on the build type

### DIFF
--- a/tools/android/packaging/.gitignore
+++ b/tools/android/packaging/.gitignore
@@ -1,2 +1,1 @@
 /.gradle/
-/.gradle-home/

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -30,7 +30,7 @@ endif
 # one will time each other out. Override to share a warm cache between builds
 # that cannot overlap.
 ifeq ($(GRADLE_USER_HOME),)
-export GRADLE_USER_HOME:=$(CURDIR)/.gradle-home
+export GRADLE_USER_HOME:=$(HOME)/.gradle/$(CPU)
 endif
 
 # libc++


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- Avoids gradle re-download again in every Jenkins build.
- Allows concurrency of one instance of all build types (CPU type) in parallel.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From https://github.com/xbmc/xbmc/pull/29088 gradle (and all it's dependencies) is re-download for every Jenkins build (is more than 1GB of data). This also affects private builds of devs/users (not only Jenkins).

```
[100%] Built target kodi
[100%] Built target bundle_files
[100%] Built target bundle
make[4]: warning: -j1 forced in submake: resetting jobserver mode.
Gradle build and sign...
Downloading https://services.gradle.org/distributions/gradle-9.4.1-bin.zip
.............10%.............20%.............30%.............40%.............50%.............60%..............70%.............80%.............90%.............100%
```
https://jenkins.kodi.tv/view/Android/job/android-arm64-docker/17904/execution/node/78/log/

Cache moved again to `$HOME/.gradle` but in a sub-folder with build type (CPU type) name e.g. `arm64-v8a`. In this way, each cache remains separate but is reused for the next Jenkins build of the same type.

From https://github.com/xbmc/xbmc/pull/29088 is destroyed in each build because, by default, cache is located inside kodi build folder.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No re-download gradle in each build and speed-up substantially last stage of Android build and sign.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
