### PR TITLE
Fix a data race on m_multiInfo that crashes below getInfoLabel

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11880,7 +11880,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string* 
   }
   else if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
-    return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow);
+    return GetMultiInfoLabel(GetMultiInfo(info), contextWindow);
   }
   else if (info >= LISTITEM_START && info <= LISTITEM_END)
   {
@@ -11901,7 +11901,7 @@ bool CGUIInfoManager::GetInt(int& value,
 {
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
-    return GetMultiInfoInt(value, m_multiInfo[info - MULTI_INFO_START], contextWindow, item);
+    return GetMultiInfoInt(value, GetMultiInfo(info), contextWindow, item);
   }
   else if (info >= LISTITEM_START && info <= LISTITEM_END)
   {
@@ -11973,7 +11973,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   }
   else if (condition >= MULTI_INFO_START && condition <= MULTI_INFO_END)
   {
-    bReturn = GetMultiInfoBool(m_multiInfo[condition - MULTI_INFO_START], contextWindow, item);
+    bReturn = GetMultiInfoBool(GetMultiInfo(condition), contextWindow, item);
   }
   else if (!m_infoProviders.GetBool(bReturn, m_currentFile.get(), contextWindow,
                                     CGUIInfo(condition)))
@@ -12044,8 +12044,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo& info,
             int iResolvedInfo2 = ResolveMultiInfo(info2);
             if (iResolvedInfo2 != 0)
             {
-              const GUIINFO::CGUIInfo& resolvedInfo2 =
-                  m_multiInfo[iResolvedInfo2 - MULTI_INFO_START];
+              const GUIINFO::CGUIInfo resolvedInfo2 = GetMultiInfo(iResolvedInfo2);
               if (resolvedInfo2.GetInfoFlag() & INFOFLAG_LISTITEM_CONTAINER)
                 item2 = GUIINFO::GetCurrentListItem(
                     contextWindow, resolvedInfo2.GetData1()); // data1 contains the container id
@@ -12226,7 +12225,7 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string* 
   }
   else if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
-    return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow, fallback);
+    return GetMultiInfoLabel(GetMultiInfo(info), contextWindow, fallback);
   }
   else if (info == LISTITEM_THUMB || info == LISTITEM_ICON || info == LISTITEM_ACTUAL_ICON ||
            info == LISTITEM_OVERLAY || info == LISTITEM_ART)
@@ -12317,6 +12316,7 @@ void CGUIInfoManager::UpdateAVInfo() const
 
 int CGUIInfoManager::AddMultiInfo(const CGUIInfo& info)
 {
+  std::unique_lock lock(m_critMultiInfo);
   // check to see if we have this info already
   for (unsigned int i = 0; i < m_multiInfo.size(); ++i)
     if (m_multiInfo[i] == info)
@@ -12329,6 +12329,18 @@ int CGUIInfoManager::AddMultiInfo(const CGUIInfo& info)
   return id;
 }
 
+CGUIInfo CGUIInfoManager::GetMultiInfo(int id) const
+{
+  std::unique_lock lock(m_critMultiInfo);
+  const size_t index = static_cast<size_t>(id) - MULTI_INFO_START;
+  // An id inside the range is no promise a block was registered for it:
+  // ResolveMultiInfo() walks a chain by feeding a block's own data back in as
+  // the next id, and that data can land anywhere in the range
+  if (index >= m_multiInfo.size())
+    return CGUIInfo(0); // every provider declines info 0
+  return m_multiInfo[index];
+}
+
 int CGUIInfoManager::ResolveMultiInfo(int info) const
 {
   int iLastInfo = 0;
@@ -12337,7 +12349,7 @@ int CGUIInfoManager::ResolveMultiInfo(int info) const
   while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
   {
     iLastInfo = iResolvedInfo;
-    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].GetInfo();
+    iResolvedInfo = GetMultiInfo(iResolvedInfo).GetInfo();
   }
 
   return iLastInfo;
@@ -12347,7 +12359,7 @@ bool CGUIInfoManager::IsListItemInfo(int info) const
 {
   int iResolvedInfo = info;
   while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
-    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].GetInfo();
+    iResolvedInfo = GetMultiInfo(iResolvedInfo).GetInfo();
 
   return (iResolvedInfo >= LISTITEM_START && iResolvedInfo <= LISTITEM_END);
 }
