### PR TITLE
changed: size the file cache by how long it holds, not by how many bytes

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -14,7 +14,9 @@
 #include "URL.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "threads/Thread.h"
+#include "utils/MemUtils.h"
 #include "utils/log.h"
 
 #include <mutex>
@@ -125,6 +127,79 @@ IFile *CFileCache::GetFileImp()
   return m_source->GetImplementation();
 }
 
+std::unique_ptr<CCacheStrategy> CFileCache::CreateMemoryCache(size_t cacheSize)
+{
+  if (m_flags & READ_MULTI_STREAM)
+    CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> using double memory cache each sized {} bytes",
+              __FUNCTION__, m_sourcePath, cacheSize);
+  else
+    CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> using single memory cache sized {} bytes",
+              __FUNCTION__, m_sourcePath, cacheSize);
+
+  const size_t back = cacheSize / 4;
+  const size_t front = cacheSize - back;
+
+  std::unique_ptr<CCacheStrategy> cache = std::make_unique<CCircularCache>(front, back);
+
+  // NOTE: READ_MULTI_STREAM is only used with READ_AUDIO_VIDEO
+  if (m_flags & READ_MULTI_STREAM)
+  {
+    // If READ_MULTI_STREAM flag is set: Double buffering is required
+    cache = std::make_unique<CDoubleCache>(cache.release());
+  }
+
+  m_forwardCacheSize = front;
+  m_maxForward = m_forwardCacheSize;
+  m_memoryCacheSize = cacheSize;
+
+  return cache;
+}
+
+size_t CFileCache::CacheSizeForRate(uint32_t bytesPerSecond) const
+{
+  constexpr int64_t secondsForward = 60;
+
+  // Only three quarters of the cache is forward
+  const int64_t wanted = static_cast<int64_t>(bytesPerSecond) * secondsForward * 4 / 3;
+
+  // Bounded by installed memory, so the size does not depend on what is resident at the time
+  KODI::MEMORY::MemoryStatus memory{};
+  KODI::MEMORY::GetMemoryStatus(&memory);
+  int64_t budget = static_cast<int64_t>(memory.totalPhys / 16);
+  if (m_flags & READ_MULTI_STREAM)
+    budget /= 2;
+
+  return static_cast<size_t>(std::min(wanted, budget));
+}
+
+void CFileCache::GrowCacheForRate(uint32_t bytesPerSecond)
+{
+  // Rebuilding refetches the cached content, which needs a source that can seek back to it
+  if (!m_autoSizeCache || !m_seekPossible || bytesPerSecond == 0 || m_memoryCacheSize == 0 ||
+      !CThread::IsRunning())
+    return;
+
+  const size_t wanted = CacheSizeForRate(bytesPerSecond);
+  if (wanted <= m_memoryCacheSize)
+    return;
+
+  // Rebuilt by the fill thread at the read position, the way a seek rebuilds it
+  std::unique_lock lock(m_sync);
+
+  CLog::LogF(LOGINFO, "<{}> growing the cache from {} to {} bytes for {} bytes per second",
+             m_sourcePath, m_memoryCacheSize, wanted, bytesPerSecond);
+
+  m_pendingCacheSize = wanted;
+  m_seekPos = m_readPos;
+  m_seekEnded.Reset();
+  m_seekEvent.Set();
+  while (!m_seekEnded.Wait(100ms))
+  {
+    if (!CThread::IsRunning())
+      return;
+  }
+}
+
 bool CFileCache::Open(const CURL& url)
 {
   Close();
@@ -177,6 +252,12 @@ bool CFileCache::Open(const CURL& url)
       m_pCache = std::make_unique<CSimpleFileCache>();
       m_forwardCacheSize = 0;
       m_maxForward = m_fileSize;
+
+      if (m_flags & READ_MULTI_STREAM)
+      {
+        // If READ_MULTI_STREAM flag is set: Double buffering is required
+        m_pCache = std::make_unique<CDoubleCache>(m_pCache.release());
+      }
     }
     else
     {
@@ -207,25 +288,11 @@ bool CFileCache::Open(const CURL& url)
           cacheSize = m_chunkSize * 2;
       }
 
