### PR TITLE
fixed: a network source freezing mid-file ending playback as if it were complete

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -172,9 +172,13 @@ static int dvd_file_read(void* h, uint8_t* buf, int size)
   std::shared_ptr<CDVDInputStream> pInputStream = static_cast<CDVDDemuxFFmpeg*>(h)->m_pInput;
   int len = pInputStream->Read(buf, size);
   if (len == 0)
+  {
+    // A file input that has bytes left is a stalled source rather than the end
+    if (pInputStream->IsStreamType(DVDSTREAM_TYPE_FILE) && !pInputStream->IsEOF())
+      return AVERROR(EAGAIN);
     return AVERROR_EOF;
-  else
-    return len;
+  }
+  return len;
 }
 /*
 static int dvd_file_write(URLContext* h, uint8_t* buf, int size)
@@ -1060,9 +1064,14 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
     std::unique_lock lock(m_critSection); // open lock scope
     if (m_pFormatContext)
     {
-      // assume we are not eof
+      // assume we are not eof; clear stale io error so a failure below is this read's own
       if (m_pFormatContext->pb)
+      {
         m_pFormatContext->pb->eof_reached = 0;
+        m_pFormatContext->pb->error = 0;
+      }
+
+      bool readPacingExpired = false;
 
       // check for saved packet after a program change
       if (m_pkt.result < 0)
@@ -1071,10 +1080,16 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
         m_pkt.pkt.size = 0;
         m_pkt.pkt.data = NULL;
 
-        // timeout reads after 100ms
-        m_timeout.Set(20s);
+        m_timeout.Set(m_readTimeout);
         m_pkt.result = av_read_frame(m_pFormatContext, &m_pkt.pkt);
+        readPacingExpired = m_timeout.IsTimePast();
         m_timeout.SetInfinite();
+      }
+
+      if (m_inputStalled && m_pkt.result >= 0)
+      {
+        m_inputStalled = false;
+        CLog::LogF(LOGINFO, "input recovered");
       }
 
       if (m_pkt.result == AVERROR(EINTR) || m_pkt.result == AVERROR(EAGAIN))
@@ -1084,10 +1099,18 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
       }
       else if (m_pkt.result == AVERROR_EOF)
       {
+        if (WaitingOutInputStall(readPacingExpired))
+          bReturnEmpty = true;
       }
       else if (m_pkt.result < 0)
       {
-        Flush();
+        // A source that blocks inside av_read_frame trips the read timer before its io
+        // error can propagate, so an expired timer is read as pacing rather than an abort
+        if ((m_pkt.result != AVERROR_EXIT || readPacingExpired) &&
+            WaitingOutInputStall(readPacingExpired))
+          bReturnEmpty = true;
+        else
+          Flush();
       }
       // check size and stream index for being in a valid range
       else if (m_pkt.pkt.size < 0 || m_pkt.pkt.stream_index < 0 ||
@@ -1271,6 +1294,57 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
     pPacket->demuxerId = GetDemuxerId();
   }
   return pPacket;
+}
+
+bool CDVDDemuxFFmpeg::WaitingOutInputStall(bool readPacingExpired)
+{
+  if (!m_pInput || !m_pInput->IsStreamType(DVDSTREAM_TYPE_FILE) || m_pInput->IsEOF())
+    return false;
+
+  // Opening the window takes evidence of a stall: an io-reported failure, or the read pacing
+  // expiring around a blocked read.
+  if (!m_inputStalled && !readPacingExpired &&
+      (!m_pFormatContext || !m_pFormatContext->pb || m_pFormatContext->pb->error == 0))
+    return false;
+
+  if (!m_inputStalled)
+  {
+    m_inputStalled = true;
+    m_stallDeadline.Set(m_stallRecoveryWindow);
+    m_nextStallProbe.Set(STALL_PROBE_INTERVAL);
+    CLog::LogF(LOGWARNING, "input stalled short of its length, polling for up to {} s",
+               std::chrono::duration_cast<std::chrono::seconds>(m_stallRecoveryWindow).count());
+    // Answering at once lets the player stop its clock; probing first would park this thread in
+    // the stalled input for another read, with the clock running on over a stopped picture
+    return true;
+  }
+
+  if (m_stallDeadline.IsTimePast())
+    return false;
+
+  if (!m_nextStallProbe.IsTimePast())
+    return true;
+
+  m_nextStallProbe.Set(STALL_PROBE_INTERVAL);
+
+  // Only the input stream can report recovery: the demuxer's io state stays latched from the
+  // failed reads.
+  const int64_t position = m_pInput->Seek(0, SEEK_CUR);
+  if (position >= 0)
+  {
+    uint8_t probe = 0;
+    if (m_pInput->Read(&probe, 1) >= 0)
+    {
+      m_pInput->Seek(position, SEEK_SET);
+      // A seek is what resets the demuxer's latched end-of-file
+      if (m_pFormatContext && m_currentPts != DVD_NOPTS_VALUE)
+        av_seek_frame(m_pFormatContext, -1, static_cast<int64_t>(m_currentPts),
+                      AVSEEK_FLAG_BACKWARD);
+      CLog::LogF(LOGINFO, "input answered again, resuming");
+    }
+  }
+
+  return true;
 }
 
 DemuxPacket* CDVDDemuxFFmpeg::Read()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -93,6 +93,12 @@ public:
   void SetSpeed(int iSpeed) override;
   std::string GetFileName() override;
 
+  /*! \brief How long a stalled input is polled before playback ends. */
+  void SetStallRecoveryWindow(std::chrono::milliseconds window) { m_stallRecoveryWindow = window; }
+
+  /*! \brief How long one read is given before it counts as pacing rather than an abort. */
+  void SetReadTimeout(std::chrono::milliseconds timeout) { m_readTimeout = timeout; }
+
   DemuxPacket* Read() override;
   DemuxPacket* ReadInternal(bool keep);
 
