### PR TITLE
[Estuary] Refactor game OSD menu layout

### DIFF
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -72,410 +72,103 @@
 				</control>
 			</control>
 			<control type="group" id="20">
-				<visible>!System.GetBool(gamesgeneral.showosdhelp) + !RetroPlayer.SupportsEject</visible>
+				<visible>!System.GetBool(gamesgeneral.showosdhelp)</visible>
 				<centerleft>50%</centerleft>
-				<height>640</height>
+				<height>1040</height>
 				<centertop>50%</centertop>
 				<width>700</width>
 				<animation effect="fade" time="200">VisibleChange</animation>
-				<include content="DialogBackgroundCommons">
-					<param name="width" value="700" />
-					<param name="height" value="640" />
-					<param name="header_label" value="$LOCALIZE[35221]" />
-					<param name="header_id" value="3" />
-				</include>
-				<control type="group" id="2000">
-					<top>80</top>
-					<control type="list" id="1103">
-						<height>560</height>
-						<orientation>vertical</orientation>
-						<itemlayout condition="!Control.IsVisible(2200)" width="700" height="80">
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</itemlayout>
-						<itemlayout condition="Control.IsVisible(2200)" width="688" height="80">
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</itemlayout>
-						<focusedlayout condition="!Control.IsVisible(2200)" width="700" height="80">
-							<control type="image">
-								<texture colordiffuse="button_focus">lists/focus.png</texture>
-								<visible>Control.HasFocus(1103)</visible>
-							</control>
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</focusedlayout>
-						<focusedlayout condition="Control.IsVisible(2200)" width="688" height="80">
-							<control type="image">
-								<texture colordiffuse="button_focus">lists/focus.png</texture>
-								<visible>Control.HasFocus(1103)</visible>
-							</control>
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</focusedlayout>
-						<content>
-							<item>
-								<description>Pause / Resume button</description>
-								<label>$LOCALIZE[35224]</label>
-								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[x,game.controller.default]</label2>
-								<icon>osd/fullscreen/buttons/play.png</icon>
-								<onclick>Play</onclick>
-							</item>
-							<item>
-								<description>Save / Load button</description>
-								<label>$LOCALIZE[35249]</label>
-								<icon>osd/fullscreen/buttons/saves.png</icon>
-								<onclick>ActivateWindow(InGameSaves)</onclick>
-							</item>
-							<item>
-								<description>Players button</description>
-								<label>$LOCALIZE[35172]</label>
-								<icon>osd/fullscreen/buttons/agent.png</icon>
-								<onclick>ActivateWindow(GameAgents)</onclick>
-							</item>
-							<item>
-								<description>
-									Achievements button. Shown unconditionally: the dialog says
-									whether the player needs to sign in or the game has no
-									achievement set, which is clearer than hiding the button.
-								</description>
-								<label>$LOCALIZE[35287]</label>
-								<label2>$INFO[RetroPlayer.AchievementsProgress]</label2>
-								<icon>osd/fullscreen/buttons/rating.png</icon>
-								<onclick>ActivateWindow(GameAchievements)</onclick>
-							</item>
-							<item>
-								<description>Reset button</description>
-								<label>$LOCALIZE[13007]</label>
-								<icon>osd/fullscreen/buttons/reset.png</icon>
-								<onclick>PlayerControl(Reset)</onclick>
-							</item>
-							<item>
-								<description>Stop button</description>
-								<label>$LOCALIZE[35222]</label>
-								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[start,game.controller.default]</label2>
-								<icon>osd/fullscreen/buttons/stop.png</icon>
-								<onclick>Stop</onclick>
-							</item>
-							<item>
-								<description>Settings button</description>
-								<label>$LOCALIZE[5]</label>
-								<icon>osd/fullscreen/buttons/settings.png</icon>
-								<onclick>SetProperty(settingsdialog_content,games,home)</onclick>
-								<onclick>SetProperty(settingsdialog_header,$LOCALIZE[5],home)</onclick>
-								<onclick>ActivateWindow(1101)</onclick>
-							</item>
-						</content>
-						<pagecontrol>2200</pagecontrol>
-					</control>
-					<control type="scrollbar" id="2200">
-						<top>-10</top>
-						<right>0</right>
-						<width>12</width>
-						<orientation>vertical</orientation>
-					</control>
+				<control type="button">
+					<left>-2000</left>
+					<top>-2000</top>
+					<width>6000</width>
+					<height>6000</height>
+					<texturefocus />
+					<texturenofocus />
+					<onclick>Action(close)</onclick>
 				</control>