-      if (m_flags & READ_MULTI_STREAM)
-        CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> using double memory cache each sized {} bytes",
-                  __FUNCTION__, m_sourcePath, cacheSize);
-      else
-        CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> using single memory cache sized {} bytes",
-                  __FUNCTION__, m_sourcePath, cacheSize);
+      m_pCache = CreateMemoryCache(cacheSize);
 
-      const size_t back = cacheSize / 4;
-      const size_t front = cacheSize - back;
-
-      m_pCache = std::make_unique<CCircularCache>(front, back);
-      m_forwardCacheSize = front;
-      m_maxForward = m_forwardCacheSize;
-    }
-
-    if (m_flags & READ_MULTI_STREAM)
-    {
-      // If READ_MULTI_STREAM flag is set: Double buffering is required
-      m_pCache = std::make_unique<CDoubleCache>(m_pCache.release());
+      // A size the user chose is left as chosen
+      const auto sizeSetting = settings->GetSetting(CSettings::SETTING_FILECACHE_MEMORYSIZE);
+      m_autoSizeCache = sizeSetting && sizeSetting->IsDefault();
     }
   }
 
@@ -299,6 +366,20 @@ void CFileCache::Process()
     // check for seek events
     if (seekRequested)
     {
+      // Only safe here: the reader is held in Seek or GrowCacheForRate until the seek completes
+      if (m_pendingCacheSize)
+      {
+        m_pCache = CreateMemoryCache(m_pendingCacheSize);
+        m_pendingCacheSize = 0;
+        if (m_pCache->Open() != CACHE_RC_OK)
+        {
+          CLog::LogF(LOGERROR, "<{}> failed to open the grown cache", m_sourcePath);
+          m_pCache.reset();
+          m_seekEnded.Set();
+          break;
+        }
+      }
+
       const int64_t cacheMaxPos = m_pCache->CachedDataEndPosIfSeekTo(m_seekPos);
       const bool cacheReachEOF = (cacheMaxPos == m_fileSize);
 
@@ -746,6 +827,8 @@ int CFileCache::IoControl(IOControl request, void* param)
     CLog::Log(LOGDEBUG,
               "CFileCache::IoControl - setting maxRate to {:.2f} Mbit/s with processWait of {} ms",
               mBits, wait);
+
+    GrowCacheForRate(m_writeRate);
     return 0;
   }
 

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -90,6 +90,12 @@ public:
     CFileCache(unsigned int flags, std::unique_ptr<IFileCacheSource> source);
 
   private:
+    std::unique_ptr<CCacheStrategy> CreateMemoryCache(size_t cacheSize);
+    //! The per-buffer size holding a minute of content at the given rate, within a memory budget
+    size_t CacheSizeForRate(uint32_t bytesPerSecond) const;
+    //! Grows a default-sized memory cache once the content's rate is known
+    void GrowCacheForRate(uint32_t bytesPerSecond);
+
     std::unique_ptr<CCacheStrategy> m_pCache;
     int m_seekPossible = 0;
     std::unique_ptr<IFileCacheSource> m_source;
@@ -113,6 +119,9 @@ public:
     unsigned int m_flags;
     CCriticalSection m_sync;
     std::chrono::milliseconds m_processWait{100ms};
+    size_t m_memoryCacheSize = 0; // per buffer, 0 when caching to disk
+    size_t m_pendingCacheSize = 0; // size the fill thread rebuilds the cache at, 0 for none
+    bool m_autoSizeCache = false;
   };
 
 }

--- a/xbmc/filesystem/test/TestFileCache.cpp
+++ b/xbmc/filesystem/test/TestFileCache.cpp
@@ -6,9 +6,15 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/FileCache.h"
+#include "filesystem/IFileTypes.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "threads/Event.h"
+#include "utils/MemUtils.h"
 
 #if !defined(TARGET_WINDOWS)
 #include "platform/posix/ConvUtils.h"
