### PR TITLE
Add option to disable writing kodi.log to disk

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25682,3 +25682,15 @@ msgstr ""
 msgctxt "#40804"
 msgid "{0:.1f} dB"
 msgstr ""
+
+#. Label of setting "Write log file to disk"
+#: system/settings/settings.xml
+msgctxt "#40805"
+msgid "Write log file to disk"
+msgstr ""
+
+#. Description of setting with label #40805 "Write log file to disk"
+#: system/settings/settings.xml
+msgctxt "#40806"
+msgid "If enabled, log messages are written to the kodi.log file. If disabled, no log file is written, but logging to other outputs (such as the debugger or the system log) is unaffected and unrelated logging settings, such as component-specific and debug logging, continue to apply to those outputs."
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3894,6 +3894,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="debug.enablefilelogging" type="boolean" label="40805" help="40806">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="debug.extralogging" type="boolean" label="666" help="36394">
           <level>1</level>
           <default>false</default>

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -453,6 +453,7 @@ public:
   static constexpr auto SETTING_POWERMANAGEMENT_WAITFORNETWORK = "powermanagement.waitfornetwork";
   static constexpr auto SETTING_POWERMANAGEMENT_RESTARTPLAYER = "powermanagement.restartplayer";
   static constexpr auto SETTING_DEBUG_SHOWLOGINFO = "debug.showloginfo";
+  static constexpr auto SETTING_DEBUG_ENABLEFILELOGGING = "debug.enablefilelogging";
   static constexpr auto SETTING_DEBUG_EXTRALOGGING = "debug.extralogging";
   static constexpr auto SETTING_DEBUG_SETEXTRALOGLEVEL = "debug.setextraloglevel";
   static constexpr auto SETTING_DEBUG_SCREENSHOTPATH = "debug.screenshotpath";

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -11,6 +11,8 @@
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "profiles/ProfileManager.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/SettingUtils.h"
@@ -22,6 +24,7 @@
 #include "utils/Map.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML.h"
 
 #include <cstring>
 #include <set>
@@ -115,6 +118,7 @@ void CLog::OnSettingsLoaded()
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   m_componentLogEnabled = settings->GetBool(CSettings::SETTING_DEBUG_EXTRALOGGING);
   SetComponentLogLevel(settings->GetList(CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL));
+  SetFileLoggingEnabled(settings->GetBool(CSettings::SETTING_DEBUG_ENABLEFILELOGGING));
 }
 
 void CLog::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
@@ -128,6 +132,8 @@ void CLog::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
   else if (settingId == CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL)
     SetComponentLogLevel(
         CSettingUtils::GetList(std::static_pointer_cast<const CSettingList>(setting)));
+  else if (settingId == CSettings::SETTING_DEBUG_ENABLEFILELOGGING)
+    SetFileLoggingEnabled(std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
 }
 
 void CLog::Initialize(const std::string& path) 
@@ -141,16 +147,45 @@ void CLog::Initialize(const std::string& path)
   settingsManager->RegisterSettingOptionsFiller("loggingcomponents",
                                                 SettingOptionsLoggingComponentsFiller);
   settingsManager->RegisterSettingsHandler(this);
-  settingsManager->RegisterCallback(
-      this, {CSettings::SETTING_DEBUG_EXTRALOGGING, CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL});
+  settingsManager->RegisterCallback(this, {CSettings::SETTING_DEBUG_EXTRALOGGING,
+                                           CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL,
+                                           CSettings::SETTING_DEBUG_ENABLEFILELOGGING});
 
   if (path.empty())
