### PR TITLE
[GUI] Composite translucent GUI over HDR video at the right opacity

### DIFF
--- a/system/shaders/GL/1.5/gl_gui_composite.frag
+++ b/system/shaders/GL/1.5/gl_gui_composite.frag
@@ -43,10 +43,14 @@ void main()
   if (gui.a == 0.0)
     discard;
 
+  // The GUI blends into the FBO premultiplied; the EOTF and the composite blend
+  // below both need the unassociated colour, so divide the coverage back out.
+  vec3 color = min(gui.rgb / gui.a, vec3(1.0));
+
   // sRGB -> linear (IEC 61966-2-1 piecewise EOTF)
-  vec3 linear = mix(gui.rgb / 12.92,
-                    pow((gui.rgb + 0.055) / 1.055, vec3(2.4)),
-                    step(0.04045, gui.rgb));
+  vec3 linear = mix(color / 12.92,
+                    pow((color + 0.055) / 1.055, vec3(2.4)),
+                    step(0.04045, color));
 
   // BT.709 -> BT.2020 gamut mapping
   linear = bt709_to_bt2020 * linear;

--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -33,11 +33,15 @@ void main()
   if (gui.a == 0.0)
     discard;
 
+  // The GUI blends into the FBO premultiplied; the EOTF and the composite blend
+  // below both need the unassociated colour, so divide the coverage back out.
+  vec3 color = min(gui.rgb / gui.a, vec3(1.0));
+
   // sRGB -> linear via LUT (IEC 61966-2-1 EOTF, replaces inline pow)
   vec3 linear = vec3(
-    texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
-    texture2D(u_lutDegamma, vec2(gui.g, 0.5)).r,
-    texture2D(u_lutDegamma, vec2(gui.b, 0.5)).r
+    texture2D(u_lutDegamma, vec2(color.r, 0.5)).r,
+    texture2D(u_lutDegamma, vec2(color.g, 0.5)).r,
+    texture2D(u_lutDegamma, vec2(color.b, 0.5)).r
   );
 
   // BT.709 -> BT.2020 gamut mapping

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -131,19 +131,9 @@ bool CGUIFontTTFGL::FirstBegin()
     m_textureStatus = TEXTURE_READY;
   }
 
-  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
-  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
-  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
-  // FBO that is color-transformed to PQ before compositing with video in
-  // that non-linear space -- two stages of non-linear blending. The
-  // compensated factors below trade accumulator coverage for a squared-
-  // alpha blend that approximately matches SDR perceived translucency. It
-  // is a "close enough" compromise; a mathematically correct fix would
-  // require linear-light compositing (too expensive on typical ARM GPUs).
-  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  else
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+  // The HDR composite pass multiplies by this alpha again, so accumulate coverage
+  // here; squaring src alpha erases translucency and reopens opaque GUI to video.
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
   glEnable(GL_BLEND);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_nTexture);

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -126,19 +126,9 @@ bool CGUIFontTTFGLES::FirstBegin()
     m_textureStatus = TEXTURE_READY;
   }
 
-  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
-  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
-  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
-  // FBO that is color-transformed to PQ/HLG before compositing with video
-  // in that non-linear space -- two stages of non-linear blending. The
-  // compensated factors below trade accumulator coverage for a squared-
-  // alpha blend that approximately matches SDR perceived translucency. It
-  // is a "close enough" compromise; a mathematically correct fix would
-  // require linear-light compositing (too expensive on typical ARM GPUs).
-  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  else
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+  // The HDR composite pass multiplies by this alpha again, so accumulate coverage
+  // here; squaring src alpha erases translucency and reopens opaque GUI to video.
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
   glEnable(GL_BLEND);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_nTexture);

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -89,15 +89,7 @@ void CGUITextureGL::Begin(KODI::UTILS::COLOR::Color color)
 
   if (hasAlpha)
   {
-    // See CGUIFontTTFGL::FirstBegin for rationale. SDR uses accumulator
-    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
-    // blend because the FBO is color-transformed to PQ before composite,
-    // and alpha blending in non-linear space is mathematically wrong.
-    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA,
-                          GL_ONE_MINUS_SRC_ALPHA);
-    else
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable(GL_BLEND);
   }
   else
@@ -282,7 +274,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
 
   if (blending)
   {
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable(GL_BLEND);
   }
   else

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -121,15 +121,7 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
 
   if (hasAlpha)
   {
-    // See CGUIFontTTFGLES::FirstBegin for rationale. SDR uses accumulator
-    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
-    // blend because the FBO is color-transformed to PQ/HLG before composite,
-    // and alpha blending in non-linear space is mathematically wrong.
-    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA,
-                          GL_ONE_MINUS_SRC_ALPHA);
-    else
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable( GL_BLEND );
   }
   else
@@ -297,7 +289,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
 
   if (blending)
   {
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable(GL_BLEND);
   }
   else


### PR DESCRIPTION
## Description

During HDR passthrough on GBM the GUI is drawn into an FBO and composited over the video. The alpha channel is wrong on both sides of that handover.

The GUI draw sites blend the alpha channel with `GL_SRC_ALPHA` as its source factor, storing `a²` in a transparent FBO instead of `a`. `CompositeGui()` then multiplies by that stored alpha again. Separately the FBO colour is premultiplied, but the shader feeds it to the EOTF as if it were not.

So a translucent element over video is drawn at `a²`, and one drawn on an opaque GUI panel drops that panel's coverage below 1 and lets video through it.

Fix: same coverage factors for alpha at every draw site, and divide the coverage back out before the EOTF.

#28350 makes the same blend change for two of the four sites. This adds the GL twins, `DrawQuad`, and the un-premultiply. Happy to rebase on top of it instead.

## Motivation and context

On HDR playback every translucent element is far too transparent: an 8% white fill contributes nothing measurable. Same skin is correct in SDR.

## How has this been tested?

AMD RX 7600, LibreELEC, GBM+GLES single plane (VAAPI), DV clip. Measured against a paused frame, so no model is involved.

Alpha swatches: effective opacity was `a²`, is now `a`, to three decimals across 0x14..0xFF. Video leaking through an opaque panel: 24.9% to 0.2%.

Estuary video settings dialog: video transmission 0.323 to 0.156, i.e. opacity 0.677 to 0.844, and 0.844² = 0.712. Over 34,630 GUI pixels, predicting master as `1-(1-new)²` fits to a median 0.066.

`kodi-test` passes. Not tested by me: Direct-to-Plane, GLES2-only, Intel.

## What is the effect on users?

Translucent GUI over HDR video gets the opacity the skin asked for. Deliberately more opaque than master.

## Screenshots (if appropriate)

Video settings dialog over the same paused HDR frame, master then this PR. The video's burned-in timecode is legible through the dialog on the left.

<img width="1528" height="438" alt="pr_fig_dialog" src="https://github.com/user-attachments/assets/9b25739a-e825-4c9d-bad3-5ca50b01fb49" />
<img width="1528" height="465" alt="pr_fig_ramp" src="https://github.com/user-attachments/assets/7c360143-c446-45a1-b2dd-48fae9ec19be" />

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