@@ -151,6 +157,50 @@ private:
   CEvent m_seekEntered{true};
 };
 
+//! Serves a large file whose every byte is derived from its position
+class CPatternFileCacheSource : public IFileCacheSource
+{
+public:
+  explicit CPatternFileCacheSource(bool seekable) : m_seekable(seekable) {}
+
+  static unsigned char ByteAt(int64_t position)
+  {
+    return static_cast<unsigned char>(position % 251);
+  }
+
+  bool Open(const CURL& url, unsigned int flags) override
+  {
+    m_position = 0;
+    return true;
+  }
+  void Close() override {}
+  ssize_t Read(void* buffer, size_t size) override
+  {
+    for (size_t index = 0; index < size; ++index)
+      static_cast<unsigned char*>(buffer)[index] = ByteAt(m_position + index);
+    m_position += size;
+    return static_cast<ssize_t>(size);
+  }
+  int64_t Seek(int64_t position, int whence) override
+  {
+    if (!m_seekable)
+      return -1;
+    m_position = position;
+    return position;
+  }
+  int64_t GetLength() override { return int64_t{4} * 1024 * 1024 * 1024; }
+  int GetChunkSize() override { return 64 * 1024; }
+  int IoControl(IOControl request, void* param) override
+  {
+    return request == IOControl::SEEK_POSSIBLE && m_seekable ? 1 : 0;
+  }
+  IFile* GetImplementation() override { return nullptr; }
+
+private:
+  const bool m_seekable;
+  int64_t m_position{0};
+};
+
 class TestFileCache : public CFileCache
 {
 public:
@@ -170,6 +220,32 @@ SeekResult SeekWithError(CFileCache& cache, int64_t position)
 {
   const int64_t result = cache.Seek(position, SEEK_SET);
   return {result, GetLastError()};
+}
+
+bool ReadsPattern(CFileCache& cache, size_t count)
+{
+  std::vector<unsigned char> buffer(64 * 1024);
+  while (count > 0)
+  {
+    const int64_t position = cache.GetPosition();
+    const ssize_t read = cache.Read(buffer.data(), std::min(buffer.size(), count));
+    if (read <= 0)
+      return false;
+    for (ssize_t index = 0; index < read; ++index)
+    {
+      if (buffer[index] != CPatternFileCacheSource::ByteAt(position + index))
+        return false;
+    }
+    count -= read;
+  }
+  return true;
+}
+
+uint64_t ForwardCapacity(CFileCache& cache)
+{
+  SCacheStatus status{};
+  cache.IoControl(IOControl::CACHE_STATUS, &status);
+  return status.maxforward;
 }
 } // namespace
 
@@ -368,4 +444,65 @@ TEST(TestFileCache, ReadFailsPromptlyAfterQuarantinedCacheDrains)
   const auto [readResult, readError] = failedRead.get();
   EXPECT_EQ(-1, readResult);
   EXPECT_EQ(ECONNRESET, readError);