@@ -134,6 +140,7 @@ protected:
   AVDictionary* GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
   bool IsProgramChange();
+  bool WaitingOutInputStall(bool readPacingExpired);
   unsigned int HLSSelectProgram();
 
   std::string GetStereoModeFromMetadata(AVDictionary* pMetadata);
@@ -162,6 +169,19 @@ protected:
   int m_seekStream;
 
   XbmcThreads::EndTime<> m_timeout;
+
+  // Long enough to ride out a network share dropping individual connections for a minute or two
+  static constexpr auto STALL_RECOVERY_WINDOW{std::chrono::minutes(2)};
+  static constexpr auto READ_TIMEOUT{std::chrono::seconds(20)};
+  // The recovery probe blocks until the source fails and holds m_critSection while it does,
+  // so it is paced rather than run on every read
+  static constexpr auto STALL_PROBE_INTERVAL{std::chrono::seconds(1)};
+
+  bool m_inputStalled = false;
+  XbmcThreads::EndTime<> m_stallDeadline;
+  XbmcThreads::EndTime<> m_nextStallProbe;
+  std::chrono::milliseconds m_stallRecoveryWindow{STALL_RECOVERY_WINDOW};
+  std::chrono::milliseconds m_readTimeout{READ_TIMEOUT};
 
   // Due to limitations of ffmpeg, we only can detect a program change
   // with a packet. This struct saves the packet for the next read and

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestDVDDemuxUtils.cpp)
+set(SOURCES TestDVDDemuxFFmpeg.cpp
+            TestDVDDemuxUtils.cpp)
 
 core_add_test_library(dvddemuxers_test)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxFFmpeg.cpp
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h"
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h"
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "filesystem/File.h"
+#include "test/TestUtils.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+/* Serves a real file from memory and, once told to stall, behaves like the file cache over a
+ * frozen network flow: each read blocks and then reports an error.
+ */
+class CStallingInputStream : public CDVDInputStreamFile
+{
+public:
+  explicit CStallingInputStream(const CFileItem& fileitem) : CDVDInputStreamFile(fileitem, 0) {}
+
+  bool Open() override
+  {
+    XFILE::CFile file;
+    if (!file.Open(m_item.GetPath()))
+      return false;
+    const int64_t length = file.GetLength();
+    if (length <= 0)
+      return false;
+    m_data.resize(static_cast<size_t>(length));
+    int64_t total = 0;
+    while (total < length)
+    {
+      const ssize_t read = file.Read(m_data.data() + total, length - total);
+      if (read <= 0)
+        return false;
+      total += read;
+    }
+    m_pos = 0;
+    return true;
+  }
+
+  void Close() override {}
+
+  int Read(uint8_t* buf, int buf_size) override
+  {
+    if (m_stalled.load())
+    {
+      // Longer than the demuxer's read timer, so the timer fires before this failure surfaces
+      for (int i = 0; i < 20 && m_stalled.load(); ++i)
+        std::this_thread::sleep_for(100ms);
+      if (m_stalled.load())
+        return -1;
+    }
+    if (m_pos >= static_cast<int64_t>(m_data.size()))
+    {
+      m_eofLatched = true;
+      return 0;
+    }
+    const int count =
+        static_cast<int>(std::min<int64_t>(buf_size, static_cast<int64_t>(m_data.size()) - m_pos));
+    std::memcpy(buf, m_data.data() + m_pos, count);
+    m_pos += count;
+    return count;
+  }
+
+  int64_t Seek(int64_t offset, int whence) override
+  {
+    if (whence == DVDSTREAM_SEEK_POSSIBLE)
+      return 1;
+    int64_t target = -1;
+    if (whence == SEEK_SET)
+      target = offset;
+    else if (whence == SEEK_CUR)
+      target = m_pos + offset;
+    else if (whence == SEEK_END)
+      target = static_cast<int64_t>(m_data.size()) + offset;
+    if (target < 0 || target > static_cast<int64_t>(m_data.size()))
+      return -1;
+    m_pos = target;
+    m_eofLatched = false;
+    return m_pos;
+  }
+
+  bool IsEOF() override { return m_eofLatched; }
+  int64_t GetLength() override { return static_cast<int64_t>(m_data.size()); }
+  int GetBlockSize() override { return 0; }
+
+  void Stall(bool stalled) { m_stalled = stalled; }
+
+private:
+  std::vector<uint8_t> m_data;
+  int64_t m_pos = 0;
+  bool m_eofLatched = false;
+  std::atomic<bool> m_stalled{false};
+};
+} // namespace
+
+/* A container whose index ends before the physical file does - an mp4 with its
+ * moov after the mdat, the default layout - reaches its true end with the read
+ * position still short of the file length, and without a final zero-length
+ * read to latch the input's eof flag. That end must surface promptly.
+ */
+TEST(TestDVDDemuxFFmpeg, IndexedEofWithTrailingBytesIsPrompt)
+{
+  const std::string path = XBMC_REF_FILE_PATH("xbmc/utils/test/resources/no_chapters.mp4");
+  const CFileItem item(path, false);
+  auto input = std::make_shared<CDVDInputStreamFile>(item, 0);
+  ASSERT_TRUE(input->Open());
+
+  CDVDDemuxFFmpeg demux;
+  ASSERT_TRUE(demux.Open(input, false));
+
+  int dataPackets = 0;
+  int emptyPackets = 0;
+  while (DemuxPacket* packet = demux.Read())
+  {
+    if (packet->iSize > 0)
+      ++dataPackets;
+    else
+      ++emptyPackets;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+    if (emptyPackets > 32)
+      break;
+  }
+
+  EXPECT_GT(dataPackets, 0) << "the fixture demuxed no data at all";
+  EXPECT_LE(emptyPackets, 32) << "a cleanly ended file was polled as a stalled one";
+}
+
+/* A source that freezes mid-file blocks inside av_read_frame, so the demuxer's
+ * own read timer fires before any io error can surface.
+ *
+ * The matroska fixture is generated:
+ *
+ *   ffmpeg -f lavfi -i "smptebars=s=320x240:r=10:d=2" \
+ *          -c:v libx264 -preset veryslow -crf 30 -pix_fmt yuv420p -g 10 \
+ *          h264_8bit_320x240.mkv
+ */
+TEST(TestDVDDemuxFFmpeg, StalledInputOutlivesTheReadTimer)
+{
+  const std::string path =
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/test/testdata/h264_8bit_320x240.mkv");
+  const CFileItem item(path, false);
+  auto input = std::make_shared<CStallingInputStream>(item);
+  ASSERT_TRUE(input->Open());
+
+  CDVDDemuxFFmpeg demux;
+  demux.SetReadTimeout(1s);
+  demux.SetStallRecoveryWindow(60s);
+  ASSERT_TRUE(demux.Open(input, false));
+
+  int dataPackets = 0;
+  while (dataPackets < 8)
+  {
+    DemuxPacket* packet = demux.Read();
+    ASSERT_NE(nullptr, packet) << "demuxing the healthy start of the file failed";
+    if (packet->iSize > 0)
+      ++dataPackets;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+
+  input->Stall(true);
+  const auto stallStart = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - stallStart < 6s)
+  {
+    DemuxPacket* packet = demux.Read();
+    const auto stalledFor = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - stallStart);
+    ASSERT_NE(nullptr, packet) << "demuxer gave up " << stalledFor.count()
+                               << "s into a recoverable stall";
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+  input->Stall(false);
+
+  int recovered = 0;
+  for (int i = 0; i < 256 && recovered == 0; ++i)
+  {
+    DemuxPacket* packet = demux.Read();
+    ASSERT_NE(nullptr, packet) << "demuxer did not survive the stall clearing";
+    if (packet->iSize > 0)
+      ++recovered;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+  EXPECT_GT(recovered, 0) << "no data packet arrived after the input recovered";
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -100,7 +100,12 @@ int CDVDInputStreamFile::Read(uint8_t* buf, int buf_size)
 
   /* we currently don't support non completing reads */
   if (ret == 0)
-    m_eof = true;
+  {
+    // A zero read short of the file's length is a stalled source, not the end
+    const int64_t length = m_pFile->GetLength();
+    if (length <= 0 || m_pFile->GetPosition() >= length)
+      m_eof = true;
+  }
 
   return (int)ret;
 }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -100,6 +100,16 @@ private:
   int64_t  m_size;
 };
 