-			</control>
-			<control type="group" id="20">
-				<visible>!System.GetBool(gamesgeneral.showosdhelp) + RetroPlayer.SupportsEject</visible>
-				<centerleft>50%</centerleft>
-				<height>720</height>
-				<centertop>50%</centertop>
-				<width>700</width>
-				<animation effect="fade" time="200">VisibleChange</animation>
-				<include content="DialogBackgroundCommons">
-					<param name="width" value="700" />
-					<param name="height" value="720" />
-					<param name="header_label" value="$LOCALIZE[35221]" />
-					<param name="header_id" value="3" />
-				</include>
-				<control type="group" id="2000">
-					<top>80</top>
-					<control type="list" id="1103">
-						<height>640</height>
-						<orientation>vertical</orientation>
-						<itemlayout condition="!Control.IsVisible(2200)" width="700" height="80">
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</itemlayout>
-						<itemlayout condition="Control.IsVisible(2200)" width="688" height="80">
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</itemlayout>
-						<focusedlayout condition="!Control.IsVisible(2200)" width="700" height="80">
-							<control type="image">
-								<texture colordiffuse="button_focus">lists/focus.png</texture>
-								<visible>Control.HasFocus(1103)</visible>
-							</control>
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</focusedlayout>
-						<focusedlayout condition="Control.IsVisible(2200)" width="688" height="80">
-							<control type="image">
-								<texture colordiffuse="button_focus">lists/focus.png</texture>
-								<visible>Control.HasFocus(1103)</visible>
-							</control>
-							<control type="image">
-								<left>8</left>
-								<top>8</top>
-								<width>64</width>
-								<height>64</height>
-								<info>ListItem.Icon</info>
-							</control>
-							<control type="label">
-								<left>80</left>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label</info>
-								<font>font13</font>
-								<align>left</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<width>600</width>
-								<height>80</height>
-								<info>ListItem.Label2</info>
-								<font>font13</font>
-								<align>right</align>
-								<aligny>center</aligny>
-								<textcolor>grey</textcolor>
-							</control>
-						</focusedlayout>
-						<content>
-							<item>
-								<description>Pause / Resume button</description>
-								<label>$LOCALIZE[35224]</label>
-								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[x,game.controller.default]</label2>
-								<icon>osd/fullscreen/buttons/play.png</icon>
-								<onclick>Play</onclick>
-							</item>
-							<item>
-								<description>Save / Load button</description>
-								<label>$LOCALIZE[35249]</label>
-								<icon>osd/fullscreen/buttons/saves.png</icon>
-								<onclick>ActivateWindow(InGameSaves)</onclick>
-							</item>
-							<item>
-								<description>Disc Manager button</description>
-								<label>$LOCALIZE[35272]</label>
-								<icon>DefaultSets.png</icon>
-								<onclick>ActivateWindow(GameDiscManager)</onclick>
-							</item>
-							<item>
-								<description>Players button</description>
-								<label>$LOCALIZE[35172]</label>
-								<icon>osd/fullscreen/buttons/agent.png</icon>
-								<onclick>ActivateWindow(GameAgents)</onclick>
-							</item>
-							<item>
-								<description>
-									Achievements button. Shown unconditionally: the dialog says
-									whether the player needs to sign in or the game has no
-									achievement set, which is clearer than hiding the button.
-								</description>
-								<label>$LOCALIZE[35287]</label>
-								<label2>$INFO[RetroPlayer.AchievementsProgress]</label2>
-								<icon>osd/fullscreen/buttons/rating.png</icon>
-								<onclick>ActivateWindow(GameAchievements)</onclick>
-							</item>
-							<item>
-								<description>Reset button</description>
-								<label>$LOCALIZE[13007]</label>
-								<icon>osd/fullscreen/buttons/reset.png</icon>
-								<onclick>PlayerControl(Reset)</onclick>
-							</item>
-							<item>
-								<description>Stop button</description>
-								<label>$LOCALIZE[35222]</label>
-								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[start,game.controller.default]</label2>
-								<icon>osd/fullscreen/buttons/stop.png</icon>
-								<onclick>Stop</onclick>
-							</item>
-							<item>
-								<description>Settings button</description>
-								<label>$LOCALIZE[5]</label>
-								<icon>osd/fullscreen/buttons/settings.png</icon>
-								<onclick>SetProperty(settingsdialog_content,games,home)</onclick>
-								<onclick>SetProperty(settingsdialog_header,$LOCALIZE[5],home)</onclick>
-								<onclick>ActivateWindow(1101)</onclick>
-							</item>
-						</content>
-						<pagecontrol>2201</pagecontrol>
+				<control type="grouplist" id="2000">
+					<width>700</width>
+					<height>1040</height>
+					<orientation>vertical</orientation>
+					<align>center</align>
+					<itemgap>0</itemgap>
+					<!-- Keep the header anonymous so the nested menu retains automatic wraparound. -->
+					<control type="group">
+						<width>700</width>
+						<height>80</height>
+						<control type="image" id="2001">
+							<width>700</width>
+							<height>80</height>
+							<texture colordiffuse="dialog_tint">colors/white.png</texture>
+						</control>
+						<include content="DialogBackground">
+							<param name="width" value="700" />
+							<param name="height" value="80" />
+							<param name="header_label" value="$LOCALIZE[35221]" />
+							<param name="header_id" value="3" />
+						</include>
 					</control>
