### PR TITLE
fixed: tell a UPnP renderer to stop once, and close even when it does not answer

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -497,14 +497,18 @@ failed:
 
 bool CUPnPPlayer::CloseFile(bool reopen)
 {
-  NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
-  if (m_stopremote)
+  bool stopped = true;
+
+  // Also reached from the player thread's exit and the destructor; the renderer is told once.
+  if (m_delegate && m_stopremote.exchange(false))
   {
-    NPT_CHECK_LABEL(m_control->Stop(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-                    failed);
-    if (!m_delegate->m_resevent.Wait(10000ms))
-      goto failed;
-    NPT_CHECK_LABEL(m_delegate->m_resstatus, failed);
+    if (NPT_FAILED(
+            m_control->Stop(m_delegate->m_device, m_delegate->m_instance, m_delegate.get())) ||
+        !m_delegate->m_resevent.Wait(10000ms) || NPT_FAILED(m_delegate->m_resstatus))
+    {
+      m_logger->error("CloseFile - unable to stop playback");
+      stopped = false;
+    }
   }
 
   if (m_started)
@@ -515,11 +519,7 @@ bool CUPnPPlayer::CloseFile(bool reopen)
 
   StopThread(true);
   CServiceBroker::GetDataCacheCore().Reset();
-  return true;
-failed:
-  m_logger->error("CloseFile - unable to stop playback");
-  CServiceBroker::GetDataCacheCore().Reset();
-  return false;
+  return stopped;
 }
 
 void CUPnPPlayer::Pause()

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -14,6 +14,7 @@
 #include "threads/Thread.h"
 #include "utils/logtypes.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -67,7 +68,7 @@ private:
   PLT_MediaController* m_control = nullptr;
   std::unique_ptr<CUPnPPlayerController> m_delegate;
   bool m_started = false;
-  bool m_stopremote = false;
+  std::atomic<bool> m_stopremote{false};
   bool m_hasVideo{false};
   bool m_hasAudio{false};
   XbmcThreads::EndTime<> m_updateTimer;


### PR DESCRIPTION
**TL;DR:** Bug fix. Stopping playback on a UPnP renderer sends it `Stop` three times, and when the renderer does not answer, Kodi never reports playback stopped and holds the application thread for over a minute. The renderer is told once, and the player closes whether or not it answers.

## Description
`CUPnPPlayer::CloseFile()` is called by the application, again as the player thread exits (`Process()` falls through to `CloseFile()`), and again from the destructor. `m_stopremote` stayed set through all three, so each sent `Stop` and waited up to ten seconds for its reply.

When the renderer did not answer, `CloseFile()` gave up after that wait through its `failed:` label, which skipped reporting playback stopped and ending the player thread, so the next caller tried again.

The renderer is now told once per opened file, by exchanging `m_stopremote` before sending, and the player closes whether or not it answers: a failed `Stop` is logged and returned, and playback is still reported stopped and the thread ended.

## Motivation and context
Found while measuring the player thread for #29289.

## How has this been tested?
Against a mock MediaRenderer, opening a file with `Player.Open` and `playername`, then `Player.Stop` after five seconds:

- **Renderer answers:** without this change the renderer receives three `Stop` requests within 2 ms; with it, one. `Player.OnStop` arrives at once either way.
- **Renderer accepts `Stop` and never answers:** without this change the renderer receives `Stop` at 0 s, 10 s and 60 s, and no `Player.OnStop` arrives within 60 s. With it, one `Stop`, and `Player.OnStop` arrives after the single ten-second wait.

Full gtest suite passes. clang-format clean on the changed lines.

## What is the effect on users?
Stopping playback on a UPnP renderer that has stopped responding no longer leaves Kodi unresponsive for over a minute.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