+namespace
+{
+int64_t SteadyMilliseconds()
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+} // unnamed namespace
+
 CFileCache::CFileCache(const unsigned int flags)
   : CFileCache(flags, std::make_unique<CFileCacheSource>())
 {
@@ -131,6 +141,7 @@ bool CFileCache::Open(const CURL& url)
 
   std::unique_lock lock(m_sync);
 
+  m_sourceUrl = url;
   m_sourcePath = url.GetRedacted();
 
   CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> opening", __FUNCTION__, m_sourcePath);
@@ -144,6 +155,7 @@ bool CFileCache::Open(const CURL& url)
     Close();
     return false;
   }
+  m_sourceOpen = true;
 
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   if (!settings)
@@ -167,7 +179,8 @@ bool CFileCache::Open(const CURL& url)
             "CFileCache::{} - <{}> source chunk size is {}, setting cache chunk size to {}",
             __FUNCTION__, m_sourcePath, m_source->GetChunkSize(), m_chunkSize);
 
-  m_fileSize = m_source->GetLength();
+  // A negative length means unknown size, not past the end
+  m_fileSize = std::max<int64_t>(0, m_source->GetLength());
 
   if (!m_pCache)
   {
@@ -286,7 +299,10 @@ void CFileCache::Process()
     bool seekRequested = false;
     if (m_sourcePositionValid)
     {
-      m_fileSize = m_source->GetLength();
+      // A dead source reports no length, which must not erase the real one mid-file
+      const int64_t sourceLength = m_source->GetLength();
+      if (sourceLength > 0)
+        m_fileSize = sourceLength;
       seekRequested = m_seekEvent.Wait(0ms);
     }
     else
@@ -305,7 +321,10 @@ void CFileCache::Process()
       bool sourceSeekFailed = false;
       if (!cacheReachEOF || !m_sourcePositionValid)
       {
-        const int64_t sourceSeekResult = m_source->Seek(cacheMaxPos, SEEK_SET);
+        // A source closed by a failed reconnect is reopened rather than sought
+        const int64_t sourceSeekResult = m_sourceOpen
+                                             ? m_source->Seek(cacheMaxPos, SEEK_SET)
+                                             : (ReopenSource(cacheMaxPos) ? cacheMaxPos : -1);
         const DWORD sourceSeekError = GetLastError();
         if (sourceSeekResult != cacheMaxPos)
         {
@@ -315,7 +334,8 @@ void CFileCache::Process()
                     sourceSeekResult);
           m_nSeekResult = -1;
           m_seekError = sourceSeekError != 0 ? sourceSeekError : EIO;
-          m_seekPossible = m_source->IoControl(IOControl::SEEK_POSSIBLE, NULL);
+          if (m_sourceOpen)
+            m_seekPossible = m_source->IoControl(IOControl::SEEK_POSSIBLE, NULL);
           sourceSeekFailed = true;
           m_sourcePositionValid = false;
 
@@ -407,9 +427,34 @@ void CFileCache::Process()
 
     ssize_t iRead = 0;
     if (maxSourceRead > 0)
+    {
+      // Published for CancelStalledSourceRead
+      m_sourceReadStart = SteadyMilliseconds();
       iRead = m_source->Read(buffer.get(), maxSourceRead);
+      m_sourceReadStart = 0;
+      m_sourceReadCancelled = false;
+    }
     if (iRead <= 0)
     {
+      // Mid-file on a seekable source this is a stalled or dropped connection, not the end
+      if (!m_bStop && m_seekPossible && m_fileSize > 0 && m_writePos < m_fileSize)
+      {
+        CLog::LogF(LOGWARNING, "<{}> source read returned {} at {} of {}, reconnecting",
+                   m_sourcePath, iRead, m_writePos, m_fileSize.load());
+
+        if (m_seekEvent.Wait(2000ms))
+        {
+          if (!m_bStop)
+            m_seekEvent.Set(); // hack so that later we realize seek is needed
+        }
+        else if (ReopenSource(m_writePos))
+        {
+          CLog::LogF(LOGINFO, "<{}> source reconnected at {}", m_sourcePath, m_writePos);
+        }
+
+        continue; // while (!m_bStop)
+      }
+
       // Check for actual EOF and retry as long as we still have data in our cache
       if (m_writePos < m_fileSize && m_pCache->WaitForData(0, 0ms) > 0)
       {
@@ -513,6 +558,32 @@ void CFileCache::Process()
   }
 }
 
+bool CFileCache::ReopenSource(int64_t position)
+{
+  // Held so a cancel or a property query cannot reach a handle being closed
+  std::unique_lock sourceLock(m_sourceSection);
+  m_source->Close();
+  m_sourceOpen = false;
+  if (!m_source->Open(m_sourceUrl, READ_NO_CACHE | READ_TRUNCATED | READ_NO_BUFFER))
+    return false;
+
+  // A reopened source is a fresh protocol instance, so the source controls are reapplied
+  m_source->IoControl(IOControl::SET_CACHE, this);
+  bool retry = false;
+  m_source->IoControl(IOControl::SET_RETRY, &retry);
+  m_seekPossible = m_source->IoControl(IOControl::SEEK_POSSIBLE, nullptr);
+
+  // Reading from a misplaced connection would corrupt the cache silently
+  if (!m_seekPossible || m_source->Seek(position, SEEK_SET) != position)
+  {
+    m_source->Close();
+    return false;
+  }
+
+  m_sourceOpen = true;
+  return true;
+}
+
 void CFileCache::OnExit()
 {
   m_bStop = true;
@@ -535,8 +606,46 @@ int CFileCache::Stat(const CURL& url, struct __stat64* buffer)
   return CFile::Stat(url.Get(), buffer);
 }
 
+void CFileCache::CancelStalledSourceRead()
+{
+  // A healthy source answers one chunk in well under a second
+  constexpr auto answerTimeout = 10s;
+
+  // Only a source the fill thread can reconnect and resume is worth cancelling
+  if (!m_seekPossible || m_sourceReadCancelled)
+    return;
+
+  const int64_t startedAt = m_sourceReadStart;
+  if (startedAt == 0 ||
+      SteadyMilliseconds() - startedAt <
+          std::chrono::duration_cast<std::chrono::milliseconds>(answerTimeout).count())
+    return;
+
+  // A held lock means the fill thread is already replacing the connection
+  std::unique_lock sourceLock(m_sourceSection, std::try_to_lock);
+  if (!sourceLock.owns_lock())
+    return;
+
+  // The read may have been answered, and another started, since it was checked
+  if (m_sourceReadStart != startedAt)
+    return;
+
+  m_sourceReadCancelled = true;
+
+  if (m_source->IoControl(IOControl::CANCEL_IO, nullptr) >= 0)
+    CLog::LogF(LOGWARNING,
+               "<{}> source has not answered a read for {} s at {} of {}, cancelling it to "
+               "reconnect",
+               m_sourcePath,
+               std::chrono::duration_cast<std::chrono::seconds>(answerTimeout).count(), m_writePos,
+               m_fileSize.load());
+}
+
 ssize_t CFileCache::Read(void* lpBuf, size_t uiBufSize)
 {
+  // The fill thread cannot notice its own blocked read; this thread can
+  CancelStalledSourceRead();
+
   std::unique_lock lock(m_sync);
   if (!m_pCache)
   {
@@ -573,6 +682,16 @@ retry:
     if (!m_sourcePositionValid)
     {
       SetLastError(m_seekError != 0 ? m_seekError : EIO);
+      return -1;
+    }
+
+    // Zero means end-of-file to every caller, so starvation has to surface as an error
+    if (iRc == 0 && m_readPos < m_fileSize)
+    {
+      CLog::LogF(LOGWARNING, "<{}> timeout waiting for data at {} of {}", m_sourcePath, m_readPos,
+                 m_fileSize.load());
+      // The wait above can outlast the stall timeout
+      CancelStalledSourceRead();
       return -1;
     }
   }
@@ -688,7 +807,9 @@ void CFileCache::Close()
   if (m_pCache)
     m_pCache->Close();
 
+  std::unique_lock sourceLock(m_sourceSection);
   m_source->Close();
+  m_sourceOpen = false;
 }
 
 int64_t CFileCache::GetPosition()
@@ -711,6 +832,8 @@ void CFileCache::StopThread(bool bWait /*= true*/)
 
 const std::string CFileCache::GetProperty(XFILE::FileProperty type, const std::string &name) const
 {
+  // The fill thread may be replacing the source to reconnect
+  std::unique_lock sourceLock(m_sourceSection);
   if (!m_source->GetImplementation())
     return IFile::GetProperty(type, name);
 

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -10,6 +10,7 @@
 
 #include "CacheStrategy.h"
 #include "IFile.h"
+#include "URL.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
@@ -90,9 +91,16 @@ public:
     CFileCache(unsigned int flags, std::unique_ptr<IFileCacheSource> source);
 
   private:
+    //! Cancels a source read left unanswered for longer than a healthy source takes
+    void CancelStalledSourceRead();
+    //! Replaces the source with a new connection at the position; false leaves it closed
+    bool ReopenSource(int64_t position);
+
     std::unique_ptr<CCacheStrategy> m_pCache;
-    int m_seekPossible = 0;
+    std::atomic<int> m_seekPossible{0};
     std::unique_ptr<IFileCacheSource> m_source;
+    bool m_sourceOpen = false;
+    CURL m_sourceUrl;
     std::string m_sourcePath;
     CEvent m_seekEvent;
     CEvent m_seekEnded;
@@ -113,6 +121,9 @@ public:
     unsigned int m_flags;
     CCriticalSection m_sync;
     std::chrono::milliseconds m_processWait{100ms};
+    std::atomic<int64_t> m_sourceReadStart{0}; // steady ms, 0 while no source read is outstanding
+    std::atomic<bool> m_sourceReadCancelled{false};
+    mutable CCriticalSection m_sourceSection; // held while the source is replaced
   };
 
 }

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -74,6 +74,7 @@ enum class IOControl
   CACHE_SETRATE = 4, /**< unsigned int with speed limit for caching in bytes per second */
   SET_CACHE = 8, /**< CFileCache */
   SET_RETRY = 16, /**< Enable/disable retry within the protocol handler (if supported) */
+  CANCEL_IO = 32, /**< Fail an outstanding read (if supported) */
 };
 
 enum class CURLOptionType

