### PR TITLE
fixed: playback racing to catch up after a read blocks

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2208,7 +2208,15 @@ void CVideoPlayer::HandlePlaySpeed()
           if (m_VideoPlayerAudio->GetLevel() <= 50 &&
               m_processInfo->GetLevelVQ() <= 50)
           {
-            SetCaching(CACHESTATE_FULL);
+            // Re-sync the clock to the stream instead of playing its lead off at speed
+            const double streamAt =
+                m_CurrentVideo.dts != DVD_NOPTS_VALUE ? m_CurrentVideo.dts : m_CurrentAudio.dts;
+            CLog::Log(LOGINFO,
+                      "CVideoPlayer::HandlePlaySpeed - streams ran dry {:.1f} s behind "
+                      "the clock, re-syncing",
+                      streamAt != DVD_NOPTS_VALUE ? (m_clock.GetClock() - streamAt) / DVD_TIME_BASE
+                                                  : 0.0);
+            FlushBuffers(DVD_NOPTS_VALUE, false, true);
           }
           else if (m_CurrentAudio.id >= 0 && m_CurrentAudio.inited &&
                    m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_INSYNC &&


### PR DESCRIPTION
**TL;DR:** Bug fix. When a read blocks mid-film, playback freezes and then races through the next stretch at speed to catch up; it now re-syncs and carries on at normal speed from where it stopped.

## Description
`CVideoPlayer::Process` reads from the demuxer and runs the "have the players run dry?" check in the same loop, on the same thread. While a read is blocked, that check cannot run, so nothing pauses the clock.

An example, with a network share that stops answering for 20 seconds:

| time | what happens today |
|---|---|
| 0 s | The read blocks. The players finish what they have queued and stop. The clock keeps running. |
| 20 s | The read returns. The player now notices the streams ran dry and starts caching, but the clock is already ~20 s ahead of the content. |
| 20 s + | Data flows again. Audio and video are handed content that is behind the clock, so they race through it: audio is resampled or dropped, frames are skipped, until the clock is caught up. |

What the viewer sees is a freeze followed by a burst of fast playback, instead of a buffering pause. Measured against a NAS share that stopped answering, ActiveAE reported a 25 second sync error at the point it adjusted.

With this change the non-realtime underrun branch flushes the players instead of only caching, exactly as the realtime branch a few lines above already does when the players cannot take data. The streams go back through their startup sync, which sets the clock from the stream it resumes on. The lead is discarded rather than played off:

| time | with this change |
|---|---|
| 0 s | The read blocks. The players stop. |
| 20 s | The read returns, the player sees the streams ran dry, and flushes. |
| 20 s + | Buffering, then playback resumes at normal speed from where it stopped. |

A flush drops whatever the players still hold. When this branch runs, at least one player has already run out and neither is more than half full, so at most a moment of the other stream is lost.

## Motivation and context
Nothing about this is specific to one kind of source. Any read that blocks the player thread for a few seconds produces the same freeze-then-race:

- an SMB or NFS share that stops answering and then recovers
- an HTTP server that stops sending mid-file and then resumes
- a local or USB disk that has spun down

A few seconds of drift is barely noticeable; tens of seconds is a long, audible stretch of fast playback. It is independent of #29286, which stops a stalled network source from ending playback altogether and makes the demuxer report a stall sooner. That shortens the lead; this change handles whatever lead there is, from any source.

## How has this been tested?
- Builds on Windows x64; full gtest suite green.
- `HandlePlaySpeed` needs a running player and has no unit test coverage; none is added here.
- Not yet validated in playback in this form: the 25 second figure above is the problem being fixed, measured before the change.

## What is the effect on users?
After a source stalls mid-film, playback buffers and resumes at normal speed instead of racing through the next stretch to catch up.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
