### PR TITLE
VideoPlayer: turn on forced subtitles in place of those hidden for the audio language

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24975,7 +24975,7 @@ msgstr ""
 #. Help text for setting "Don't show subtitles matching the audio language" of label #39211
 #: system/settings/settings.xml
 msgctxt "#39212"
-msgid "Do not turn on subtitles that are in the same language as the audio being played. Forced subtitles are not affected."
+msgid "Do not turn on subtitles that are in the same language as the audio being played. Forced subtitles in that language are turned on instead, where the video has them."
 msgstr ""
 
 #empty strings from id 39213 to 39899

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -129,7 +129,9 @@ public:
     m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
     m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
-    m_hideSameAudioLang = settings->GetBool(CSettings::SETTING_SUBTITLES_HIDESAMEAUDIOLANGUAGE);
+    // The setting keeps its value while disabled for none and forced_only
+    m_hideSameAudioLang = !m_isSubNone && !m_isPrefForced &&
+                          settings->GetBool(CSettings::SETTING_SUBTITLES_HIDESAMEAUDIOLANGUAGE);
 
     // Prefer the subtitle language setting; none, original and forced_only name no language, so
     // fall back to the audio setting, and default, original and mediadefault name none either,
@@ -149,6 +151,22 @@ public:
   bool MatchesSubtitleLanguage(const CLanguageTag& language) const
   {
     return language.Matches(m_subLang);
+  }
+
+  // \brief Whether a stream is in the language of the audio being played. Both languages must be
+  //        declared, a stream that states none is never assumed to match.
+  bool MatchesPlayedAudioLanguage(const CLanguageTag& language) const
+  {
+    return IsKnownLanguage(m_playedAudioLang) && IsKnownLanguage(language) &&
+           language.Matches(m_playedAudioLang);
+  }
+
+  // \brief Whether a stream is a forced one that takes the place of the subtitles hidden for being
+  //        in the audio language, which is also the language the settings ask for
+  bool IsForcedForHiddenAudioLanguage(const SelectionStream& ss) const
+  {
+    return m_hideSameAudioLang && (ss.flags & FLAG_FORCED) &&
+           MatchesPlayedAudioLanguage(ss.language) && MatchesSubtitleLanguage(ss.language);
   }
 
   // \brief Whether the subtitle language setting is "original"
@@ -179,11 +197,12 @@ public:
     const bool isSameSubLang = MatchesSubtitleLanguage(ss.language);
 
     // The user does not want to read subtitles in a language they are already listening to.
-    // Forced subtitles are kept, as they usually only translate foreign language parts.
-    // Both languages must be declared, a stream that states none is never assumed to match.
+    // Forced subtitles take their place, as they usually only translate foreign language parts.
+    if (IsForcedForHiddenAudioLanguage(ss))
+      return false;
+
     if (m_hideSameAudioLang && (ss.flags & FLAG_FORCED) == 0 &&
-        IsKnownLanguage(m_playedAudioLang) && IsKnownLanguage(ss.language) &&
-        ss.language.Matches(m_playedAudioLang))
+        MatchesPlayedAudioLanguage(ss.language))
     {
       return true;
     }
@@ -326,6 +345,10 @@ public:
   bool operator()(const SelectionStream& lh, const SelectionStream& rh) const
   {
     PREDICATE_RETURN(lh.type_index == m_subStream, rh.type_index == m_subStream);
+
+    // Ahead of external subtitles too, as those in the audio language are hidden as well
+    PREDICATE_RETURN(m_filter.IsForcedForHiddenAudioLanguage(lh),
+                     m_filter.IsForcedForHiddenAudioLanguage(rh));
 
     const bool isLexternal = STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB ||
                              STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT;


### PR DESCRIPTION
"Don't show subtitles matching the audio language" now turns on forced subtitles in that language instead, so the translations of foreign language scenes are still shown.

## Description
Follow-up to #28862, from the report by @jjd-uk there.

On a common Blu-ray layout, a film in English with a few scenes in another language carries an English track and a forced English track for those scenes. With the setting on, the English track is hidden as asked, but the forced one was never picked, because with a named subtitle language only regular tracks are turned on. The foreign scenes then play with no translation, which is exactly what the forced track exists for.

Where the setting hides the audio language, a forced track in that language now takes the place of the hidden ones. It ranks first, ahead of external subtitles too, since those are hidden as well when they are in the audio language. It is limited to the preferred subtitle language, so an English viewer watching a French film that has French forced subtitles still gets the English subtitles.

The setting also kept its effect while disabled under "None" and "Forced only". With "Forced only", "prefer subtitles for the hearing impaired" and the toggle left on underneath, it still hid the hearing impaired subtitles in the audio language. It now only applies where it can be changed.

The help text said forced subtitles are not affected, which is what led to the report, so it now says what happens.

## Motivation and context
Reported in https://github.com/xbmc/xbmc/pull/28862#issuecomment-5622441951 (Dances with Wolves: English audio, Lakota scenes, English and English forced tracks).

## How has this been tested?
LibreELEC 13 on a Raspberry Pi 4, Kodi master 956ba329f0 with this patch (`VideoPlayer.cpp` is unchanged between that and the base of this PR), compared against stock 22.0 Beta 2. Test clip cut from Dances with Wolves: English DTS audio, an English forced track, a full English track and 12 other languages. Preferred audio language "Original language", as in the report. Each run played a fresh file path so no stored stream settings applied, and the result was read over JSON-RPC:

| Settings | Beta 2 | This PR |
|---|---|---|
| Subtitles English, setting on | nothing shown | forced English |
| Subtitles English, setting off | English | English |
| Subtitles French, setting on | French | French |
| Subtitles English, setting on, external `.swedish.srt` | nothing shown | forced English |
| Subtitles English, setting off, external `.swedish.srt` | nothing shown | nothing shown |
| Subtitles English, setting on, prefer hearing impaired | nothing shown | forced English |
| Forced only, prefer hearing impaired, setting on (disabled) | nothing shown | English (hearing impaired) |
| Forced only, prefer hearing impaired, setting off | English (hearing impaired) | English (hearing impaired) |

And with a preferred language that is not the audio language, audio and subtitles set to Swedish, setting on (the film has no Swedish audio, so it plays in English):

| Clip | This PR |
|---|---|
| External `.swedish.srt` next to it | Swedish (external) |
| No Swedish subtitles at all | nothing shown |

The forced English track stays out of the way there, as it is not in the preferred subtitle language.

Also checked on screen: the English narration plays without subtitles and the Lakota lines show the forced track's translation.

## What is the effect on users?
With the setting on, films that carry forced subtitles in the audio language now show them instead of nothing. Nothing changes with the setting off.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
