### PR TITLE
fixed: stop the UPnP player thread spinning, and keep polling while Kodi is minimised

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -23,7 +23,6 @@
 #include "settings/SettingsComponent.h"
 #include "threads/Event.h"
 #include "utils/StringUtils.h"
-#include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoThumbLoader.h"
@@ -120,12 +119,21 @@ public:
 
   void UpdatePositionInfo()
   {
-    if (m_postime == 0 || m_postime > CTimeUtils::GetFrameTime())
-      return;
+    {
+      std::unique_lock lock(m_section);
+      if (m_pollOutstanding || !m_nextPoll.IsTimePast())
+        return;
+      // Set before sending, because the reply that clears it can arrive before these return.
+      m_pollOutstanding = true;
+    }
 
     m_control->GetTransportInfo(m_device, m_instance, this);
-    m_control->GetPositionInfo(m_device, m_instance, this);
-    m_postime = 0;
+    if (NPT_FAILED(m_control->GetPositionInfo(m_device, m_instance, this)))
+    {
+      std::unique_lock lock(m_section);
+      m_pollOutstanding = false;
+      m_nextPoll.Set(500ms);
+    }
   }
 
   void OnGetPositionInfoResult(NPT_Result res,
@@ -142,7 +150,8 @@ public:
     }
     else
       m_posinfo = *info;
-    m_postime = CTimeUtils::GetFrameTime() + 500;
+    m_pollOutstanding = false;
+    m_nextPoll.Set(500ms);
     m_posevnt.Set();
   }
 
@@ -157,8 +166,6 @@ public:
   NPT_Result m_resstatus;
   CEvent m_resevent;
 
-  unsigned int m_postime = 0;
-
   CEvent m_posevnt;
   PLT_PositionInfo m_posinfo;
 
@@ -167,6 +174,9 @@ public:
 
 private:
   mutable CCriticalSection m_section;
+  // Polling starts with the first position reply, which OpenFile asks for.
+  bool m_pollOutstanding = true;
+  XbmcThreads::EndTime<> m_nextPoll;
   Logger m_logger;
 };
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -624,6 +624,8 @@ void CUPnPPlayer::Process()
         m_callback.OnPlayBackEnded();
       }
     }
+
+    CThread::Sleep(100ms);
   }
 failed:
   CloseFile();


### PR DESCRIPTION
**TL;DR:** Bug fix. `CUPnPPlayer`'s thread spins at a full core for as long as anything plays to a renderer, and its renderer poll stops whenever Kodi is minimised, so a playlist on a renderer never moves past the current track. The poll gets its own clock and the loop sleeps between passes.

## Description
Two commits.

### `fixed: keep polling a UPnP renderer while the GUI is not rendering`
The player thread polls the renderer's transport and position every half second, and that poll is what notices the end of a track. It was timed with `CTimeUtils::GetFrameTime()`, which only advances when `CApplication::Render()` runs. While Kodi is minimised the GUI is not rendered, so the poll stopped, the playback time froze and the end of the track went unnoticed.

The schedule could also stop for good. A poll marked itself outstanding by clearing `m_postime` *after* sending, but Platinum sends from its own threads, so a reply that arrived before the player thread reached that line was overwritten and nothing was left outstanding to set it again.

The poll is now timed with its own `EndTime` and marked outstanding before it is sent, under the lock its reply takes. A poll that cannot be sent is retried after the same interval instead of waited on.

### `fixed: stop the UPnP player thread spinning`
`CUPnPPlayer::Process()` looped without ever waiting. Nothing in the loop needs to run more often than the half-second poll, so it now sleeps 100 ms per pass. `CThread::Sleep` waits on the stop event, so closing is not delayed.

The order matters: the spinning loop happened to keep the thread on-CPU through the window the lost update needs, and a sleep alone makes that stall frequent.

## Motivation and context
The loop has spun since a07a44c23e ("[UPnP] Move player to its own thread"), so Omega has it too.

## How has this been tested?
Against a mock MediaRenderer with 15-second tracks, playing a three-track directory with `Player.Open` and `playername`, measuring CPU per thread and logging every request the renderer received:

- **Upstream:** the player thread used 0.98 CPU-seconds per second while playing, against 0.03 for the whole process idle. Minimised for 19 s, Kodi sent the renderer nothing, and the track that ended meanwhile was only noticed on restore.
- **Sleep without the poll fix:** the poll stopped in 2 of 4 runs, in one of them 1.7 s after playback started and for the rest of the run, with the renderer answering every request.
- **Both commits:** no thread above 0.04 CPU-seconds per second while playing, every track end detected across three runs, and the gap between polls never above 0.6 s (one 2.1 s gap was a request the renderer received late). Minimised for 23 s, Kodi kept polling and opened the next track 11 s before the window was restored.

Full gtest suite passes. clang-format clean on the changed lines.

## What is the effect on users?
Playing to a UPnP renderer no longer keeps a CPU core busy, and a playlist on a renderer keeps advancing while Kodi is minimised.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