--- a/xbmc/filesystem/test/TestFileCache.cpp
+++ b/xbmc/filesystem/test/TestFileCache.cpp
@@ -8,6 +8,8 @@
 
 #include "URL.h"
 #include "filesystem/FileCache.h"
+#include "filesystem/IFileTypes.h"
+#include "filesystem/PipeFile.h"
 #include "threads/Event.h"
 
 #if !defined(TARGET_WINDOWS)
@@ -149,6 +151,127 @@ private:
   CEvent m_firstReadEntered{true};
   CEvent m_allowFirstRead{true};
   CEvent m_seekEntered{true};
+};
+
+/* Behaves as a CFile whose connections stop answering at a given offset. One connection can be
+ * made to fail to open, a closed source answers as a closed CFile does, and the implementation's
+ * property query can be held open.
+ */
+class CStallingFileCacheSource : public IFileCacheSource
+{
+public:
+  static constexpr int64_t FILE_SIZE = 1024 * 1024;
+
+  //! Connections stop answering at stallAt: the first only, or every one
+  CStallingFileCacheSource(int64_t stallAt, bool everyConnection, int failingConnection)
+    : m_stallAt(stallAt),
+      m_everyConnection(everyConnection),
+      m_failingConnection(failingConnection)
+  {
+  }
+
+  bool Open(const CURL& url, unsigned int flags) override
+  {
+    const int connection = ++m_connections;
+    if (connection == m_failingConnection)
+    {
+      m_openFailed.Set();
+      return false;
+    }
+    m_position = 0;
+    m_open = true;
+    return true;
+  }
+
+  void Close() override
+  {
+    if (m_inProperty)
+      m_closedUnderProperty = true;
+    if (m_open.exchange(false))
+      m_closeEntered.Set();
+  }
+
+  ssize_t Read(void* buffer, size_t size) override
+  {
+    if (!m_open)
+      return -1;
+    const int64_t end = m_everyConnection || m_connections == 1 ? m_stallAt : FILE_SIZE;
+    const int64_t count = std::min<int64_t>(size, end - m_position);
+    if (count <= 0)
+      return 0;
+    std::fill_n(static_cast<unsigned char*>(buffer), count, 0x5a);
+    m_position += count;
+    return static_cast<ssize_t>(count);
+  }
+
+  int64_t Seek(int64_t position, int whence) override
+  {
+    if (!m_open)
+      return -1;
+    m_position = position;
+    return position;
+  }
+
+  int64_t GetLength() override { return m_open ? FILE_SIZE : 0; }
+  int GetChunkSize() override { return 16 * 1024; }
+  int IoControl(IOControl request, void* param) override
+  {
+    if (!m_open)
+      return -1;
+    return request == IOControl::SEEK_POSSIBLE ? 1 : 0;
+  }
+  IFile* GetImplementation() override { return &m_implementation; }
+
+  bool WaitForFailedOpen(std::chrono::milliseconds timeout) { return m_openFailed.Wait(timeout); }
+  bool WaitForProperty(std::chrono::milliseconds timeout)
+  {
+    return m_propertyEntered.Wait(timeout);
+  }
+  bool WaitForClose(std::chrono::milliseconds timeout) { return m_closeEntered.Wait(timeout); }
+  void ReleaseProperty() { m_releaseProperty.Set(); }
+  bool ClosedUnderProperty() const { return m_closedUnderProperty; }
+
+private:
+  class CImplementation : public IFile
+  {
+  public:
+    explicit CImplementation(CStallingFileCacheSource& owner) : m_owner(owner) {}
+
+    bool Open(const CURL& url) override { return true; }
+    bool Exists(const CURL& url) override { return true; }
+    int Stat(const CURL& url, struct __stat64* buffer) override { return -1; }
+    ssize_t Read(void* bufPtr, size_t bufSize) override { return -1; }
+    int64_t Seek(int64_t iFilePosition, int iWhence) override { return -1; }
+    void Close() override {}
+    int64_t GetPosition() override { return 0; }
+    int64_t GetLength() override { return 0; }
+
+    const std::string GetProperty(FileProperty type, const std::string& name) const override
+    {
+      m_owner.m_inProperty = true;
+      m_owner.m_propertyEntered.Set();
+      m_owner.m_releaseProperty.Wait();
+      m_owner.m_inProperty = false;
+      return "video/x-matroska";
+    }
+
+  private:
+    CStallingFileCacheSource& m_owner;
+  };
+
+  const int64_t m_stallAt;
+  const bool m_everyConnection;
+  const int m_failingConnection;
+  std::atomic<bool> m_open{false};
+  std::atomic<int> m_connections{0};
+  std::atomic<bool> m_inProperty{false};
+  std::atomic<bool> m_closedUnderProperty{false};
+  int64_t m_position{0};
+  CEvent m_openFailed{true};
+  CEvent m_propertyEntered{true};
+  CEvent m_releaseProperty{true};
+  CEvent m_closeEntered{false};
+  CImplementation m_implementation{*this};
 };
 
 class TestFileCache : public CFileCache