@@ -12389,8 +12401,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem* item,
   }
   else if (info.GetInfo() >= MULTI_INFO_START && info.GetInfo() <= MULTI_INFO_END)
   {
-    return GetMultiInfoItemLabel(item, contextWindow,
-                                 m_multiInfo[info.GetInfo() - MULTI_INFO_START], fallback);
+    return GetMultiInfoItemLabel(item, contextWindow, GetMultiInfo(info.GetInfo()), fallback);
   }
   else if (!m_infoProviders.GetLabel(value, item, contextWindow, info, fallback))
   {
@@ -12531,8 +12542,7 @@ std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem* item,
   }
   else if (info.GetInfo() >= MULTI_INFO_START && info.GetInfo() <= MULTI_INFO_END)
   {
-    return GetMultiInfoItemImage(item, contextWindow,
-                                 m_multiInfo[info.GetInfo() - MULTI_INFO_START], fallback);
+    return GetMultiInfoItemImage(item, contextWindow, GetMultiInfo(info.GetInfo()), fallback);
   }
 
   return GetMultiInfoItemLabel(item, contextWindow, info, fallback);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -222,6 +222,16 @@ private:
 
   int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo& info);
 
+  /*!
+   \brief One registered multi-info block, by value.
+
+   A reference into m_multiInfo cannot be held: any thread translating an info
+   string it has not seen before appends to the vector, and the reallocation
+   that follows frees what the reference points at. Callers get a copy taken
+   under the lock instead.
+   */
+  KODI::GUILIB::GUIINFO::CGUIInfo GetMultiInfo(int id) const;
+
   int ResolveMultiInfo(int info) const;
   bool IsListItemInfo(int info) const;
 
@@ -230,6 +240,7 @@ private:
 
   // Vector of multiple information mapped to a single integer lookup
   std::vector<KODI::GUILIB::GUIINFO::CGUIInfo> m_multiInfo;
+  mutable CCriticalSection m_critMultiInfo;
 
   // Current playing stuff
   std::unique_ptr<CFileItem> m_currentFile;


### PR DESCRIPTION
## Description

`m_multiInfo` is a vector that only ever grows, indexed by every caller that resolves a multi-info id, and it is guarded by nothing. The lock the class already has covers `m_bools` and `m_skinVariableStrings`, not this.

Readers now take a copy through a new `GetMultiInfo(id)` accessor, under a lock of its own rather than sharing the bools lock, which is held across expression parsing. Returning by value is the point: a reference cannot be handed out safely whatever the locking, because the caller outlives the lock.

The accessor bounds-checks as well. `AddMultiInfo` logs when a skin exceeds the id range and then hands back an index past the end regardless, so an out-of-range id can still reach a reader.

## Motivation and context

Both halves of the Python `getInfoLabel` path are unsynchronised: `TranslateString` may append a block the skin has not asked for before, and `GetImage` then indexes the vector. Every reader binds a **reference** into it and copies from that. When an append reallocates in between, the reference is left pointing at freed storage, and copying the block's `std::string` member dereferences whatever is there.

The result is a segfault inside `_M_construct`, several frames below `getInfoLabel`, in code that looks entirely innocent. Two service add-ons polling labels while the GUI thread renders is enough to hit it. The window is a few instructions wide, which is why it presents as a rare unexplained crash rather than anything reproducible.

No open issue linked — this was found by reading the path after an unexplained crash, not from a bug report.

## How has this been tested?

Built against current master (`92abe35f9d`) and confirmed to compile.

**I have not reproduced the crash deliberately, and I would not claim to.** The race is a few instructions wide and I know of no way to force the reallocation to land between a reader taking its reference and copying from it. The argument here is from the code: the vector is appended to at `AddMultiInfo`, it is indexed in seven places, and `m_critInfo` is held at none of them.

I have also not run the test suite against this change.

## What is the effect on users?

Removes a source of rare, unexplained crashes for anyone running service add-ons that poll info labels. No behavioural change otherwise.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