+    return;
+
+  m_logDirectory = path;
+
+  // settings aren't loaded yet at this point, so peek the persisted value directly
+  m_fileLoggingEnabled = ReadPersistedFileLoggingSetting();
+
+  if (m_fileLoggingEnabled)
+    CreateFileSink();
+}
+
+bool CLog::ReadPersistedFileLoggingSetting() const
+{
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  const auto settings = settingsComponent->GetSettings();
+
+  // merge just the one persisted value, as CProfileManager does when switching profiles
+  CXBMCTinyXML doc;
+  if (doc.LoadFile(
+          CSpecialProtocol::TranslatePath(settingsComponent->GetProfileManager()->GetSettingsFile())))
+    settings->LoadSetting(doc.RootElement(), CSettings::SETTING_DEBUG_ENABLEFILELOGGING);
+
+  return settings->GetBool(CSettings::SETTING_DEBUG_ENABLEFILELOGGING);
+}
+
+void CLog::CreateFileSink()
+{
+  if (m_logDirectory.empty())
     return;
 
   // put together the path to the log file(s)
   std::string appName = CCompileInfo::GetAppName();
   StringUtils::ToLower(appName);
-  const std::string filePathBase = URIUtils::AddFileToFolder(path, appName);
+  const std::string filePathBase = URIUtils::AddFileToFolder(m_logDirectory, appName);
   const std::string filePath = filePathBase + LogFileExtension;
   const std::string oldFilePath = filePathBase + ".old" + LogFileExtension;
 
@@ -174,8 +209,8 @@ void CLog::Initialize(const std::string& path)
   duplicateFilterSink->add_sink(basicFileSink);
   m_fileSink = duplicateFilterSink;
 
-  // add it to the existing sinks
   m_sinks->add_sink(m_fileSink);
+  m_fileSinkAttached = true;
 }
 
 void CLog::UnregisterFromSettings()
@@ -200,7 +235,11 @@ void CLog::Deinitialize()
   m_fileSink->flush();
 
   // remove and destroy the file sink
-  m_sinks->remove_sink(m_fileSink);
+  if (m_fileSinkAttached)
+  {
+    m_sinks->remove_sink(m_fileSink);
+    m_fileSinkAttached = false;
+  }
   m_fileSink.reset();
 }
 
@@ -354,6 +393,36 @@ void CLog::SetComponentLogLevel(const std::vector<CVariant>& components)
       continue;
 
     m_componentLogLevels |= static_cast<uint32_t>(component.asInteger());
+  }
+}
+
+void CLog::SetFileLoggingEnabled(bool enabled)
+{
+  m_fileLoggingEnabled = enabled;
+
+  if (enabled && !m_fileSinkAttached)
+  {
+    // the sink may not exist yet, e.g. if file logging was off when Initialize() ran
+    if (m_fileSink == nullptr)
+      CreateFileSink();
+    else
+    {
+      m_sinks->add_sink(m_fileSink);
+      m_fileSinkAttached = true;
+    }
+
+    if (m_fileSinkAttached)
+      FormatAndLogInternal(spdlog::level::info, LOG_COMPONENT_GENERAL,
+                           "Log file writing has been enabled", fmt::make_format_args());
+  }
+  else if (!enabled && m_fileSinkAttached)
+  {
+    FormatAndLogInternal(spdlog::level::info, LOG_COMPONENT_GENERAL,
+                         "Log file writing has been disabled, no further messages will be "
+                         "written to the log file",
+                         fmt::make_format_args());
+    m_sinks->remove_sink(m_fileSink);
+    m_fileSinkAttached = false;
   }
 }
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -174,16 +174,25 @@ private:
 
   void SetComponentLogLevel(const std::vector<CVariant>& components);
 
+  bool ReadPersistedFileLoggingSetting() const;
+
+  void SetFileLoggingEnabled(bool enabled);
+
+  void CreateFileSink();
+
   void FormatLineBreaks(std::string& message) const;
 
   std::unique_ptr<IPlatformLog> m_platform;
   std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> m_sinks;
   Logger m_defaultLogger;
 
+  std::string m_logDirectory;
   std::shared_ptr<spdlog::sinks::sink> m_fileSink;
+  bool m_fileSinkAttached{false};
 
   int m_logLevel{LOG_LEVEL_DEBUG};
 
   bool m_componentLogEnabled{false};
   uint32_t m_componentLogLevels{0};
+  bool m_fileLoggingEnabled{true};
 };


### PR DESCRIPTION
## Description
Adds a new toggle under Settings → System → Logging: "Write log file to disk" (debug.enablefilelogging, default: on).

When disabled, CLog detaches the file sink from the spdlog dist_sink so no further messages are written to kodi.log/kodi.old.log. The setting is read live via the existing settings-changed callback, so it can be toggled without a restart.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