+}
+
+TEST(TestFileCache, DefaultSizedCacheGrowsToTheContentRate)
+{
+  // A minute at this rate is 90 MiB forward, past the 48 MiB a default cache holds
+  uint32_t rate = 1536 * 1024;
+  KODI::MEMORY::MemoryStatus memory{};
+  KODI::MEMORY::GetMemoryStatus(&memory);
+  if (memory.totalPhys / 16 < 128 * 1024 * 1024)
+    GTEST_SKIP() << "not enough installed memory for the cache to grow";
+
+  TestFileCache cache{READ_AUDIO_VIDEO, std::make_unique<CPatternFileCacheSource>(true)};
+  ASSERT_TRUE(cache.Open(CURL{"mock://server/movie.mkv"}));
+  const bool readsBefore = ReadsPattern(cache, 1024 * 1024);
+  const uint64_t capacityBefore = ForwardCapacity(cache);
+
+  cache.IoControl(IOControl::CACHE_SETRATE, &rate);
+  const uint64_t capacityAfter = ForwardCapacity(cache);
+  const bool readsAfter = ReadsPattern(cache, 1024 * 1024);
+  cache.Close();
+
+  EXPECT_TRUE(readsBefore);
+  EXPECT_GT(capacityAfter, capacityBefore);
+  EXPECT_TRUE(readsAfter);
+}
+
+TEST(TestFileCache, UserChosenCacheSizeIsKept)
+{
+  uint32_t rate = 1536 * 1024;
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  ASSERT_TRUE(settings->SetInt(CSettings::SETTING_FILECACHE_MEMORYSIZE, 96));
+
+  TestFileCache cache{READ_AUDIO_VIDEO, std::make_unique<CPatternFileCacheSource>(true)};
+  const bool opened = cache.Open(CURL{"mock://server/movie.mkv"});
+  const uint64_t capacityBefore = ForwardCapacity(cache);
+  cache.IoControl(IOControl::CACHE_SETRATE, &rate);
+  const uint64_t capacityAfter = ForwardCapacity(cache);
+  cache.Close();
+  settings->GetSetting(CSettings::SETTING_FILECACHE_MEMORYSIZE)->Reset();
+
+  ASSERT_TRUE(opened);
+  EXPECT_EQ(capacityBefore, capacityAfter);
+}
+
+TEST(TestFileCache, UnseekableSourceKeepsItsCache)
+{
+  uint32_t rate = 1536 * 1024;
+
+  TestFileCache cache{READ_AUDIO_VIDEO, std::make_unique<CPatternFileCacheSource>(false)};
+  ASSERT_TRUE(cache.Open(CURL{"mock://server/stream.ts"}));
+  const bool readsBefore = ReadsPattern(cache, 1024 * 1024);
+  const uint64_t capacityBefore = ForwardCapacity(cache);
+
+  cache.IoControl(IOControl::CACHE_SETRATE, &rate);
+  const uint64_t capacityAfter = ForwardCapacity(cache);
+  const bool readsAfter = ReadsPattern(cache, 1024 * 1024);
+  cache.Close();
+
+  EXPECT_TRUE(readsBefore);
+  EXPECT_EQ(capacityBefore, capacityAfter);
+  EXPECT_TRUE(readsAfter);
 }


### PR DESCRIPTION
**TL;DR:** Improvement. When the file cache size is left at its default, the memory cache grows to hold a minute of content at the file's measured rate, instead of a fixed 64 MB that covers only seconds of a high-bitrate file.

## Description
The default 64 MB memory cache holds 48 MB forward: under five seconds of an 80 Mbit/s UHD remux. `CVideoPlayer` already reports the content's byte rate to the cache through `CACHE_SETRATE` about a second into playback. With the size setting at its default, `CFileCache` now uses that rate to grow the memory cache to hold 60 seconds forward, bounded by a sixteenth of installed memory (half that per buffer when double buffered).

- A size the user chose is left as chosen.
- A source that cannot seek keeps its cache: the rebuild refetches what the cache held.
- The rebuild runs on the fill thread through the seek handler, with the reader held as a seek holds it, so it costs a refetch of the few chunks cached at that point.

Related to #29286, which handles a network source that freezes mid-file: this gives such a stall more content to play through, but neither change depends on the other.

## Motivation and context
A network share that pauses for a few seconds drains a byte-sized cache long before it drains a minute of content, and high-bitrate files are hit first.

## How has this been tested?
- `TestFileCache.DefaultSizedCacheGrowsToTheContentRate`: the forward capacity grows (48 MiB to 90 MiB at 1.5 MiB/s) and a position-derived byte pattern reads back intact across the rebuild.
- `TestFileCache.UserChosenCacheSizeIsKept`: a non-default size setting is not grown.
- `TestFileCache.UnseekableSourceKeepsItsCache`: a source that cannot seek is not rebuilt and keeps reading (written failing first: the rebuild's refetch seek failed and every later read failed).
- Full gtest suite green on Windows x64.
- Not yet measured in real playback.

## What is the effect on users?
With the default cache setting, high-bitrate video from a network source rides out longer network pauses; memory use during playback rises to up to a minute of content, capped at a sixteenth of installed memory.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
