### PR TITLE
[GUI] Fix panel scrollbar page size

### DIFF
--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -453,8 +453,11 @@ void CGUIPanelContainer::CalculateLayout()
     m_itemsPerRow = (int)(m_width / m_layout->Size(HORIZONTAL));
     m_itemsPerPage = (int)(m_height / m_layout->Size(VERTICAL));
   }
-  if (m_itemsPerRow < 1) m_itemsPerRow = 1;
-  if (m_itemsPerPage < 1) m_itemsPerPage = 1;
+  if (m_itemsPerRow < 1)
+    m_itemsPerRow = 1;
+  if (m_itemsPerPage < 1)
+    m_itemsPerPage = 1;
+  m_pageSize = m_itemsPerPage;
 
   // ensure that the scroll offset is a multiple of our size
   m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
             TestGUIFixedListContainer.cpp
+            TestGUIPanelContainer.cpp
             TestGUILabel.cpp
             TestGUITextLayout.cpp
             TestGUIWindowOnAction.cpp

--- a/xbmc/guilib/test/TestGUIPanelContainer.cpp
+++ b/xbmc/guilib/test/TestGUIPanelContainer.cpp
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUIListItem.h"
+#include "guilib/GUIListItemLayout.h"
+#include "guilib/GUIPanelContainer.h"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+class TestGUIPanelContainer : public CGUIPanelContainer
+{
+public:
+  TestGUIPanelContainer(
+      float height, float screenStart, float screenEnd, float itemHeight, float focusedItemHeight)
+    : CGUIPanelContainer(0, 1, 0, 0, 800, height, VERTICAL, CScroller(0), 0),
+      m_screenStart(screenStart),
+      m_screenEnd(screenEnd)
+  {
+    m_layout = &m_layouts.emplace_back();
+    m_layout->SetWidth(800);
+    m_layout->SetHeight(itemHeight);
+
+    m_focusedLayout = &m_focusedLayouts.emplace_back();
+    m_focusedLayout->SetWidth(800);
+    m_focusedLayout->SetHeight(focusedItemHeight);
+  }
+
+  bool CalculateScreenRange() override
+  {
+    CGUIBaseContainer::m_screenStart = m_screenStart;
+    CGUIBaseContainer::m_screenEnd = m_screenEnd;
+    CGUIBaseContainer::m_hasScreenRange = true;
+    return true;
+  }
+
+  void AddItems(int count)
+  {
+    for (int i = 0; i < count; ++i)
+      m_items.emplace_back(std::make_shared<CGUIListItem>(std::to_string(i)));
+  }
+
+  int GetPageSizeForTest() const { return GetPageSize(); }
+
+  void PrepareForAction()
+  {
+    m_wasReset = true;
+    CalculateLayout();
+  }
+
+private:
+  float m_screenStart;
+  float m_screenEnd;
+};
+
+TEST(TestGUIPanelContainer, CalculateLayoutUpdatesPageNavigationSize)
+{
+  TestGUIPanelContainer container(960, 0, 960, 80, 120);
+  container.AddItems(30);
+  container.PrepareForAction();
+
+  EXPECT_EQ(container.GetPageSizeForTest(), 12);
+}


### PR DESCRIPTION
## Description

Fixes the page size used by panel scrollbar/page controls.

Panel containers advance by their normal layout row size, even when the focused layout has a different size. This keeps the cached page size aligned with `m_itemsPerPage`, so scrollbar page changes match panel page up/down navigation.

Also adds a regression test covering a panel with a larger focused layout.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/29295.

This is a follow-up to https://github.com/xbmc/xbmc/pull/28803. That PR fixed page navigation/page size handling for oversized and partially visible layouts, but exposed a separate panel-specific issue where the scrollbar could use a different page size than panel page up/down navigation.

## How has this been tested?

Tested locally on Windows 64-bit with a Debug build.

Manual testing:
- Changed Estuary `View_55_WideList.xml` control `id=55` to use a `panel`
- Confirmed page up/down jumps by the expected number of items
- Confirmed scrollbar page changes now match page up/down navigation
- Confirmed Estuary’s actual `panel` viewtype, Wall `id=500`, still behaves correctly

Automated/local checks:
- `cmake --build C:\xbmc-build --target kodi-test --config Debug -- /m:1`
- `C:\xbmc-build\Debug\kodi-test.exe --gtest_filter=TestGUIFixedListContainer.*:TestGUIPanelContainer.*`
- `git -C C:\xbmc diff --check`
- `clang-format --dry-run --Werror` on touched C++ files

## What is the effect on users?

Panel scrollbars now page by the same amount as page up/down navigation, instead of using an incorrect page size when focused and unfocused layouts differ.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed