### PR TITLE
[Video][Bluray] Improve episode matching heuristics.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -40,6 +40,7 @@
 #include <numeric>
 #include <ranges>
 #include <set>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -153,45 +154,111 @@ void SortEpisodes(Episodes& episodes)
                     { return std::tie(e.iSeason, e.iEpisode, e.iSubepisode); });
 }
 
-bool IsPotentialPlayAllPlaylist(const PlaylistInformation& playlistInformation,
-                                unsigned int numEpisodes)
+// 'Play-all' playlists
+//
+// This is the term given to a playlist that plays all the episodes on a disc in order.
+// The underlying assumption is that the bulk of each episode is contained in a single clip and that the 'play-all'
+// playlist will contain all those clips.
+//
+// However, in some cases there are additional 'filler' clips - ie. individual intros, credits, summaries etc..
+// These may be found in the episode playlists themselves or in the play-all playlist.
+//
+// For example - lets assume a disc has 3 episodes, each with a single clip:
+//
+// Playlist 1   - clip 1 (episode 1)
+// Playlist 2   - clip 2 (episode 2)
+// Playlist 3   - clip 3 (episode 3)
+// Playlist 800 - clips 1,2,3 - the 'play-all' playlist containing clips 1,2,3 in that order
+//
+// Sometimes the episode playlists may have individual intros and credits, which are not included in the play-all playlist:
+//
+// Playlist 1   - clip 10,1,11 (episode 1)
+// Playlist 2   - clip 12,2,13 (episode 2)
+// Playlist 3   - clip 14,3,15 (episode 3)
+// Playlist 800 - clips 1,2,3 - the 'play-all' playlist
+//
+// There can also be variations of the theme (ie. a single intro clip and a single credits clip - so playlist 2 would be clip 10,2,11)
+//
+// There may also be additional clips in the play-all playlist, which are not found in the episode playlists. There could be a
+// single intro and single credits clip (and the episode playlists may/not have their own individual intros and credits).
+//
+// Playlist 1   - clip 10,1,11 (episode 1)
+// Playlist 2   - clip 10,2,11 (episode 2)
+// Playlist 3   - clip 10,3,11 (episode 3)
+// Playlist 800 - clips 12,1,2,3,13 - the 'play-all' playlist
+//
+// Or alternatively:
+//
+// Playlist 1   - clip 10,1,11 (episode 1)
+// Playlist 2   - clip 10,2,11 (episode 2)
+// Playlist 3   - clip 10,3,11 (episode 3)
+// Playlist 800 - clips 10,1,11,10,2,11,10,3,11 - the 'play-all' playlist
+
+// Determine the episode clips in a potential play all playlist, and their positions within it
+// Done on the basis of clip duration
+std::vector<size_t> GetEpisodeClipPositions(const ClipMap& clips,
+                                            const PlaylistInformation& playlistInformation,
+                                            std::chrono::milliseconds minEpisodeDuration)
 {
-  return playlistInformation.clips.size() >= numEpisodes &&
-         playlistInformation.clips.size() <= numEpisodes + 2;
+  std::vector<size_t> positions;
+  for (size_t position = 0; const unsigned int clip : playlistInformation.clips)
+  {
+    if (const auto it{clips.find(clip)};
+        it != clips.end() && it->second.duration >= minEpisodeDuration)
+      positions.emplace_back(position);
+    ++position;
+  }
+  return positions;
 }
 