@@ -368,4 +491,148 @@ TEST(TestFileCache, ReadFailsPromptlyAfterQuarantinedCacheDrains)
   const auto [readResult, readError] = failedRead.get();
   EXPECT_EQ(-1, readResult);
   EXPECT_EQ(ECONNRESET, readError);
+}
+
+TEST(TestFileCache, SeekAfterFailedReconnectReopensSource)
+{
+  using namespace std::chrono_literals;
+
+  // The first connection stalls and the reconnect fails
+  auto source = std::make_unique<CStallingFileCacheSource>(64 * 1024, false, 2);
+  auto* sourcePtr = source.get();
+  TestFileCache cache{READ_AUDIO_VIDEO, std::move(source)};
+
+  ASSERT_TRUE(cache.Open(CURL{"mock://server/movie.mkv"}));
+  const bool reconnectFailed = sourcePtr->WaitForFailedOpen(10s);
+  if (!reconnectFailed)
+  {
+    cache.Close();
+    ASSERT_TRUE(reconnectFailed);
+  }
+
+  constexpr int64_t target = CStallingFileCacheSource::FILE_SIZE / 2;
+  auto seekResult = std::async(std::launch::async, [&]() { return SeekWithError(cache, target); });
+  const bool seekReady = seekResult.wait_for(5s) == std::future_status::ready;
+  SeekResult result{};
+  if (seekReady)
+    result = seekResult.get();
+
+  unsigned char value = 0;
+  const ssize_t bytesRead = seekReady && result.position == target ? cache.Read(&value, 1) : -1;
+  cache.Close();
+
+  ASSERT_TRUE(seekReady);
+  EXPECT_EQ(target, result.position);
+  EXPECT_EQ(1, bytesRead);
+  EXPECT_EQ(0x5a, value);
+}
+
+TEST(TestFileCache, ReconnectWaitsForPropertyQueryOnSource)
+{
+  using namespace std::chrono_literals;
+
+  // Every connection stalls after its first chunk, so the fill thread keeps reconnecting
+  auto source = std::make_unique<CStallingFileCacheSource>(16 * 1024, true, 0);
+  auto* sourcePtr = source.get();
+  TestFileCache cache{READ_AUDIO_VIDEO, std::move(source)};
+
+  ASSERT_TRUE(cache.Open(CURL{"mock://server/movie.mkv"}));
+  auto property = std::async(std::launch::async,
+                             [&]() { return cache.GetProperty(FileProperty::CONTENT_TYPE); });
+  const bool propertyEntered = sourcePtr->WaitForProperty(5s);
+
+  // The fill thread reconnects about two seconds into the stall
+  sourcePtr->WaitForClose(4s);
+  sourcePtr->ReleaseProperty();
+  const bool propertyReady = property.wait_for(5s) == std::future_status::ready;
+  cache.Close();
+
+  ASSERT_TRUE(propertyEntered);
+  ASSERT_TRUE(propertyReady);
+  EXPECT_EQ("video/x-matroska", property.get());
+  EXPECT_FALSE(sourcePtr->ClosedUnderProperty());
+}
+
+/* A source that merely stops answering must not surface as 0. A pipe stands in for
+ * one: reads block while it is empty and the cache's fill thread parks inside the
+ * read. A pipe is not seekable, so this does not exercise the reconnect path.
+ */
+TEST(TestFileCache, StalledSourceMidFileIsNotEof)
+{
+  const CURL pipeUrl("pipe://filecache-stall-test/");
+
+  CPipeFile writer;
+  ASSERT_TRUE(writer.OpenForWrite(pipeUrl));
+
+  CFileCache cache{static_cast<unsigned int>(READ_AUDIO_VIDEO)};
+  ASSERT_TRUE(cache.Open(pipeUrl));
+
+  // The cache refreshes the source's length every fill pass; report an honest
+  // size so the stall happens mid-file rather than at an unknown position.
+  constexpr int64_t fileSize = 10 * 1024 * 1024;
+  auto* source = static_cast<CPipeFile*>(cache.GetFileImp());
+  ASSERT_NE(nullptr, source);
+  source->SetLength(fileSize);
+
+  constexpr size_t delivered = 1024 * 1024;
+  const std::vector<char> data(delivered, 'x');
+  ASSERT_EQ(static_cast<ssize_t>(delivered), writer.Write(data.data(), delivered));
+
+  std::vector<char> buffer(64 * 1024);
+  size_t total = 0;
+  while (total < delivered)
+  {
+    const ssize_t read = cache.Read(buffer.data(), std::min(buffer.size(), delivered - total));
+    ASSERT_GT(read, 0) << "read failed at offset " << total << " with all data still available";
+    total += read;
+  }
+
+  // The source is now stalled with most of the file outstanding.
+  const ssize_t starved = cache.Read(buffer.data(), buffer.size());
+  EXPECT_NE(0, starved) << "a stalled source was reported as end-of-file at position "
+                        << cache.GetPosition() << " of " << cache.GetLength();
+
+  // Eof must be raised before Close: the fill thread may be blocked inside
+  // the pipe read, and Close waits for it to exit.
+  writer.SetEof();
+  cache.Close();
+  writer.Close();
+}
+
+/* When the source really is exhausted at its stated length, 0 is the correct
+ * answer and must keep being served.
+ */
+TEST(TestFileCache, ExhaustedSourceIsEof)
+{
+  const CURL pipeUrl("pipe://filecache-eof-test/");
+
+  CPipeFile writer;
+  ASSERT_TRUE(writer.OpenForWrite(pipeUrl));
+
+  CFileCache cache{static_cast<unsigned int>(READ_AUDIO_VIDEO)};
+  ASSERT_TRUE(cache.Open(pipeUrl));
+
+  constexpr int64_t fileSize = 256 * 1024;
+  auto* source = static_cast<CPipeFile*>(cache.GetFileImp());
+  ASSERT_NE(nullptr, source);
+  source->SetLength(fileSize);
+
+  const std::vector<char> data(fileSize, 'x');
+  ASSERT_EQ(static_cast<ssize_t>(fileSize), writer.Write(data.data(), fileSize));
+  writer.SetEof();
+
+  std::vector<char> buffer(64 * 1024);
+  int64_t total = 0;
+  while (total < fileSize)
+  {
+    const ssize_t read = cache.Read(buffer.data(), buffer.size());
+    ASSERT_GT(read, 0) << "read failed at offset " << total << " of a complete file";
+    total += read;
+  }
+
+  EXPECT_EQ(0, cache.Read(buffer.data(), buffer.size()))
+      << "a source exhausted at its stated length did not read as end-of-file";
+
+  cache.Close();
+  writer.Close();
 }