-					<control type="scrollbar" id="2201">
-						<top>-10</top>
-						<right>0</right>
-						<width>12</width>
+					<control type="grouplist" id="1103">
+						<width>700</width>
+						<height max="960">auto</height>
 						<orientation>vertical</orientation>
+						<itemgap>0</itemgap>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1110" />
+							<param name="label" value="$LOCALIZE[35224]" />
+							<param name="label2" value="$FEATURE[select,game.controller.snes] + $FEATURE[x,game.controller.default]" />
+							<param name="icon" value="osd/fullscreen/buttons/play.png" />
+							<onclick>Play</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1111" />
+							<param name="label" value="$LOCALIZE[35249]" />
+							<param name="icon" value="osd/fullscreen/buttons/saves.png" />
+							<onclick>ActivateWindow(InGameSaves)</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1112" />
+							<param name="label" value="$LOCALIZE[35272]" />
+							<param name="icon" value="DefaultSets.png" />
+							<visible>RetroPlayer.SupportsEject</visible>
+							<onclick>ActivateWindow(GameDiscManager)</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1113" />
+							<param name="label" value="$LOCALIZE[35172]" />
+							<param name="icon" value="osd/fullscreen/buttons/agent.png" />
+							<onclick>ActivateWindow(GameAgents)</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1114" />
+							<param name="label" value="$LOCALIZE[35287]" />
+							<param name="label2" value="$INFO[RetroPlayer.AchievementsProgress]" />
+							<param name="icon" value="osd/fullscreen/buttons/rating.png" />
+							<description>Always show Achievements; its dialog explains sign-in requirements and missing achievement sets.</description>
+							<onclick>ActivateWindow(GameAchievements)</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1115" />
+							<param name="label" value="$LOCALIZE[13007]" />
+							<param name="icon" value="osd/fullscreen/buttons/reset.png" />
+							<onclick>PlayerControl(Reset)</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1116" />
+							<param name="label" value="$LOCALIZE[35222]" />
+							<param name="label2" value="$FEATURE[select,game.controller.snes] + $FEATURE[start,game.controller.default]" />
+							<param name="icon" value="osd/fullscreen/buttons/stop.png" />
+							<onclick>Stop</onclick>
+						</include>
+						<include content="GameOSDMenuButton">
+							<param name="id" value="1117" />
+							<param name="label" value="$LOCALIZE[5]" />
+							<param name="icon" value="osd/fullscreen/buttons/settings.png" />
+							<onclick>SetProperty(settingsdialog_content,games,home)</onclick>
+							<onclick>SetProperty(settingsdialog_header,$LOCALIZE[5],home)</onclick>
+							<onclick>ActivateWindow(1101)</onclick>
+						</include>
 					</control>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -893,6 +893,14 @@
 			<texturenofocus />
 			<onclick>Action(close)</onclick>
 		</control>
+		<include content="DialogBackground">
+			<param name="width" value="$PARAM[width]" />
+			<param name="height" value="$PARAM[height]" />
+			<param name="header_label" value="$PARAM[header_label]" />
+			<param name="header_id" value="$PARAM[header_id]" />
+		</include>
+	</include>
+	<include name="DialogBackground">
 		<control type="group">
 			<width>$PARAM[width]</width>
 			<height>$PARAM[height]</height>

--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -1,5 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
+	<include name="GameOSDMenuButton">
+		<param name="label2"></param>
+		<definition>
+			<control type="button" id="$PARAM[id]">
+				<width>700</width>
+				<height>80</height>
+				<label>$PARAM[label]</label>
+				<label2>$PARAM[label2]</label2>
+				<font></font>
+				<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+				<texturenofocus />
+				<nested />
+			</control>
+			<!-- Overlay the preceding button without adding another row to the grouplist. -->
+			<control type="group" id="1$PARAM[id]">
+				<top>0</top>
+				<width>700</width>
+				<height>0</height>
+				<visible>Control.IsVisible($PARAM[id])</visible>
+				<control type="image">
+					<left>8</left>
+					<top>-72</top>
+					<width>64</width>
+					<height>64</height>
+					<texture>$PARAM[icon]</texture>
+				</control>
+				<control type="label">
+					<left>80</left>
+					<top>-80</top>
+					<width>600</width>
+					<height>80</height>
+					<label>$PARAM[label]</label>
+					<font>font13</font>
+					<align>left</align>
+					<aligny>center</aligny>
+				</control>
+				<control type="label">
+					<right>20</right>
+					<top>-80</top>
+					<width>600</width>
+					<height>80</height>
+					<label>$PARAM[label2]</label>
+					<font>font13</font>
+					<align>right</align>
+					<aligny>center</aligny>
+					<textcolor>grey</textcolor>
+				</control>
+			</control>
+		</definition>
+	</include>
 	<include name="GameDialogControllers">
 		<control type="group">
 			<centertop>50%</centertop>