-bool ClipQualifies(const ClipInfo& clipInformation,
-                   unsigned int clip,
-                   const PlaylistInformation& playlistInformation,
-                   unsigned int& playAllPlaylistEpisodesStartOffset,
-                   bool& allowBeginningOrEnd,
-                   bool allowBeginningAndEnd,
-                   std::chrono::milliseconds minEpisodeDuration)
+// If there are filler clips (intro/credits etc.) in a 'play-all' playlist they should be in the same place
+// relative to each episode clip
+bool IsPlayAllPlaylistFillerRegular(const std::vector<unsigned int>& clips,
+                                    const std::vector<size_t>& episodeClipPositions)
 {
-  // If clip doesn't appear in another playlist (ie. clip should appear in both the play all playlist and the individual episode)
-  // or clip is too short this is not a Play All playlist
-  // BUT we allow first and/or last clip to be shorter or single (ie start intro/end credits)
-  const bool isShort{clipInformation.duration < minEpisodeDuration};
-  const bool inSinglePlaylist{clipInformation.playlists.size() == 1};
-  if (!isShort && !inSinglePlaylist)
-    return true;
+  const auto span = [&clips](size_t begin, size_t end)
+  { return std::span{clips}.subspan(begin, end - begin); };
 
-  const bool canBeAtBeginningOrEnd{allowBeginningOrEnd || allowBeginningAndEnd};
-  if (isShort && canBeAtBeginningOrEnd)
+  const size_t first{episodeClipPositions.front()};
+  const size_t last{episodeClipPositions.back()};
+  const auto leading{span(0, first)};
+  const auto trailing{span(last + 1, clips.size())};
+
+  // Every pair of consecutive episode clips is separated by the same filler clips
+  const auto separator{
+      span(first + 1, episodeClipPositions.size() > 1 ? episodeClipPositions[1] : first + 1)};
+  for (size_t i = 2; i < episodeClipPositions.size(); ++i)
   {
-    if (clip == playlistInformation.clips.front())
-    {
-      playAllPlaylistEpisodesStartOffset = 1;
-      allowBeginningOrEnd =
-          false; // If allowBeginningOrEnd true and short clip found at beginning, cannot have one at end
-      return true;
-    }
-
-    if (clip == playlistInformation.clips.back())
-      return true;
+    if (!std::ranges::equal(span(episodeClipPositions[i - 1] + 1, episodeClipPositions[i]),
+                            separator))
+      return false;
   }
 
-  return false;
+  // With no separator to match, allow a lone intro and/or credits clip
+  if (separator.empty())
+    return leading.size() <= 1 && trailing.size() <= 1;
+
+  // The playlist begins part way through the separator and ends part way into the next one
+  return leading.size() <= separator.size() &&
+         std::ranges::equal(leading, separator.last(leading.size())) &&
+         trailing.size() <= separator.size() &&
+         std::ranges::equal(trailing, separator.first(trailing.size()));
+}
+
+// Check if the potential 'play-all' playlist:
+// 1) Has the right number of episode length clips for the number of episodes on the disc
+// 2) Has the filler (intro/credits etc.) clips in the same place relative to each episode clip
+bool IsPotentialPlayAllPlaylist(const ClipMap& clips,
+                                const PlaylistInformation& playlistInformation,
+                                unsigned int numEpisodes,
+                                std::chrono::milliseconds minEpisodeDuration)
+{
+  const std::vector<size_t> episodeClipPositions{
+      GetEpisodeClipPositions(clips, playlistInformation, minEpisodeDuration)};
+  if (episodeClipPositions.size() != numEpisodes)
+    return false;
+
+  return IsPlayAllPlaylistFillerRegular(playlistInformation.clips, episodeClipPositions);
 }
 
 bool IsValidSingleEpisodePlaylist(const PlaylistInformation& singleEpisodePlaylistInformation,
@@ -257,38 +324,32 @@ bool CheckClip(const PlaylistMap& playlists,
 
 bool ProcessPlaylistClips(const ClipMap& clips,
                           const PlaylistMap& playlists,
-                          unsigned int numEpisodes,
                           unsigned int playlistNumber,
-                          unsigned int& playAllPlaylistEpisodesStartOffset,
                           std::chrono::milliseconds minEpisodeDuration,
                           const PlaylistInformation& playlistInformation,
                           std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap)
 {
-  bool allowBeginningOrEnd{playlistInformation.clips.size() == numEpisodes + 1};
-  const bool allowBeginningAndEnd{playlistInformation.clips.size() == numEpisodes + 2};
-
-  // Loop through each clip in potential play all playlist (numbering between numEpisodes and numEpisodes+2)
-  for (unsigned int clip : playlistInformation.clips)
+  // Loop through each clip in the potential play all playlist, whose filler clips
+  // IsPotentialPlayAllPlaylist() has already found to be in the expected places
+  for (const unsigned int clip : playlistInformation.clips)
   {
     const auto& it{clips.find(clip)};
     if (it == clips.end())
       return false;
-
-    // See if the clips qualify (ie. small clips (in addition to numEpisode clips) at start or end)
     const ClipInfo& clipInformation{it->second};
-    if (!ClipQualifies(clipInformation, clip, playlistInformation,
-                       playAllPlaylistEpisodesStartOffset, allowBeginningOrEnd,
-                       allowBeginningAndEnd, minEpisodeDuration))
-      return false;
 
-    // A short first/last clip is an extra intro or ending clip, not an episode playlist
-    // A short clip elsewhere would fail ClipQualifies
+    // A short clip is an intro or ending clip, not an episode
     // Record it with no episode playlists, so UsePlayAllPlaylistMethod skips over it
     if (clipInformation.duration < minEpisodeDuration)
     {
       playAllPlaylistClipMap[clip] = {};
       continue;
     }
+
+    // An episode's clip has to appear in both the play all playlist and the individual episode
+    // playlist, so a clip in no other playlist means this is not a play all playlist
+    if (clipInformation.playlists.size() == 1)
+      return false;
 
     // See if the playlists associated with the clip are valid as a single episodes
     std::vector<unsigned int> playAllPlaylistMap;
@@ -713,14 +774,12 @@ bool ArePlaylistsConsecutive(const R& items)
 
 void CDiscDirectoryHelper::StorePlayAllPlaylist(
     unsigned int playlistNumber,
-    unsigned int playAllPlaylistEpisodesStartOffset,
     const PlaylistInformation& playlistInformation,
     const std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap)
 {
   CLog::LogF(LOGDEBUG, "Potential play all playlist {}", playlistNumber);
   m_playAllPlaylists.insert(CandidatePlaylistInformation{
       .playlist = playlistNumber,
-      .playAllPlaylistEpisodesStartOffset = playAllPlaylistEpisodesStartOffset,
       .duration = playlistInformation.duration,
       .chapters = static_cast<unsigned int>(playlistInformation.chapters.size()),
       .clips = playlistInformation.clips,
@@ -735,12 +794,13 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
   // Look for a potential play all playlist (gives episode order)
   //
   // Assumptions
-  //   1) Playlist clip count = number of episodes on disc (+2 for potential separate intro/end credits)
-  //   2) Each clip will be in at least one other playlist (the individual episode playlist)
-  //   3) Each clip (bar the last) will be at least MIN_EPISODE_DURATION long
-  //   4) Each potential individual episode playlist containing a clip from the potential play all playlist
+  //   1) The playlist has one clip at least MIN_EPISODE_DURATION long per episode on disc, and any
+  //      shorter clip is intro/credits filler in one of the places a play all playlist puts it
+  //      (see IsPotentialPlayAllPlaylist())
+  //   2) Each episode clip will be in at least one other playlist (the individual episode playlist)
+  //   3) Each potential individual episode playlist containing a clip from the potential play all playlist
   //      will have at most one other clip before/after
-  //   5) The clips look like the episodes (see ArePlayAllPlaylistClipsEpisodes())
+  //   4) The clips look like the episodes (see ArePlayAllPlaylistClipsEpisodes())
 
   // Only look for play all playlists if enough playlists and more than one episode on disc
   if (m_numEpisodes < 2 || playlists.size() < m_numEpisodes)
@@ -748,7 +808,8 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
 
   for (const auto& [playlistNumber, playlistInformation] : playlists)
   {
-    if (!IsPotentialPlayAllPlaylist(playlistInformation, m_numEpisodes))
+    if (!IsPotentialPlayAllPlaylist(clips, playlistInformation, m_numEpisodes,
+                                    m_minEpisodeDuration))
       continue;
 
     if (!ArePlayAllPlaylistClipsEpisodes(clips, playlistInformation, episodesOnDisc, m_numSpecials,
@@ -762,14 +823,9 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
     }
 
     std::map<unsigned int, std::vector<unsigned int>> playAllPlaylistClipMap;
-    unsigned int playAllPlaylistEpisodesStartOffset{0};
-    if (ProcessPlaylistClips(clips, playlists, m_numEpisodes, playlistNumber,
-                             playAllPlaylistEpisodesStartOffset, m_minEpisodeDuration,
+    if (ProcessPlaylistClips(clips, playlists, playlistNumber, m_minEpisodeDuration,
                              playlistInformation, playAllPlaylistClipMap))
-    {
-      StorePlayAllPlaylist(playlistNumber, playAllPlaylistEpisodesStartOffset, playlistInformation,
-                           playAllPlaylistClipMap);
-    }
+      StorePlayAllPlaylist(playlistNumber, playlistInformation, playAllPlaylistClipMap);
   }
 
   if (m_playAllPlaylists.empty())
@@ -1024,28 +1080,37 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
   CLog::LogF(LOGDEBUG, "Using candidate play all playlist {} duration {}", playAllPlaylist,
              static_cast<int>(playlistInformation.duration.count() / 1000));
 
-  // Find the clip for the episode(s)
-  const int episodeOffset{
-      episodeIndex - static_cast<int>(m_numSpecials) + // Specials before episodes in episodesOnDisc
-      static_cast<int>(
-          playlistInformation
-              .playAllPlaylistEpisodesStartOffset)}; // Adjust if a short clip at start of play-all playlist
-  unsigned int i{0};
-  for (const auto& clip : playlistInformation.clips)
+  const auto& clipMapIt{m_playAllPlaylistsMap.find(playAllPlaylist)};
+  if (clipMapIt == m_playAllPlaylistsMap.end())
   {
+    CLog::LogF(LOGERROR, "Play all playlist {} missing in play all playlist map", playAllPlaylist);
+    return;
+  }
+  const auto& playAllPlaylistClipMap{clipMapIt->second};
+
+  // Find the clip for the episode(s). Specials come before episodes in episodesOnDisc.
+  const int episodeOffset{episodeIndex - static_cast<int>(m_numSpecials)};
+
+  // Walk the episode clips, skipping the play all playlist's intro/credits filler clips - those
+  // were recorded with no episode playlists of their own (see ProcessPlaylistClips())
+  unsigned int i{0};
+  for (const unsigned int clip : playlistInformation.clips)
+  {
+    const auto& it{playAllPlaylistClipMap.find(clip)};
+    if (it == playAllPlaylistClipMap.end())
+    {
+      CLog::LogF(LOGERROR, "Clip {} missing in play all playlist map", clip);
+      return;
+    }
+
+    // Playlist(s) with that clip, from the map populated earlier
+    const auto& singleEpisodePlaylists{it->second};
+    if (singleEpisodePlaylists.empty())
+      continue; // Filler clip
+
     if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(i, episodeOffset))
     {
-      const auto& it{m_playAllPlaylistsMap.find(playAllPlaylist)};
-      if (it == m_playAllPlaylistsMap.end() || !it->second.contains(clip))
-      {
-        CLog::LogF(LOGERROR, "Clip {} missing in play all playlist map", clip);
-        return;
-      }
-
       CLog::LogF(LOGDEBUG, "Clip is {}", clip);
-
-      // Find playlist(s) with that clip from map populated earlier
-      const auto& singleEpisodePlaylists{it->second.find(clip)->second};
 
       for (const auto& singleEpisodePlaylist : singleEpisodePlaylists)
       {
@@ -1064,14 +1129,13 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
 
         m_candidatePlaylists.try_emplace(
             singleEpisodePlaylist,
-            CandidatePlaylistInformation{
-                .playlist = singleEpisodePlaylist,
-                .index = i + m_numSpecials - playlistInformation.playAllPlaylistEpisodesStartOffset,
-                .duration = singleEpisodePlaylistInformation.duration,
-                .chapters =
-                    static_cast<unsigned int>(singleEpisodePlaylistInformation.chapters.size()),
-                .clips = singleEpisodePlaylistInformation.clips,
-                .languages = singleEpisodePlaylistInformation.languages});
+            CandidatePlaylistInformation{.playlist = singleEpisodePlaylist,
+                                         .index = i + m_numSpecials,
+                                         .duration = singleEpisodePlaylistInformation.duration,
+                                         .chapters = static_cast<unsigned int>(
+                                             singleEpisodePlaylistInformation.chapters.size()),
+                                         .clips = singleEpisodePlaylistInformation.clips,
+                                         .languages = singleEpisodePlaylistInformation.languages});
       }
     }
     ++i;

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -196,7 +196,6 @@ class CDiscDirectoryHelper
   {
     unsigned int playlist{0};
     unsigned int index{0};
-    unsigned int playAllPlaylistEpisodesStartOffset{0};
     std::chrono::milliseconds duration{0ms};
     std::chrono::milliseconds durationDelta{0ms};
     int multiple{0};
@@ -333,7 +332,6 @@ private:
   void InitialiseEpisodePlaylistSearch(int episodeIndex, const Episodes& episodesOnDisc);
   void StorePlayAllPlaylist(
       unsigned int playlistNumber,
-      unsigned int playAllPlaylistEpisodesStartOffset,
       const PlaylistInformation& playlistInformation,
       const std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap);
   void FindPlayAllPlaylists(const ClipMap& clips,

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -1054,6 +1054,64 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraIndivid
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// The play-all playlist wraps every episode in the same short intro and credits clips, rather than
+// carrying them once at the beginning and end of the playlist.
+// (Example Stranger Things (2016) S1D1 UK Bluray, whose play-all playlist 3 is clips
+// 12,0,14,12,1,14,12,2,14 - the episodes being clips 0,1 and 2)
+// Playlist 3 = play-all; 4 = episode 1; 5 = episode 2; 6 = episode 3
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_FillerAroundEveryEpisode)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2880),
+      MakeEpisode(1, 2, 3300),
+      MakeEpisode(1, 3, 3060),
+  };
+
+  PlaylistMap playlists{
+      {3u, MakePlaylist(3u, 9203s, {12u, 0u, 14u, 12u, 1u, 14u, 12u, 2u, 14u},
+                        {11s, 2842s, 11s, 11s, 3254s, 11s, 11s, 3041s, 11s})},
+      {4u, MakePlaylist(4u, 2864s, {12u, 0u, 14u}, {11s, 2842s, 11s})},
+      {5u, MakePlaylist(5u, 3276s, {12u, 1u, 14u}, {11s, 3254s, 11s})},
+      {6u, MakePlaylist(6u, 3063s, {12u, 2u, 14u}, {11s, 3041s, 11s})},
+      {11u, MakePlaylist(11u, 28s, {10u, 11u}, {18s, 10s})},
+      {12u, MakePlaylist(12u, 10s, {9u}, {10s})},
+  };
+  ClipMap clips{
+      {0u, MakeClip(2842s, {4u, 3u})},
+      {1u, MakeClip(3254s, {5u, 3u})},
+      {2u, MakeClip(3041s, {6u, 3u})},
+      {9u, MakeClip(10s, {12u})},
+      {10u, MakeClip(18s, {11u})},
+      {11u, MakeClip(10s, {11u})},
+      {12u, MakeClip(11s, {6u, 4u, 5u, 3u})},
+      {14u, MakeClip(11s, {6u, 4u, 5u, 3u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 4);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 5);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 6);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  const auto returned{GetPlaylists(items)};
+  const std::set<unsigned int> expected{4u, 5u, 6u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // Disc has a play-all playlist (clips shared with individual episode playlists)
 // Note that clips in playlist 100 don't match the individual episodes' clips (800,802,804)
 // Clip 900 needed otherwise a group could be made with 800,802,804 as 'exactly numEpisode playlists and no specials'


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A 'play-all' playlist contains the episodes' clips in order, but may also carry filler (intro/credits) clips.

Handle these.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Episodes on Stranger Things S1D1/S1D2 were not being recognised.

There could be an intro before the first episode and/or credits after the last, but some discs repeat the same filler around every episode (example Stranger Things (2016) S1D1 Bluray, whose play all playlist is clips 12,0,14,12,1,14,12,2,14 - the episodes being 0,1,2 and the filler clips 12 and 14).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