--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -17,6 +17,7 @@
 #include "platform/win32/WIN32Util.h"
 
 #include <cassert>
+#include <mutex>
 #include <wchar.h>
 
 #include <Windows.h>
@@ -165,6 +166,46 @@ void CWin32File::Close()
   m_filepathnameW.clear();
 }
 
+#ifndef TARGET_WINDOWS_STORE
+namespace
+{
+// Publishes the reading thread for CancelSynchronousIo, the only call that ends a synchronous
+// read issued by another thread. The pseudo-handle from GetCurrentThread is duplicated because it
+// means the calling thread to whoever uses it.
+class CPublishedReadThread
+{
+public:
+  CPublishedReadThread(CCriticalSection& section, HANDLE& slot) : m_section(section), m_slot(slot)
+  {
+    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &m_thread,
+                         THREAD_TERMINATE, FALSE, 0))
+      m_thread = nullptr;
+
+    std::unique_lock lock(m_section);
+    m_slot = m_thread;
+  }
+
+  ~CPublishedReadThread()
+  {
+    {
+      std::unique_lock lock(m_section);
+      m_slot = nullptr;
+    }
+    if (m_thread)
+      CloseHandle(m_thread);
+  }
+
+  CPublishedReadThread(const CPublishedReadThread&) = delete;
+  CPublishedReadThread& operator=(const CPublishedReadThread&) = delete;
+
+private:
+  CCriticalSection& m_section;
+  HANDLE& m_slot;
+  HANDLE m_thread{nullptr};
+};
+} // unnamed namespace
+#endif
+
 ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
 {
   if (m_hFile == INVALID_HANDLE_VALUE)
@@ -173,6 +214,10 @@ ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
   assert(lpBuf != NULL || uiBufSize == 0);
   if (lpBuf == NULL && uiBufSize != 0)
     return -1;
+
+#ifndef TARGET_WINDOWS_STORE
+  const CPublishedReadThread published(m_readThreadSection, m_readThread);
+#endif
 
   if (uiBufSize == 0)
   { // allow "test" read with zero size
@@ -776,4 +821,24 @@ int CWin32File::GetChunkSize()
   }
 
   return 0;
+}
+
+int CWin32File::IoControl(IOControl request, void* param)
+{
+#ifndef TARGET_WINDOWS_STORE
+  if (request == IOControl::CANCEL_IO && m_hFile != INVALID_HANDLE_VALUE)
+  {
+    // The handle has no timeout, so a share that stops answering holds ReadFile until cancelled.
+    // The read then fails with ERROR_OPERATION_ABORTED.
+    std::unique_lock lock(m_readThreadSection);
+    if (m_readThread && !CancelSynchronousIo(m_readThread) && GetLastError() != ERROR_NOT_FOUND)
+    {
+      CLog::LogF(LOGERROR, "Failed to cancel the pending read, error {}", GetLastError());
+      return -1;
+    }
+    return 1;
+  }
+#endif
+
+  return IFile::IoControl(request, param);
 }

