### PR TITLE
fixed: python owns the objects in a list that a binding returns

### DIFF
--- a/xbmc/interfaces/python/test/TestPythonBindings.cpp
+++ b/xbmc/interfaces/python/test/TestPythonBindings.cpp
@@ -165,6 +165,27 @@ tag.setCast([xbmc.Actor('a', 'lead'), xbmc.Actor('b')])
 )py"));
 }
 
+// python owns each object in a returned list
+TEST_F(TestPythonBindings, ListElementsAreOwned)
+{
+  if (!s_pythonUp)
+    GTEST_SKIP() << "python runtime not initialized";
+  ASSERT_TRUE(s_mainImportOk);
+  EXPECT_TRUE(RunPy(R"py(
+import xbmc, xbmcgui
+li = xbmcgui.ListItem('owned', '', '', True)
+tag = li.getVideoInfoTag()
+assert tag.thisown
+tag.setCast([xbmc.Actor('a', 'lead'), xbmc.Actor('b')])
+actors = tag.getActors()
+assert [a.getName() for a in actors] == ['a', 'b'], [a.getName() for a in actors]
+assert all(a.thisown for a in actors), [a.thisown for a in actors]
+del li, tag
+assert actors[0].getRole() == 'lead', actors[0].getRole()
+del actors
+)py"));
+}
+
 // PyType_Ready mirrors tp_init into the class dict as a wrapper_descriptor; autodoc's constructor docstring injection replaces it with a method_descriptor that runs a second construction
 TEST_F(TestPythonBindings, NoInitInjection)
 {

--- a/xbmc/interfaces/swig/kodi_list.i
+++ b/xbmc/interfaces/swig/kodi_list.i
@@ -6,12 +6,28 @@
  *  See LICENSES/README.md for more information.
  */
 
-/* Kodi returns python lists, not tuples, for sequence-valued results.
-   SWIG fragments are first-definition-wins, so defining StdVectorTraits here,
-   ahead of every stock include, replaces the library's PyTuple_New version. */
+/* Sequences return as python lists, not tuples. Fragments are first-definition-wins,
+   so this must precede every stock include. */
 %fragment("StdVectorTraits","header",fragment="StdSequenceTraits")
 %{
+  #include <type_traits>
+
   namespace swig {
+    // python owns each AddonClass element, as %newobject does for a single return
+    template <class T>
+    PyObject *kodi_from_element(const T& val) {
+      using Pointee = std::remove_cv_t<std::remove_pointer_t<T>>;
+      if constexpr (std::is_pointer_v<T> && std::is_base_of_v<XBMCAddon::AddonClass, Pointee>) {
+        Pointee *obj = const_cast<Pointee *>(val);
+        PyObject *result = traits_from_ptr<Pointee>::from(obj, SWIG_POINTER_OWN);
+        if (result)
+          KodiSwig_acquire(obj);
+        return result;
+      } else {
+        return swig::from<T>(val);
+      }
+    }
+
     template <class T>
     struct traits_reserve<std::vector<T> > {
       static void reserve(std::vector<T> &seq, typename std::vector<T>::size_type n) {
@@ -31,7 +47,7 @@
         if (!lst) return NULL;
         Py_ssize_t i = 0;
         for (typename std::vector<T>::const_iterator it = vec.begin(); it != vec.end(); ++it, ++i)
-          PyList_SetItem(lst, i, swig::from<T>(*it));
+          PyList_SetItem(lst, i, kodi_from_element<T>(*it));
         return lst;
       }
     };


### PR DESCRIPTION
**TL;DR:** Bug fix. Every `xbmc.Actor` that `InfoTagVideo.getActors()` returns is leaked, because SWIG wraps the elements of a returned list without ownership; the list conversion now takes a reference to each one, as `%newobject` already does for a single returned object.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`InfoTagVideo.getActors()` creates a new `Actor` for each cast member and returns them in a `std::vector`. SWIG converts each element through `swig::traits_from<T*>`, which wraps the pointer with owner 0: the wrapper takes no reference, and nothing is released when the python object is collected.

For a single object a getter creates (`getVideoInfoTag`, `getPlayingItem` and the rest), `%newobject` makes the wrapper own it: `%feature("ref")` takes a reference, and `%feature("unref")` releases it on dealloc. That does not reach the elements of a returned container.

The list conversion in `kodi_list.i` now does the same for any element that is an `AddonClass` pointer: it wraps it as owned and takes a reference with `KodiSwig_acquire`. That is equally correct for an element something else holds through a `Ref`, because the reference python takes is its own. Elements of any other type convert exactly as before.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found while wiring a second binding of the same shape (a list of newly created objects) under the new SWIG generator. `getActors()` is the only binding on master that returns such a list today.

The Groovy generator leaked the same objects a different way: it wrapped them without taking a reference, then released one on dealloc, which left the count at -1.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New `TestPythonBindings.ListElementsAreOwned`: it sets a cast, calls `getActors()`, and asserts that every element is owned (`thisown`). It then drops the list item and the tag, uses an actor, and drops the list. Before the change it fails with `AssertionError: [False, False]`; after it, it passes.

Full `kodi-test` suite on Windows x64 with SWIG 4.5.0: 4321 tests, all passed. The regenerated wrappers for every module compile.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Add-ons that read a video's cast no longer leak memory each time they do.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
