### PR TITLE
added: gapless playback to UPnP renderers

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -409,6 +409,16 @@ public:
                                                                                    userdata);
   }
 
+  void OnSetNextAVTransportURIResult(NPT_Result res,
+                                     PLT_DeviceDataReference& device,
+                                     void* userdata) override
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
+    static_cast<PLT_MediaControllerDelegate*>(userdata)->OnSetNextAVTransportURIResult(res, device,
+                                                                                       userdata);
+  }
+
   void OnSeekResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
   {
     NPT_AutoLock lock(g_UserDataLock);

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -8,6 +8,7 @@
  */
 #include "UPnPPlayer.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "ThumbLoader.h"
 #include "UPnP.h"
@@ -28,6 +29,7 @@
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoThumbLoader.h"
 
+#include <atomic>
 #include <mutex>
 
 #include <Platinum/Source/Devices/MediaRenderer/PltMediaController.h>
@@ -44,6 +46,11 @@ NPT_SET_LOCAL_LOGGER("xbmc.upnp.player")
 
 namespace UPNP
 {
+
+namespace
+{
+constexpr std::chrono::milliseconds QUEUE_NEXT_LEAD = 10s;
+} // unnamed namespace
 
 class CUPnPPlayerController : public PLT_MediaControllerDelegate
 {
@@ -77,8 +84,7 @@ public:
   {
     if (NPT_FAILED(res))
       m_logger->error("OnSetNextAVTransportURIResult failed");
-    m_resstatus = res;
-    m_resevent.Set();
+    m_nextRefused = NPT_FAILED(res);
   }
 
   void OnPlayResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
@@ -156,6 +162,12 @@ public:
     m_posevnt.Set();
   }
 
+  PLT_PositionInfo GetPosition() const
+  {
+    std::unique_lock lock(m_section);
+    return m_posinfo;
+  }
+
   ~CUPnPPlayerController() override = default;
 
   PLT_MediaController* m_control;
@@ -166,6 +178,8 @@ public:
 
   NPT_Result m_resstatus;
   CEvent m_resevent;
+
+  std::atomic<bool> m_nextRefused{false};
 
   unsigned int m_postime = 0;
 
@@ -365,6 +379,11 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_setavtransporturi);
   NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_setavtransporturi);
 
+  {
+    std::unique_lock lock(m_queueSection);
+    m_trackUri = uri;
+  }
+
   timeout.Set(timeout.GetInitialTimeoutValue());
   NPT_CHECK_LABEL_SEVERE(
       m_control->Play(m_delegate->m_device, m_delegate->m_instance, "1", m_delegate.get()),
@@ -434,6 +453,13 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   XbmcThreads::EndTime<> timeout(10s);
 
   m_started = false;
+  {
+    std::unique_lock lock(m_queueSection);
+    m_trackUri.clear();
+    m_queuedUri.clear();
+    m_queued.reset();
+    m_nextRequested = false;
+  }
 
   /* if no path we want to attach to a already playing player */
   if (file.GetPath().empty())
@@ -453,6 +479,12 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   }
   else
     NPT_CHECK_LABEL_SEVERE(PlayFile(file, options, timeout), failed);
+
+  {
+    const bool canQueueNext = m_control->CanSetNextAVTransportURI(m_delegate->m_device);
+    std::unique_lock lock(m_queueSection);
+    m_canQueueNext = canQueueNext;
+  }
 
   if (!IsRunning())
     Create();
@@ -491,13 +523,26 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
   if (!BuildResource(file, uri, metadata))
     goto failed;
 
+  {
+    // Moving to the URI already playing changes nothing the renderer reports, so it could not be
+    // followed. The file opens the ordinary way once this one ends.
+    std::unique_lock lock(m_queueSection);
+    if (uri == m_trackUri)
+      return true;
+  }
+
+  // Not waited on: this runs on the application thread, and a refusal only means the next file is
+  // opened the ordinary way once this one ends.
+  m_delegate->m_nextRefused = false;
   NPT_CHECK_LABEL_WARNING(m_control->SetNextAVTransportURI(m_delegate->m_device,
                                                            m_delegate->m_instance, uri.c_str(),
                                                            metadata.c_str(), m_delegate.get()),
                           failed);
-  if (!m_delegate->m_resevent.Wait(10000ms))
-    goto failed;
-  NPT_CHECK_LABEL_WARNING(m_delegate->m_resstatus, failed);
+  {
+    std::unique_lock lock(m_queueSection);
+    m_queuedUri = uri;
+    m_queued = std::make_unique<CFileItem>(file);
+  }
   return true;
 
 failed:
@@ -588,6 +633,50 @@ void CUPnPPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }
 