--- a/xbmc/platform/win32/filesystem/Win32File.h
+++ b/xbmc/platform/win32/filesystem/Win32File.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "filesystem/IFile.h"
+#include "threads/CriticalSection.h"
 
 #include <string>
 
@@ -41,6 +42,7 @@ namespace XFILE
     virtual int Stat(const CURL& url, struct __stat64* statData);
     virtual int Stat(struct __stat64* statData);
     virtual int GetChunkSize();
+    int IoControl(IOControl request, void* param) override;
 
   protected:
     explicit CWin32File(bool asSmbFile);
@@ -51,6 +53,8 @@ namespace XFILE
     std::wstring m_filepathnameW;
     const bool m_smbFile; // true for SMB file, false for local file
     unsigned long m_lastSMBFileErr; // used for SMB file operations
+    HANDLE m_readThread{nullptr}; // thread inside ReadFile, null when no read is outstanding
+    CCriticalSection m_readThreadSection; // guards m_readThread, never held across the read
   };
 
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. When a network share freezes mid-film for a minute, Kodi ends playback as if the film had finished; it now buffers, reconnects, and carries on from where it stopped.

Supersedes #29038.

## Description
An example, playing a film from a NAS whose connection freezes for 60 seconds at the 40 minute mark:

| | what happens today | with this change |
|---|---|---|
| 40:00 | The share stops answering. Kodi keeps playing from its cache. | Same. |
| 40:10 | The cache runs dry and reports "0 bytes read". Every caller in the chain takes 0 to mean end of file. | The cache reports an error instead. The demuxer treats it as a stall and waits. |
| 40:10 | Playback stops and Kodi returns to the library with a resume point at 40:10, as if the film had finished. | The frozen read is cancelled and the cache opens a fresh connection to the share, resuming at the byte it had reached. |
| 40:15 | | The fresh connection answers (the freeze was on the old connection only) and playback continues. |

