### PR TITLE
RetroPlayer: Fix savestate selection after deletion

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -34,6 +34,8 @@
 #include "view/GUIViewControl.h"
 #include "view/ViewState.h"
 
+#include <algorithm>
+
 using namespace KODI;
 using namespace GAME;
 
@@ -445,10 +447,16 @@ void CDialogGameSaves::OnDelete(const CFileItem& item)
     RETRO::CSavestateDatabase db;
     if (db.DeleteSavestate(savestatePath))
     {
+      const int selectedItem = m_viewControl->GetSelectedItem();
       m_vecList->Remove(&item);
 
       // Refresh thumbnails
       m_viewControl->SetItems(*m_vecList);
+
+      if (!m_vecList->IsEmpty())
+        m_viewControl->SetSelectedItem(std::min(selectedItem, m_vecList->Size() - 1));
+      else
+        SET_CONTROL_FOCUS(CONTROL_SAVES_NEW_BUTTON, 0);
     }
     else
     {

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -30,6 +30,8 @@
 #include "settings/MediaSettings.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace KODI;
 using namespace GAME;
 using namespace RETRO;
@@ -128,7 +130,8 @@ void CDialogInGameSaves::OnItemFocus(unsigned int index)
 
 unsigned int CDialogInGameSaves::GetFocusedItem() const
 {
-  return m_focusedControl;
+  // The leading "Save" item makes the savestate count the last valid index.
+  return std::min(m_focusedItemIndex, static_cast<unsigned int>(m_savestateItems.Size()));
 }
 
 void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath,

--- a/xbmc/games/dialogs/osd/test/CMakeLists.txt
+++ b/xbmc/games/dialogs/osd/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES TestLeaderboardUtils.cpp
+set(SOURCES TestDialogInGameSaves.cpp
+            TestLeaderboardUtils.cpp
 )
 
 # Cleared explicitly: this directory is entered from the one above, which has

--- a/xbmc/games/dialogs/osd/test/TestDialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/test/TestDialogInGameSaves.cpp
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "games/dialogs/DialogGameDefines.h"
+#include "games/dialogs/osd/DialogInGameSaves.h"
+#include "guilib/GUIMessage.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+class CTestDialogInGameSaves : public KODI::GAME::CDialogInGameSaves
+{
+public:
+  using CDialogInGameSaves::GetFocusedItem;
+};
+} // namespace
+
+TEST(TestDialogInGameSaves, ContainerFocusKeepsTheSaveItemSelected)
+{
+  CTestDialogInGameSaves dialog;
+  CGUIMessage message(GUI_MSG_FOCUSED, dialog.GetID(), CONTROL_VIDEO_THUMBS);
+
+  ASSERT_TRUE(dialog.OnMessage(message));
+  EXPECT_EQ(dialog.GetFocusedItem(), 0u);
+}


### PR DESCRIPTION
## Description

This PR fixes savestate selection after deleting an item.

Before this fix, deleting a savestate at the end of the list would awkwardly jump to the beginning of the list.

* Restore the deleted item's position, clamping to the new last item and focusing New when no savestates remain.
* For in-game saves, restore selection using the tracked item index instead of the focused control ID, accounting for the leading Save item. Add regression coverage for container focus.

## Motivation and context

Found while testing the new Cheats system in https://github.com/garbear/xbmc/pull/157.

Deleting the last savestate could reset selection to the beginning of the list instead of focusing the previous save, which was especially noticeable when the list had been scrolled.

## How has this been tested?

Live-tested both savestate dialogs with MGS in Debug Kodi.app:

- First, middle, last, scrolled-last and only-save deletion
- Context-menu Delete and Delete action
- Verified the replacement item remains visible after deletion
- Verified empty lists focus New/Save

Debug build succeeded and automated tests passed, including the new container-focus regression test.

## What is the effect on users?

Deleting a savestate now keeps focus at the expected position instead of jumping back to the beginning of the list.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