+void CUPnPPlayer::FollowQueue()
+{
+  const PLT_PositionInfo position = m_delegate->GetPosition();
+  const std::string reported = position.track_uri.GetChars();
+  std::unique_ptr<CFileItem> started;
+  bool request = false;
+
+  {
+    std::unique_lock lock(m_queueSection);
+    if (m_queued && m_delegate->m_nextRefused)
+    {
+      m_logger->warn("renderer refused {}; it opens when this file ends", m_queued->GetPath());
+      m_queued.reset();
+    }
+    else if (m_queued && reported == m_queuedUri)
+    {
+      started = std::move(m_queued);
+      m_trackUri = m_queuedUri;
+      m_nextRequested = false;
+    }
+    // The renderer echoing the URI it was given is what lets the move to the next one be seen.
+    else if (m_canQueueNext && !m_nextRequested && !m_trackUri.empty() && reported == m_trackUri)
+    {
+      const int64_t duration = position.track_duration.ToMillis();
+      const int64_t remaining = duration - position.rel_time.ToMillis();
+      if (duration > 0 && remaining <= QUEUE_NEXT_LEAD.count())
+      {
+        m_nextRequested = true;
+        request = true;
+      }
+    }
+  }
+
+  if (started)
+  {
+    m_hasVideo = VIDEO::IsVideo(*started);
+    m_hasAudio = !m_hasVideo && MUSIC::IsAudio(*started);
+    m_callback.OnPlayBackStarted(*started);
+    m_callback.OnAVStarted(*started);
+  }
+  else if (request)
+    m_callback.OnQueueNextItem();
+}
+
 void CUPnPPlayer::Process()
 {
   while (!m_bStop)
@@ -601,6 +690,7 @@ void CUPnPPlayer::Process()
       CDataCacheCore& dataCacheCore = CDataCacheCore::GetInstance();
       if (m_updateTimer.IsTimePast())
       {
+        FollowQueue();
         dataCacheCore.SetPlayTimes(0, GetTime(), 0, GetTotalTime());
         m_updateTimer.Set(500ms);
       }

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -71,6 +71,16 @@ public:
     m_resevent.Set();
   }
 
+  void OnSetNextAVTransportURIResult(NPT_Result res,
+                                     PLT_DeviceDataReference& device,
+                                     void* userdata) override
+  {
+    if (NPT_FAILED(res))
+      m_logger->error("OnSetNextAVTransportURIResult failed");
+    m_resstatus = res;
+    m_resevent.Set();
+  }
+
   void OnPlayResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
   {
     if (NPT_FAILED(res))
@@ -204,31 +214,28 @@ static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime<>& timeout)
   return NPT_SUCCESS;
 }
 
-int CUPnPPlayer::PlayFile(const CFileItem& file,
-                          const CPlayerOptions& options,
-                          XbmcThreads::EndTime<>& timeout)
+bool CUPnPPlayer::BuildResource(const CFileItem& file, std::string& uri, std::string& metadata)
 {
   CFileItem item(file);
   NPT_Reference<CThumbLoader> thumb_loader;
-  NPT_Reference<PLT_MediaObject> obj;
   NPT_String path(file.GetPath().c_str());
-  NPT_String tmp, resource;
-  EMediaControllerQuirks quirks = EMEDIACONTROLLERQUIRKS_NONE;
-
-  NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
 
   if (VIDEO::IsVideoDb(file))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
   else if (MUSIC::IsMusicDb(item))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
-  obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
+  NPT_Reference<PLT_MediaObject> obj(
+      BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer));
   if (obj.IsNull())
-    goto failed;
+  {
+    m_logger->error("BuildResource({}) failed to describe the item", file.GetPath());
+    return false;
+  }
 
   // One resource is built per local address. Put the ones on the address that routes to the
   // renderer first: connecting a UDP socket sends nothing, it only makes the kernel pick that
-  // address. Scoped so the goto below does not cross the declarations.
+  // address.
   {
     const NPT_HttpUrl& rendererUrl = m_delegate->m_device->GetURLBase();
     NPT_IpAddress rendererAddress;
@@ -254,18 +261,22 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
     }
   }
 
-  NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed_todidl);
-  tmp.Insert(didl_header, 0);
-  tmp.Append(didl_footer);
+  NPT_String didl;
+  if (NPT_FAILED(PLT_Didl::ToDidl(*obj, "", didl)))
+  {
+    m_logger->error("BuildResource({}) failed to serialize item into DIDL-Lite", file.GetPath());
+    return false;
+  }
+  didl.Insert(didl_header, 0);
+  didl.Append(didl_footer);
 
-  quirks = GetMediaControllerQuirks(m_delegate->m_device.AsPointer());
-  if (quirks & EMEDIACONTROLLERQUIRKS_X_MKV)
+  if (GetMediaControllerQuirks(m_delegate->m_device.AsPointer()) & EMEDIACONTROLLERQUIRKS_X_MKV)
   {
     for (NPT_Cardinal i = 0; i < obj->m_Resources.GetItemCount(); i++)
     {
       if (obj->m_Resources[i].m_ProtocolInfo.GetContentType().Compare("video/x-matroska") == 0)
       {
-        m_logger->debug("PlayFile({}): applying video/x-mkv quirk", file.GetPath());
+        m_logger->debug("BuildResource({}): applying video/x-mkv quirk", file.GetPath());
         NPT_String protocolInfo = obj->m_Resources[i].m_ProtocolInfo.ToString();
         protocolInfo.Replace(":video/x-matroska:", ":video/x-mkv:");
         obj->m_Resources[i].m_ProtocolInfo = PLT_ProtocolInfo(protocolInfo);
@@ -285,13 +296,31 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
         sinks.GetItemCount() > 0 && !(*sinks.GetFirstItem()).IsEmpty();
 
     if (advertised || obj->m_Resources.GetItemCount() == 0)
-      goto failed_findbestresource;
+    {
+      m_logger->error("BuildResource({}) failed to find a matching resource", file.GetPath());
+      return false;
+    }
 
     res_index = 0;
-    m_logger->warn("PlayFile({}): {} advertises no protocolInfo, offering '{}' unmatched",
+    m_logger->warn("BuildResource({}): {} advertises no protocolInfo, offering '{}' unmatched",
                    file.GetPath(), m_delegate->m_device->GetFriendlyName().GetChars(),
                    obj->m_Resources[res_index].m_ProtocolInfo.ToString().GetChars());
   }
+
+  uri = obj->m_Resources[res_index].m_Uri.GetChars();
+  metadata = didl.GetChars();
+  return true;
+}
+
+int CUPnPPlayer::PlayFile(const CFileItem& file,
+                          const CPlayerOptions& options,
+                          XbmcThreads::EndTime<>& timeout)
+{
+  std::string uri, metadata;
+
+  NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
+  if (!BuildResource(file, uri, metadata))
+    goto failed;
 
   // get the transport info to evaluate the TransportState to be able to
   // determine whether we first need to call Stop()
@@ -330,8 +359,8 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
 
   timeout.Set(timeout.GetInitialTimeoutValue());
   NPT_CHECK_LABEL_SEVERE(m_control->SetAVTransportURI(m_delegate->m_device, m_delegate->m_instance,
-                                                      obj->m_Resources[res_index].m_Uri,
-                                                      (const char*)tmp, m_delegate.get()),
+                                                      uri.c_str(), metadata.c_str(),
+                                                      m_delegate.get()),
                          failed_setavtransporturi);
   NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_setavtransporturi);
   NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_setavtransporturi);
@@ -377,12 +406,6 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   }
 
   return NPT_SUCCESS;
-failed_todidl:
-  m_logger->error("PlayFile({}) failed to serialize item into DIDL-Lite", file.GetPath());
-  return NPT_FAILURE;
-failed_findbestresource:
-  m_logger->error("PlayFile({}) failed to find a matching resource", file.GetPath());
-  return NPT_FAILURE;
 failed_gettransportinfo:
   m_logger->error("PlayFile({}): call to GetTransportInfo failed", file.GetPath());
   return NPT_FAILURE;
@@ -462,29 +485,16 @@ failed:
 
 bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
 {
-  CFileItem item(file);
-  NPT_Reference<CThumbLoader> thumb_loader;
-  NPT_Reference<PLT_MediaObject> obj;
-  NPT_String path(file.GetPath().c_str());
-  NPT_String tmp;
+  std::string uri, metadata;
 
-  if (VIDEO::IsVideoDb(file))
-    thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-  else if (MUSIC::IsMusicDb(item))
-    thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
+  NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
+  if (!BuildResource(file, uri, metadata))
+    goto failed;
 
-  obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
-  if (!obj.IsNull())
-  {
-    NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed);
-    tmp.Insert(didl_header, 0);
-    tmp.Append(didl_footer);
-  }
-
-  NPT_CHECK_LABEL_WARNING(
-      m_control->SetNextAVTransportURI(m_delegate->m_device, m_delegate->m_instance,
-                                       file.GetPath().c_str(), (const char*)tmp, m_delegate.get()),
-      failed);
+  NPT_CHECK_LABEL_WARNING(m_control->SetNextAVTransportURI(m_delegate->m_device,
+                                                           m_delegate->m_instance, uri.c_str(),
+                                                           metadata.c_str(), m_delegate.get()),
+                          failed);
   if (!m_delegate->m_resevent.Wait(10000ms))
     goto failed;
   NPT_CHECK_LABEL_WARNING(m_delegate->m_resstatus, failed);

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -55,6 +55,7 @@ public:
                XbmcThreads::EndTime<>& timeout);
 
 private:
+  bool BuildResource(const CFileItem& file, std::string& uri, std::string& metadata);
   bool IsPaused() const;
   int64_t GetTime();
   int64_t GetTotalTime();

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "cores/IPlayer.h"
+#include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/logtypes.h"
@@ -56,6 +57,7 @@ public:
 
 private:
   bool BuildResource(const CFileItem& file, std::string& uri, std::string& metadata);
+  void FollowQueue();
   bool IsPaused() const;
   int64_t GetTime();
   int64_t GetTotalTime();
@@ -72,6 +74,13 @@ private:
   bool m_hasVideo{false};
   bool m_hasAudio{false};
   XbmcThreads::EndTime<> m_updateTimer;
+
+  CCriticalSection m_queueSection;
+  bool m_canQueueNext{false};
+  std::string m_trackUri;
+  std::string m_queuedUri;
+  std::unique_ptr<CFileItem> m_queued;
+  bool m_nextRequested{false};
 
   Logger m_logger;
 };


### PR DESCRIPTION
**TL;DR:** New feature. A playlist played to a UPnP renderer stops and reopens between every track; a renderer that implements `SetNextAVTransportURI` is now handed the next track while the current one plays, and moves to it by itself.

## Description
Two commits.

### `fixed: queue a renderer's next file the way the current one is played`
`CUPnPPlayer::QueueNextFile()` could never succeed:

- The media controller in `UPnP.cpp` forwards the result callbacks to the delegate its userdata names, but not `OnSetNextAVTransportURIResult`, whose base implementation is empty. The reply reached nothing and the ten-second wait always ran out. The forwarding override is added alongside the others.
- The request offered the renderer the item's own path (`smb://`, a library path) rather than a URL served by Kodi's UPnP server, and did not pick a resource the renderer can play. What `PlayFile()` builds for the renderer (the served URL on the address that reaches it, the DIDL-Lite metadata, the resource matching its protocolInfo) moves into `BuildResource()`, which `QueueNextFile()` now uses too.

Nothing called `QueueNextFile()` on this player, which is why neither was noticed.

### `added: gapless playback to UPnP renderers`
`CUPnPPlayer` never raised `OnQueueNextItem`, so the application never queued anything on it. It now does, ten seconds before the end of a track.

- The request is only made once the renderer has reported the current track's URI exactly as it was given. That echo is what lets the move to the next track be recognised.
- `QueueNextFile()` hands the renderer the next resource and returns without waiting for the reply, since it runs on the application thread.
- When the renderer reports the queued URI, the player raises `OnPlayBackStarted` / `OnAVStarted` for the queued item, which moves the playlist on as it does for PAPlayer.
- A renderer that refuses the request loses nothing: the queued item is dropped, the track ends as before, and the next item opens the ordinary way.
- Nothing is queued on a renderer without `SetNextAVTransportURI`, when attaching to playback Kodi did not start, while the track's length is unknown, or when the next item is the URI already playing (repeat-one, or the same file twice), since moving to it changes nothing the renderer reports. Those open the ordinary way.

## Motivation and context
The `QueueNextFile()` reply fix was part of #29219; it moves here, next to the feature that calls it. Both PRs touch `CUPnPPlayerController`, so whichever lands second needs a manual rebase.

## How has this been tested?
Against a mock MediaRenderer implementing `SetNextAVTransportURI`, with 15-second tracks that advance to the queued URI by themselves, driving a three-track directory with `Player.Open` and `playername`:

- Gapless: one `SetAVTransportURI` and two `SetNextAVTransportURI`, each sent 5.5 s into its track. `Player.OnPlay` fired at each change, within a second of the renderer moving; there was no `Player.OnStop` between tracks and one at the end; `Player.GetProperties` read position 0, 1, 2.
- Renderer refusing `SetNextAVTransportURI`: each refusal was logged, each track then ended and the next opened with `SetAVTransportURI`, with none skipped.
- Repeat-one: one `Player.OnPlay`, then the track reopened with `SetAVTransportURI` when it ended, and no `SetNextAVTransportURI`. Before this was handled, the same URI was queued six times within one track and eight `Player.OnPlay` were announced.

Full gtest suite passes. clang-format clean on the changed lines. Not yet tried against real hardware.

## What is the effect on users?
Music played to a UPnP renderer that supports `SetNextAVTransportURI` plays track to track without a stop between them.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