The chain that turned a stall into "the film ended" was: `CFileCache::Read` returned 0 on starvation, `CDVDInputStreamFile` latched end of file on it, and the demuxer mapped it to `AVERROR_EOF`, which ends playback. Each of those now tells a stall apart from a real end:

| part | change |
|---|---|
| `CFileCache::Read` | starvation mid-file is an error, not 0; a dead source can no longer erase the known file size |
| `CDVDInputStreamFile` | end of file is latched only at the file's length |
| `CDVDDemuxFFmpeg` | waits out a stalled file input for up to two minutes; a clean end or a parse error still ends playback at once |
| `CFileCache` fill thread | reconnects a seekable source that fails mid-file and resumes at the byte it had reached |
| `IOControl::CANCEL_IO`, `CWin32File` | a read left unanswered for ten seconds is cancelled so the reconnect can start; Windows SMB reads otherwise wait for as long as the fault lasts |

The reconnect sits on #29133's source injection and failed-seek handling: a seek that arrives while a reconnect has failed reopens the source instead of failing every later read.

Related, and independent of this: #29287 sizes the cache by how many seconds of content it holds, and #29291 stops playback racing to catch up after a stall.

**Known simplification, left for a follow-up PR.** The Windows cancel works across two threads: the fill thread publishes when a read starts, the reading thread cancels it after ten seconds, and `CWin32File` records which thread is inside `ReadFile` so `CancelSynchronousIo` can reach it. A simpler shape is for `CWin32File` to open SMB files for overlapped I/O and give each read a timeout, so a frozen read fails by itself, the way HTTP does. That removes `CANCEL_IO` and the cross-thread code here, but it means tracking the file position by hand for every SMB read, so it is kept out of this fix.

## Motivation and context
Any network source that pauses for longer than the cache can cover ends the film early and silently. The fault was measured on a NAS whose individual TCP connections freeze for 60-70 seconds and then heal; a fresh connection carries the file within seconds.

## How has this been tested?
- `TestFileCache`: upstream's five seek tests; a source that stalls with most of the file still to come must not read as end of file, and one exhausted at its stated length must; a failed reconnect followed by a seek must recover; a property query held open across a reconnect must not have its source closed under it.
- `TestDVDDemuxFFmpeg`: an mp4 whose index ends before the physical file must still end promptly; a matroska fed by an input that blocks like a frozen share must survive the demuxer's read timer and resume real packets when the input answers.
- Full gtest suite green on Windows x64.
- Not yet validated end to end against the live NAS fault in this form.

## What is the effect on users?
A film played from a network share that stalls for up to a couple of minutes buffers and resumes where it paused, instead of ending partway through.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