--- a/xbmc/games/dialogs/osd/DialogGameOSD.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.cpp
@@ -12,12 +12,20 @@
 #include "ServiceBroker.h"
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
+#include "guilib/GUIControlGroupList.h"
+#include "guilib/GUIImage.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
 using namespace KODI;
 using namespace GAME;
+
+namespace
+{
+constexpr int CONTROL_MENU = 1103;
+constexpr int CONTROL_BACKGROUND = 2001;
+} // namespace
 
 CDialogGameOSD::CDialogGameOSD()
   : CGUIDialog(WINDOW_DIALOG_GAME_OSD, "GameOSD.xml"),
@@ -54,6 +62,25 @@ bool CDialogGameOSD::OnAction(const CAction& action)
   }
 
   return CGUIDialog::OnAction(action);
+}
+
+void CDialogGameOSD::Process(unsigned int currentTime, CDirtyRegionList& dirtyregions)
+{
+  const auto* menu = dynamic_cast<CGUIControlGroupList*>(GetControl(CONTROL_MENU));
+  auto* background = dynamic_cast<CGUIImage*>(GetControl(CONTROL_BACKGROUND));
+  if (menu != nullptr && background != nullptr)
+  {
+    const auto* parentControl = background->GetParentControl();
+    if (parentControl != nullptr)
+    {
+      // Match the cached menu height used by its parent grouplist for centering.
+      const float height = parentControl->GetHeight() + menu->GetHeight();
+      if (background->GetHeight() != height)
+        background->SetHeight(height);
+    }
+  }
+
+  CGUIDialog::Process(currentTime, dirtyregions);
 }
 
 void CDialogGameOSD::OnInitWindow()

--- a/xbmc/games/dialogs/osd/DialogGameOSD.h
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.h
@@ -30,6 +30,7 @@ public:
 
   // Implementation of CGUIControl via CGUIDialog
   bool OnAction(const CAction& action) override;
+  void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
 
   // Implementation of CGUIWindow via CGUIDialog
   void OnDeinitWindow(int nextWindowID) override;


### PR DESCRIPTION
## Description

This PR replaces the duplicated Disc and non-Disc layouts added in https://github.com/xbmc/xbmc/pull/27984. Instead, it uses reusable buttons in a centered grouplist. The height is dynamic; visible controls determine the menu height together with its header.

Intended for https://github.com/xbmc/xbmc/pull/29283.

## Motivation and context

I didn't feel like overhauling the menu for the new conditional disc icon in https://github.com/xbmc/xbmc/pull/27984. So I just duplicated XML at the time. But now, we're adding a new conditional icon for cheats (see https://github.com/garbear/xbmc/pull/157). So it's time to do the OSD menu right.

As a result, the cheats button is added without requiring skin modifications:

```patch
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -143,6 +144,13 @@
                                                        <description>Always show Achievements; its dialog explains sign-in requirements and missing achievement sets.</description>
                                                        <onclick>ActivateWindow(GameAchievements)</onclick>
                                                </include>
+                                               <include content="GameOSDMenuButton">
+                                                       <param name="id" value="1118" />
+                                                       <param name="label" value="$LOCALIZE[35320]" />
+                                                       <param name="icon" value="osd/fullscreen/buttons/cheats.png" />
+                                                       <visible>RetroPlayer.HasCheats</visible>
+                                                       <onclick>ActivateWindow(GameCheats)</onclick>
+                                               </include>
                                                <include content="GameOSDMenuButton">
                                                        <param name="id" value="1115" />
                                                        <param name="label" value="$LOCALIZE[13007]" />
```

## How has this been tested?

Tested as part of https://github.com/garbear/xbmc/pull/157. Creating test builds now.

## What is the effect on users?

* None

## Screenshots (if appropriate):

<img width="1721" height="957" alt="Screenshot 2026-09-10 at 1 07 58 PM" src="https://github.com/user-attachments/assets/c290fef1-e9b4-43b6-9ce8-cad8404c7c66" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
